### PR TITLE
[client] ivshmem: fix missing <sys/select.h> include

### DIFF
--- a/client/ivshmem/ivshmem.c
+++ b/client/ivshmem/ivshmem.c
@@ -30,6 +30,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <sys/select.h>
 
 #include <sys/mman.h>
 


### PR DESCRIPTION
While the function `ivshmem_wait_irq` makes use of the select(3)
function, it does not include <sys/select.h>. This happens to work on
glibc based systems, which include thet file transitively via other
header files. But on musl libc based systems, this breaks compilation.

Directly include <sys/select.h> to fix the problem.