### PR TITLE
[client] prevent event polling from consuming 100% cpu

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -922,7 +922,7 @@ int run()
     while(state.running)
     {
       SDL_Event event;
-      while(SDL_PollEvent(&event))
+      while(SDL_WaitEventTimeout(&event, 100))
         if (event.type == SDL_QUIT)
         {
           if (!params.ignoreQuit)


### PR DESCRIPTION
This change prevents the looking glass client from using over 100% CPU constantly.

As I have not used spice, I'm not sure whether this has any negative effect on responsiveness of handling keyboard events. It *shouldn't*, but I haven't tested that. I initially just tried with `SDL_WaitEvent` but it interacted a bit strangely with `^C` not able to quit properly?