### PR TITLE
Add borderless fullscreen option

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -67,6 +67,7 @@ struct AppParams
   bool         allowResize;
   bool         keepAspect;
   bool         borderless;
+  bool         fullscreen;
   bool         center;
   int          x, y;
   unsigned int w, h;
@@ -87,6 +88,7 @@ struct AppParams params =
   .allowResize      = true,
   .keepAspect       = true,
   .borderless       = false,
+  .fullscreen       = false,
   .center           = true,
   .x                = 0,
   .y                = 0,
@@ -665,6 +667,7 @@ int run()
     params.h,
     (
       SDL_WINDOW_SHOWN |
+      (params.fullscreen  ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0) |
       (params.allowResize ? SDL_WINDOW_RESIZABLE  : 0) |
       (params.borderless  ? SDL_WINDOW_BORDERLESS : 0) |
       sdlFlags
@@ -889,7 +892,7 @@ void doLicense()
 int main(int argc, char * argv[])
 {
   int c;
-  while((c = getopt(argc, argv, "hf:sc:p:jMmkanrdx:y:w:b:l")) != -1)
+  while((c = getopt(argc, argv, "hf:sc:p:jMmkanrdFx:y:w:b:l")) != -1)
     switch(c)
     {
       case '?':
@@ -944,6 +947,10 @@ int main(int argc, char * argv[])
 
       case 'd':
         params.borderless = true;
+        break;
+
+      case 'F':
+        params.fullscreen = true;
         break;
 
       case 'x':


### PR DESCRIPTION
This PR adds the option for a borderless fullscreen window.
This allows the window to display over UI elements such as the Gnome 3 top bar.
In the case of Gnome 3, the window will display at full resolution with this option, instead of shrinking the window to fit within the space below the top bar.

Currently this option can be specified by `-F` on the command line.