### PR TITLE
Do not minimize fullscreen window on focus loss

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -676,6 +676,11 @@ int run()
     )
   );
 
+  if (params.fullscreen)
+  {
+    SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
+  }
+
   // set the compositor hint to bypass for low latency
   SDL_SysWMinfo wminfo;
   SDL_VERSION(&wminfo.version);


### PR DESCRIPTION
Under Gnome 3 when switching to another desktop the client will be minimized and when swithing back to that desktop I have to do a quick alt-tab to bring the client back to focus and fullscreen. This pull request should fix that.