### PR TITLE
Windows host app Makefile

### DIFF
--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -51,7 +51,7 @@ bool DXGI::Initialize(CaptureOptions * options)
   status = CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void **)(&m_dxgiFactory));
   if (FAILED(status))
   {
-    DEBUG_ERROR("Failed to create DXGIFactory: %08x", status);
+    DEBUG_ERROR("Failed to create DXGIFactory: %08x", (int)status);
     return false;
   }
 
@@ -150,7 +150,7 @@ bool DXGI::Initialize(CaptureOptions * options)
 
   if (FAILED(status))
   {
-    DEBUG_ERROR("DuplicateOutput Failed: %08x", status);
+    DEBUG_ERROR("DuplicateOutput Failed: %08x", (int)status);
     DeInitialize();
     return false;
   }
@@ -172,7 +172,7 @@ bool DXGI::Initialize(CaptureOptions * options)
   status = m_device->CreateTexture2D(&texDesc, NULL, &m_texture);
   if (FAILED(status))
   {
-    DEBUG_ERROR("Failed to create texture: %08x", status);
+    DEBUG_ERROR("Failed to create texture: %08x", (int)status);
     DeInitialize();
     return false;
   }
@@ -286,7 +286,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
         if (!SUCCEEDED(status))
         {
           m_dup->ReleaseFrame();
-          DEBUG_ERROR("Failed to get the new pointer shape: %08x", status);
+          DEBUG_ERROR("Failed to get the new pointer shape: %08x", (int)status);
           return GRAB_STATUS_ERROR;
         }
 
@@ -350,7 +350,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
 
       default:
         // unknown failure
-        DEBUG_INFO("AcquireNextFrame failed: %08x", status);
+        DEBUG_INFO("AcquireNextFrame failed: %08x", (int)status);
         return GRAB_STATUS_ERROR;
     }
   }
@@ -391,7 +391,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
   status = surface->Map(&rect, DXGI_MAP_READ);
   if (FAILED(status))
   {
-    DEBUG_ERROR("Failed to map surface: %08x", status);
+    DEBUG_ERROR("Failed to map surface: %08x", (int)status);
     return GRAB_STATUS_ERROR;
   }
 
@@ -408,7 +408,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
 
   if (FAILED(status))
   {
-    DEBUG_ERROR("Failed to unmap surface: %08x", status);
+    DEBUG_ERROR("Failed to unmap surface: %08x", (int)status);
     return GRAB_STATUS_ERROR;
   }
 

--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -401,8 +401,9 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
   frame.width   = desc.Width;
   frame.height  = desc.Height;
   frame.stride  = rect.Pitch / 4;
-  
-  memcpySSE(frame.buffer, rect.pBits, min(frame.bufferSize, m_height * rect.Pitch));
+
+  unsigned int size = m_height * rect.Pitch;
+  memcpySSE(frame.buffer, rect.pBits, size < frame.bufferSize ? size : frame.bufferSize);
 
   status = surface->Unmap();
 

--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -26,11 +26,11 @@ using namespace Capture;
 DXGI::DXGI() :
   m_options(NULL),
   m_initialized(false),
-  m_dxgiFactory(NULL),
-  m_device(NULL),
-  m_deviceContext(NULL),
-  m_dup(NULL),
-  m_texture(NULL),
+  m_dxgiFactory(),
+  m_device(),
+  m_deviceContext(),
+  m_dup(),
+  m_texture(),
   m_pointer(NULL)
 {
 }
@@ -56,10 +56,10 @@ bool DXGI::Initialize(CaptureOptions * options)
   }
 
   bool done = false;
-  CComPtr<IDXGIAdapter1> adapter;
+  IDXGIAdapter1Ptr adapter;
   for (int i = 0; m_dxgiFactory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; i++)
   {
-    CComPtr<IDXGIOutput> output;
+    IDXGIOutputPtr output;
     for (int i = 0; adapter->EnumOutputs(i, &output) != DXGI_ERROR_NOT_FOUND; i++)
     {
       DXGI_OUTPUT_DESC outputDesc;
@@ -233,7 +233,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
     return GRAB_STATUS_ERROR;
 
   DXGI_OUTDUPL_FRAME_INFO frameInfo;
-  CComPtr<IDXGIResource> res;
+  IDXGIResourcePtr res;
 
   HRESULT status;
   bool    cursorUpdate = false;
@@ -363,7 +363,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
     return GRAB_STATUS_ERROR;
   }
 
-  CComQIPtr<ID3D11Texture2D> src = res;
+  ID3D11Texture2DPtr src(res);
   if (!src)
   {
     m_dup->ReleaseFrame();
@@ -380,7 +380,7 @@ GrabStatus DXGI::GrabFrame(FrameInfo & frame)
   res.Release();
   src.Release();
 
-  CComQIPtr<IDXGISurface1> surface = m_texture;
+  IDXGISurface1Ptr surface(m_texture);
   if (!surface)
   {
     DEBUG_ERROR("Failed to get IDXGISurface1");

--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -17,11 +17,11 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#include "DXGI.h"
+#include "Capture/DXGI.h"
 using namespace Capture;
 
-#include "common\debug.h"
-#include "common\memcpySSE.h"
+#include "common/debug.h"
+#include "common/memcpySSE.h"
 
 DXGI::DXGI() :
   m_options(NULL),

--- a/host/Capture/DXGI.h
+++ b/host/Capture/DXGI.h
@@ -51,7 +51,6 @@ namespace Capture
     }
 
     enum FrameType GetFrameType();
-    enum FrameComp GetFrameCompression();
     size_t GetMaxFrameSize();
     enum GrabStatus GrabFrame(struct FrameInfo & frame);
 

--- a/host/Capture/DXGI.h
+++ b/host/Capture/DXGI.h
@@ -25,7 +25,19 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <windows.h>
 #include <dxgi1_2.h>
 #include <d3d11.h>
-#include <atlbase.h>
+#include <stdio.h>
+#include <comdef.h>
+
+_COM_SMARTPTR_TYPEDEF(IDXGIFactory1, IID_IDXGIFactory1);
+_COM_SMARTPTR_TYPEDEF(ID3D11Device, IID_ID3D11Device);
+_COM_SMARTPTR_TYPEDEF(ID3D11DeviceContext, IID_ID3D11DeviceContext);
+_COM_SMARTPTR_TYPEDEF(IDXGIOutput1, IID_IDXGIOutput1);
+_COM_SMARTPTR_TYPEDEF(IDXGIOutput, IID_IDXGIOutput);
+_COM_SMARTPTR_TYPEDEF(IDXGIAdapter1, IID_IDXGIAdapter1);
+_COM_SMARTPTR_TYPEDEF(IDXGIOutputDuplication, IID_IDXGIOutputDuplication);
+_COM_SMARTPTR_TYPEDEF(ID3D11Texture2D, IID_ID3D11Texture2D);
+_COM_SMARTPTR_TYPEDEF(IDXGIResource, IID_IDXGIResource);
+_COM_SMARTPTR_TYPEDEF(IDXGISurface1, IID_IDXGISurface1);
 
 namespace Capture
 {
@@ -61,13 +73,13 @@ namespace Capture
     unsigned int  m_width;
     unsigned int  m_height;
 
-    CComPtr<IDXGIFactory1>          m_dxgiFactory;
-    CComPtr<ID3D11Device>           m_device;
+    IDXGIFactory1Ptr                m_dxgiFactory;
+    ID3D11DevicePtr                 m_device;
     D3D_FEATURE_LEVEL               m_featureLevel;
-    CComPtr<ID3D11DeviceContext>    m_deviceContext;
-    CComQIPtr<IDXGIOutput1>         m_output;
-    CComPtr<IDXGIOutputDuplication> m_dup;
-    CComPtr<ID3D11Texture2D>        m_texture;
+    ID3D11DeviceContextPtr          m_deviceContext;
+    IDXGIOutput1Ptr                 m_output;
+    IDXGIOutputDuplicationPtr       m_dup;
+    ID3D11Texture2DPtr              m_texture;
     BYTE *                          m_pointer;
     UINT                            m_pointerBufSize;
     UINT                            m_pointerSize;

--- a/host/Capture/NvFBC.cpp
+++ b/host/Capture/NvFBC.cpp
@@ -22,8 +22,8 @@ using namespace Capture;
 
 #include <string>
 
-#include "common\debug.h"
-#include "common\memcpySSE.h"
+#include "common/debug.h"
+#include "common/memcpySSE.h"
 #include "Util.h"
 
 #ifdef _WIN64

--- a/host/Capture/NvFBC.h
+++ b/host/Capture/NvFBC.h
@@ -21,10 +21,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "ICapture.h"
 
 #define W32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
-#include <NvFBC\nvFBC.h>
-#include <NvFBC\nvFBCToSys.h>
+#include <NvFBC/nvFBC.h>
+#include <NvFBC/nvFBCToSys.h>
 
 namespace Capture
 {

--- a/host/Capture/NvFBC.h
+++ b/host/Capture/NvFBC.h
@@ -44,7 +44,6 @@ namespace Capture
       return Initialize(m_options);
     }
     enum FrameType GetFrameType();
-    enum FrameComp GetFrameCompression();
     size_t GetMaxFrameSize();
     enum GrabStatus GrabFrame(struct FrameInfo & frame);
 

--- a/host/Capture/NvFBC.h
+++ b/host/Capture/NvFBC.h
@@ -17,6 +17,8 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#if CONFIG_CAPTURE_NVFBC
+
 #pragma once
 #include "ICapture.h"
 
@@ -68,3 +70,5 @@ namespace Capture
     NVFBC_TOSYS_GRAB_FRAME_PARAMS m_grabFrameParams;
   };
 };
+
+#endif

--- a/host/CaptureFactory.h
+++ b/host/CaptureFactory.h
@@ -25,7 +25,9 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "common/debug.h"
 #include "ICapture.h"
+#if CONFIG_CAPTURE_NVFBC
 #include "Capture/NvFBC.h"
+#endif
 #include "Capture/DXGI.h"
 
 class CaptureFactory
@@ -39,7 +41,9 @@ public:
     if (!devices.empty())
       return devices;
 
+#if CONFIG_CAPTURE_NVFBC
     devices.push_back(new Capture::NvFBC());
+#endif
     devices.push_back(new Capture::DXGI ());
 
     return devices;

--- a/host/CaptureFactory.h
+++ b/host/CaptureFactory.h
@@ -20,13 +20,13 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #pragma once
 
 #define W32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include <vector>
 
-#include "common\debug.h"
+#include "common/debug.h"
 #include "ICapture.h"
-#include "Capture\NvFBC.h"
-#include "Capture\DXGI.h"
+#include "Capture/NvFBC.h"
+#include "Capture/DXGI.h"
 
 class CaptureFactory
 {

--- a/host/CrashHandler.h
+++ b/host/CrashHandler.h
@@ -18,8 +18,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 #pragma once
-#include <Windows.h>
-#include <DbgHelp.h>
+#include <windows.h>
+#include <dbghelp.h>
 
 class CrashHandler
 {

--- a/host/ICapture.h
+++ b/host/ICapture.h
@@ -21,6 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "common/KVMFR.h"
 #include <vector>
+#include <windows.h>
 
 struct CursorInfo
 {

--- a/host/ICapture.h
+++ b/host/ICapture.h
@@ -58,15 +58,15 @@ enum GrabStatus
 
 typedef std::vector<const char *> CaptureOptions;
 
-__interface ICapture
+class ICapture
 {
 public:
-  const char * GetName();
-  
-  bool Initialize(CaptureOptions * options);
-  void DeInitialize();
-  bool ReInitialize();
-  enum FrameType GetFrameType();
-  size_t GetMaxFrameSize();
-  enum GrabStatus GrabFrame(struct FrameInfo & frame);
+  virtual const char * GetName() = 0;
+
+  virtual bool Initialize(CaptureOptions * options) = 0;
+  virtual void DeInitialize() = 0;
+  virtual bool ReInitialize() = 0;
+  virtual enum FrameType GetFrameType() = 0;
+  virtual size_t GetMaxFrameSize() = 0;
+  virtual enum GrabStatus GrabFrame(struct FrameInfo & frame) = 0;
 };

--- a/host/IVSHMEM.cpp
+++ b/host/IVSHMEM.cpp
@@ -17,12 +17,12 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#include "ivshmem.h"
+#include "IVSHMEM.h"
 
-#include <Windows.h>
-#include <SetupAPI.h>
-#include "vendor\kvm-guest-drivers-windows\ivshmem\Public.h"
-#include "common\debug.h"
+#include <windows.h>
+#include <setupapi.h>
+#include "vendor/kvm-guest-drivers-windows/ivshmem/Public.h"
+#include "common/debug.h"
 
 IVSHMEM * IVSHMEM::m_instance = NULL;
 

--- a/host/IVSHMEM.cpp
+++ b/host/IVSHMEM.cpp
@@ -112,7 +112,7 @@ void IVSHMEM::DeInitialize()
   if (m_gotMemory)
   {
     if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_RELEASE_MMAP, NULL, 0, NULL, 0, NULL, NULL))
-      DEBUG_ERROR("DeviceIoControl failed: %d", GetLastError());
+      DEBUG_ERROR("DeviceIoControl failed: %d", (int)GetLastError());
     m_memory = NULL;
   }
 
@@ -143,7 +143,7 @@ UINT64 IVSHMEM::GetSize()
   IVSHMEM_SIZE size;
   if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_REQUEST_SIZE, NULL, 0, &size, sizeof(IVSHMEM_SIZE), NULL, NULL))
   {
-    DEBUG_ERROR("DeviceIoControl Failed: %d", GetLastError());
+    DEBUG_ERROR("DeviceIoControl Failed: %d", (int)GetLastError());
     return 0;
   }
 
@@ -163,7 +163,7 @@ UINT16 IVSHMEM::GetPeerID()
   IVSHMEM_PEERID peerID;
   if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_REQUEST_SIZE, NULL, 0, &peerID, sizeof(IVSHMEM_PEERID), NULL, NULL))
   {
-    DEBUG_ERROR("DeviceIoControl Failed: %d", GetLastError());
+    DEBUG_ERROR("DeviceIoControl Failed: %d", (int)GetLastError());
     return 0;
   }
 
@@ -195,7 +195,7 @@ void * IVSHMEM::GetMemory()
   ZeroMemory(&map, sizeof(IVSHMEM_MMAP));
   if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_REQUEST_MMAP, NULL, 0, &map, sizeof(IVSHMEM_MMAP), NULL, NULL))
   {
-    DEBUG_ERROR("DeviceIoControl Failed: %d", GetLastError());
+    DEBUG_ERROR("DeviceIoControl Failed: %d", (int)GetLastError());
     return NULL;
   }
 
@@ -219,7 +219,7 @@ HANDLE IVSHMEM::CreateVectorEvent(UINT16 vector)
   HANDLE event = CreateEvent(NULL, TRUE, FALSE, NULL);
   if (event == INVALID_HANDLE_VALUE)
   {
-    DEBUG_ERROR("CreateEvent Failed: %d", GetLastError());
+    DEBUG_ERROR("CreateEvent Failed: %d", (int)GetLastError());
     return INVALID_HANDLE_VALUE;
   }
 
@@ -230,7 +230,7 @@ HANDLE IVSHMEM::CreateVectorEvent(UINT16 vector)
 
   if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_REGISTER_EVENT, &msg, sizeof(IVSHMEM_EVENT), NULL, 0, NULL, NULL))
   {
-    DEBUG_ERROR("DeviceIoControl Failed: %d", GetLastError());
+    DEBUG_ERROR("DeviceIoControl Failed: %d", (int)GetLastError());
     CloseHandle(event);
     return INVALID_HANDLE_VALUE;
   }
@@ -249,7 +249,7 @@ bool IVSHMEM::RingDoorbell(UINT16 peerID, UINT16 door)
 
   if (!DeviceIoControl(m_handle, IOCTL_IVSHMEM_RING_DOORBELL, &msg, sizeof(IVSHMEM_RING), NULL, 0, NULL, NULL))
   {
-    DEBUG_ERROR("DeviceIoControl Failed: %d", GetLastError());
+    DEBUG_ERROR("DeviceIoControl Failed: %d", (int)GetLastError());
     return false;
   }
 

--- a/host/IVSHMEM.h
+++ b/host/IVSHMEM.h
@@ -20,7 +20,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #pragma once
 
 #define W32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include <stdbool.h>
 
 class IVSHMEM

--- a/host/Makefile
+++ b/host/Makefile
@@ -1,0 +1,49 @@
+BINARY  = looking-glass-host.exe
+CFLAGS  = -g -O3 -march=native -Wall -Werror -I./ -I../common # -DDEBUG
+LDFLAGS = -lshlwapi -ldxgi -ld3d11 -lsetupapi -luuid
+
+CFLAGS  += -ffast-math
+CFLAGS  += -fdata-sections -ffunction-sections
+CFLAGS  += -I../ -I.
+LDFLAGS += -Wl,--gc-sections -mwindows
+
+PREFIX ?= x86_64-w64-mingw32-
+STRIP  = $(PREFIX)strip
+CC     = $(PREFIX)cc
+CXX    = $(PREFIX)c++
+LD     = $(CXX)
+
+BUILD  ?= .build
+BIN    ?= bin
+
+#CFLAGS  += -DCONFIG_CAPTURE_NVFBC=1
+
+CFLAGS  += -DBUILD_VERSION='"$(shell git describe --always --long --dirty --abbrev=10 --tags)"'
+
+OBJS	= main.o \
+	  CrashHandler.o \
+	  IVSHMEM.o \
+	  Service.o \
+	  Capture/DXGI.o
+
+BUILD_OBJS = $(foreach obj,$(OBJS),$(BUILD)/$(obj))
+
+all: $(BIN)/$(BINARY)
+
+$(BUILD)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) -c $(CFLAGS) -o $@ $<
+
+$(BUILD)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) -c $(CFLAGS) -o $@ $<
+
+$(BIN)/$(BINARY): $(BUILD_OBJS)
+	@mkdir -p $(dir $@)
+	$(LD) -o $@ $^ $(LDFLAGS)
+	$(STRIP) -s $@
+
+clean:
+	rm -rf $(BUILD) $(BIN)
+
+.PHONY: clean

--- a/host/Service.cpp
+++ b/host/Service.cpp
@@ -20,8 +20,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "Service.h"
 #include "IVSHMEM.h"
 
-#include "common\debug.h"
-#include "common\KVMFR.h"
+#include "common/debug.h"
+#include "common/KVMFR.h"
 
 #include "CaptureFactory.h"
 

--- a/host/Service.h
+++ b/host/Service.h
@@ -20,7 +20,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #pragma once
 
 #define W32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #include <stdbool.h>
 
 #include "IVSHMEM.h"

--- a/host/main.cpp
+++ b/host/main.cpp
@@ -17,11 +17,11 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#include <Windows.h>
-#include <Shlwapi.h>
+#include <windows.h>
+#include <shlwapi.h>
 
-#include "common\debug.h"
-#include "vendor\getopt\getopt.h"
+#include "common/debug.h"
+#include "vendor/getopt/getopt.h"
 
 #include "CrashHandler.h"
 #include "CaptureFactory.h"


### PR DESCRIPTION
Some changes that enable building of the host app using mingw-w64. I don't have VS to test building in Windows but it still should work?

Haven't tried compiling with nvfbc, and added a define to leave it out. Maybe we could add the headers in the `vendor` folder?

Note: the newer DXGI interfaces don't seem to be included in the latest released version of mingw-w64. On Arch you can install `mingw-w64-headers-git` and `mingw-w64-crt-git` from AUR to get them.