### PR TITLE
NvFBC on mingw

### DIFF
--- a/host/Capture/NvFBC.cpp
+++ b/host/Capture/NvFBC.cpp
@@ -65,7 +65,7 @@ bool NvFBC::Initialize(CaptureOptions * options)
   m_hDLL = LoadLibraryA(nvfbc.c_str());
   if (!m_hDLL)
   {
-    DEBUG_ERROR("Failed to load the NvFBC library: %d - %s", GetLastError(), nvfbc.c_str());
+    DEBUG_ERROR("Failed to load the NvFBC library: %d - %s", (int)GetLastError(), nvfbc.c_str());
     return false;
   }
 

--- a/host/Makefile
+++ b/host/Makefile
@@ -16,7 +16,6 @@ LD     = $(CXX)
 BUILD  ?= .build
 BIN    ?= bin
 
-#CFLAGS  += -DCONFIG_CAPTURE_NVFBC=1
 
 CFLAGS  += -DBUILD_VERSION='"$(shell git describe --always --long --dirty --abbrev=10 --tags)"'
 
@@ -25,6 +24,11 @@ OBJS	= main.o \
 	  IVSHMEM.o \
 	  Service.o \
 	  Capture/DXGI.o
+
+ifeq ($(CONFIG_CAPTURE_NVFBC),1)
+CFLAGS  += -DCONFIG_CAPTURE_NVFBC=1 -I../vendor
+OBJS    += Capture/NvFBC.o
+endif
 
 BUILD_OBJS = $(foreach obj,$(OBJS),$(BUILD)/$(obj))
 

--- a/host/Util.h
+++ b/host/Util.h
@@ -23,8 +23,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <inttypes.h>
 #include <tmmintrin.h>
 
-#include "common\debug.h"
+#include "common/debug.h"
 
+#if __MINGW32__
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
 
 class Util
 {
@@ -33,16 +36,15 @@ public:
   {
     std::string defaultPath;
 
-    size_t pathSize;
-    char *libPath;
+    const char *libPath = getenv("SystemRoot");
 
-    if (_dupenv_s(&libPath, &pathSize, "SystemRoot") != 0)
+    if (!libPath)
     {
       DEBUG_ERROR("Unable to get the SystemRoot environment variable");
       return defaultPath;
     }
 
-    if (!pathSize)
+    if (!strlen(libPath))
     {
       DEBUG_ERROR("The SystemRoot environment variable is not set");
       return defaultPath;


### PR DESCRIPTION
Fixes to get the NvFBC capture driver compiling on Linux. `make -C host CONFIG_CAPTURE_NVFBC=1`

Note: Requires extracting the `NvFBC` headers from the `inc` directory of the capture SDK into the `vendor` folder. The particular header also has `Windows.h` incorrectly cased and needs adjustment there. It would be nice if we could just include it in the repo, or rewrite it if there are copyright concerns about using it verbatim, but I'll leave that out for now.