### PR TITLE
Ignore SDL_MOUSEBUTTONDOWN events incompatible with SPICE

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -587,7 +587,8 @@ int eventThread(void * arg)
       }
 
       case SDL_MOUSEBUTTONDOWN:
-        if (event.button.button > 3) // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+        // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+        if (event.button.button > 3)
           break;
         if (
           !spice_mouse_position(event.button.x, event.button.y) ||
@@ -600,7 +601,8 @@ int eventThread(void * arg)
         break;
 
       case SDL_MOUSEBUTTONUP:
-        if (event.button.button > 3) // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+        // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+        if (event.button.button > 3)
           break;
         if (
           !spice_mouse_position(event.button.x, event.button.y) ||

--- a/client/main.c
+++ b/client/main.c
@@ -587,6 +587,8 @@ int eventThread(void * arg)
       }
 
       case SDL_MOUSEBUTTONDOWN:
+        if (event.button.button > 3) // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+          break;
         if (
           !spice_mouse_position(event.button.x, event.button.y) ||
           !spice_mouse_press(event.button.button)
@@ -598,6 +600,8 @@ int eventThread(void * arg)
         break;
 
       case SDL_MOUSEBUTTONUP:
+        if (event.button.button > 3) // The SPICE protocol doesn't support more than a standard PS/2 3 button mouse
+          break;
         if (
           !spice_mouse_position(event.button.x, event.button.y) ||
           !spice_mouse_release(event.button.button)


### PR DESCRIPTION
The SPICE protocol only supports a standard 3 button PS/2 virtual mouse. Right now SDL is passing through mouse 4/5 + which SPICE is interpreting as scroll up / down. Drop these events to avoid weird scrolling on mouse 4/5.