### PR TITLE
[client] Makefile: fix multi-job race condition

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -29,6 +29,7 @@ BUILD_OBJS = $(foreach obj,$(OBJS),$(BUILD)/$(obj))
 all: $(BIN)/$(BINARY) $(BIN)/xlib-shim.so
 
 $(BIN)/xlib-shim.so:
+	@mkdir -p $(dir $@)
 	$(CC) -fPIC $(CFLAGS) -shared -o $@ xlib-shim.c
 
 $(BUILD)/%.o: %.c


### PR DESCRIPTION
make fails when using `-j` because xlib-shim.so can be targeted before the binary, in which case bin/ doesn't exist yet.