### PR TITLE
Allow edge-of-screen mouse position sync/fix/jump to work in nvfbc mode

### DIFF
--- a/host/Capture/NvFBC.cpp
+++ b/host/Capture/NvFBC.cpp
@@ -28,6 +28,8 @@ using namespace Capture;
 #include "common/memcpySSE.h"
 #include "Util.h"
 
+#include <windows.h>
+
 #ifdef _WIN64
 #define NVFBC_LIBRARY_NAME "NvFBC64.dll"
 #else
@@ -242,6 +244,13 @@ enum GrabStatus NvFBC::GrabFrame(struct FrameInfo & frame)
         i = 0;
         continue;
       }
+      
+      POINT mousePos;
+      GetCursorPos(&mousePos);
+      frame.cursor.hasShape = false;
+      frame.cursor.hasPos = true;
+      frame.cursor.x = mousePos.x;
+      frame.cursor.y = mousePos.y;
 
       unsigned int dataWidth;
       unsigned int dataOffset;


### PR DESCRIPTION
Not exactly sure what that feature is called, but naturally it only actually works if the client knows where the client's mouse position is; this patch adds that information to nvfbc's output to bring it into parity with DXGI.