### PR TITLE
Revert "[host] simplify dll loading"

### DIFF
--- a/host/Capture/NvFBC.cpp
+++ b/host/Capture/NvFBC.cpp
@@ -61,10 +61,11 @@ bool NvFBC::Initialize(CaptureOptions * options)
     if (_strcmpi(*it, "nowait") == 0) { m_optNoWait = true ; continue; }
   }
 
-  m_hDLL = LoadLibraryA(NVFBC_LIBRARY_NAME);
+  std::string nvfbc = Util::GetSystemRoot() + "\\" + NVFBC_LIBRARY_NAME;
+  m_hDLL = LoadLibraryA(nvfbc.c_str());
   if (!m_hDLL)
   {
-    DEBUG_ERROR("Failed to load the NvFBC library: %d - %s", GetLastError(), NVFBC_LIBRARY_NAME);
+    DEBUG_ERROR("Failed to load the NvFBC library: %d - %s", GetLastError(), nvfbc.c_str());
     return false;
   }
 
@@ -75,7 +76,7 @@ bool NvFBC::Initialize(CaptureOptions * options)
 
   if (!m_fnCreateEx || !m_fnSetGlobalFlags || !m_fnGetStatusEx || !m_fnEnable)
   {
-    DEBUG_ERROR("Unable to locate required entry points in %s", NVFBC_LIBRARY_NAME);
+    DEBUG_ERROR("Unable to locate required entry points in %s", nvfbc.c_str());
     DeInitialize();
     return false;
   }

--- a/host/Util.h
+++ b/host/Util.h
@@ -23,10 +23,45 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <inttypes.h>
 #include <tmmintrin.h>
 
+#include "common\debug.h"
+
 
 class Util
 {
 public:
+  static std::string GetSystemRoot()
+  {
+    std::string defaultPath;
+
+    size_t pathSize;
+    char *libPath;
+
+    if (_dupenv_s(&libPath, &pathSize, "SystemRoot") != 0)
+    {
+      DEBUG_ERROR("Unable to get the SystemRoot environment variable");
+      return defaultPath;
+    }
+
+    if (!pathSize)
+    {
+      DEBUG_ERROR("The SystemRoot environment variable is not set");
+      return defaultPath;
+    }
+#ifdef _WIN64
+    defaultPath = std::string(libPath) + "\\System32";
+#else
+    if (IsWow64())
+    {
+      defaultPath = std::string(libPath) + "\\Syswow64";
+    }
+    else
+    {
+      defaultPath = std::string(libPath) + "\\System32";
+    }
+#endif
+    return defaultPath;
+  }
+
   static inline void BGRAtoRGB(uint8_t * orig, size_t imagesize, uint8_t * dest)
   {
     assert((uintptr_t)orig % 16 == 0);


### PR DESCRIPTION
Reverts gnif/LookingGlass#19

While this code may seem to be useless it helps prevent abuse by wrapping the NVIDIA capture DLL to bypass the NVIDIA Capture API License Agreement.