### PR TITLE
[host] mingw-w64 compile fixes

### DIFF
--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -386,9 +386,9 @@ bool DXGI::InitH264Capture()
     return false;
   }
 
-  m_mfTransform->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH         , NULL);
-  m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, NULL);
-  m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, NULL);
+  m_mfTransform->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH         , 0);
+  m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0);
+  m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
 
 #if 0  
   status = MFTRegisterLocalByCLSID(
@@ -415,8 +415,8 @@ void DXGI::DeInitialize()
 {
   if (m_mediaEventGen)
   {
-    m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, NULL);
-    m_mfTransform->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, NULL);
+    m_mfTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+    m_mfTransform->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0);
     while (WaitForSingleObject(m_shutdownEvent, INFINITE) != WAIT_OBJECT_0) {}
     m_mfTransform->DeleteInputStream(0);
   }

--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -761,7 +761,7 @@ GrabStatus Capture::DXGI::GrabFrameRaw(FrameInfo & frame)
       frame.stride = m_mapping.RowPitch / 4;
 
       unsigned int size = m_height * m_mapping.RowPitch;
-      m_memcpy.Copy(frame.buffer, m_mapping.pData, size < frame.bufferSize ? size : frame.bufferSize);
+      m_memcpy.Copy(frame.buffer, m_mapping.pData, LG_MIN(size, frame.bufferSize));
       return GRAB_STATUS_OK;
     }
 
@@ -795,7 +795,7 @@ GrabStatus Capture::DXGI::GrabFrameRaw(FrameInfo & frame)
   frame.stride = m_mapping.RowPitch >> 2;
 
   const unsigned int size = m_height * m_mapping.RowPitch;
-  m_memcpy.Copy(frame.buffer, m_mapping.pData, size < frame.bufferSize ? size : frame.bufferSize);
+  m_memcpy.Copy(frame.buffer, m_mapping.pData, LG_MIN(size, frame.bufferSize));
   TRACE_END;
 
   return GRAB_STATUS_OK;

--- a/host/Capture/DXGI.cpp
+++ b/host/Capture/DXGI.cpp
@@ -28,7 +28,22 @@ using namespace Capture;
 #include <codecapi.h>
 #include <mferror.h>
 #include <evr.h>
+#include <mfapi.h>
+#include <mfidl.h>
 #include <mfreadwrite.h>
+
+#if __MINGW32__
+
+EXTERN_GUID(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, 0xa634a91c, 0x822b, 0x41b9, 0xa4, 0x94, 0x4d, 0xe4, 0x64, 0x36, 0x12, 0xb0);
+EXTERN_GUID(MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING, 0xf81da2c, 0xb537, 0x4672, 0xa8, 0xb2, 0xa6, 0x81, 0xb1, 0x73, 0x7, 0xa3);
+EXTERN_GUID(MF_SA_D3D11_AWARE, 0x206b4fc8, 0xfcf9, 0x4c51, 0xaf, 0xe3, 0x97, 0x64, 0x36, 0x9e, 0x33, 0xa0);
+
+#define METransformUnknown 600
+#define METransformNeedInput 601
+#define METransformHaveOutput 602
+#define METransformDrainComplete 603
+#define METransformMarker 604
+#endif
 
 template <class T> void SafeRelease(T **ppT)
 {

--- a/host/Capture/DXGI.h
+++ b/host/Capture/DXGI.h
@@ -86,13 +86,14 @@ namespace Capture
     */
     STDMETHODIMP QueryInterface(REFIID riid, void ** ppv)
     {
-      static const QITAB qit[] =
-      {
-        QITABENT(DXGI, IMFAsyncCallback),
-        { NULL }
-      };
-
-      return QISearch(this, qit, riid, ppv);
+      if (riid == __uuidof(IUnknown) || riid == __uuidof(IMFAsyncCallback)) {
+        *ppv = static_cast<IMFAsyncCallback*>(this);
+        AddRef();
+        return S_OK;
+      } else {
+        *ppv = NULL;
+        return E_NOINTERFACE;
+      }
     }
 
     STDMETHODIMP_(ULONG) AddRef()

--- a/host/Capture/DXGI.h
+++ b/host/Capture/DXGI.h
@@ -115,9 +115,9 @@ namespace Capture
     bool InitRawCapture();
     bool InitH264Capture();
 
-    GrabStatus DXGI::GrabFrameTexture(FrameInfo & frame, ID3D11Texture2DPtr & texture, bool & timeout);
-    GrabStatus DXGI::GrabFrameRaw    (FrameInfo & frame);
-    GrabStatus DXGI::GrabFrameH264   (FrameInfo & frame);
+    GrabStatus GrabFrameTexture(FrameInfo & frame, ID3D11Texture2DPtr & texture, bool & timeout);
+    GrabStatus GrabFrameRaw    (FrameInfo & frame);
+    GrabStatus GrabFrameH264   (FrameInfo & frame);
 
     void WaitForDesktop();
 

--- a/host/Capture/NvFBC.cpp
+++ b/host/Capture/NvFBC.cpp
@@ -274,8 +274,8 @@ enum GrabStatus NvFBC::GrabFrame(struct FrameInfo & frame)
         }
 
         // use the smaller or the two dimensions provided just to be sure we don't overflow the buffer
-        const unsigned int realHeight = min(m_grabInfo.dwHeight, screenHeight);
-        const unsigned int realWidth  = min(m_grabInfo.dwWidth , screenWidth );
+        const unsigned int realHeight = LG_MIN(m_grabInfo.dwHeight, screenHeight);
+        const unsigned int realWidth  = LG_MIN(m_grabInfo.dwWidth , screenWidth );
 
         // calculate the new data width and offset to the start of the data
         dataWidth  = realWidth * 4;

--- a/host/Makefile
+++ b/host/Makefile
@@ -1,11 +1,12 @@
 BINARY  = looking-glass-host.exe
 CFLAGS  = -g -O3 -march=native -Wall -Werror -I./ -I../common # -DDEBUG
-LDFLAGS = -lshlwapi -ldxgi -ld3d11 -lsetupapi -luuid
+LDFLAGS = -lshlwapi -ldxgi -ld3d11 -lsetupapi -luuid -lole32 -lmfplat -lmfuuid
 
 CFLAGS  += -ffast-math
 CFLAGS  += -fdata-sections -ffunction-sections
 CFLAGS  += -I../ -I.
 LDFLAGS += -Wl,--gc-sections -mwindows
+CFLAGS  += -DWINVER=0x0602
 
 PREFIX ?= x86_64-w64-mingw32-
 STRIP  = $(PREFIX)strip

--- a/host/Service.cpp
+++ b/host/Service.cpp
@@ -123,12 +123,12 @@ bool Service::InitPointers()
   m_dataOffset[0] = m_frame[0]   - m_memory;
   m_dataOffset[1] = m_frame[1]   - m_memory;
 
-  DEBUG_INFO("Total Available : %3I64u MB", m_ivshmem->GetSize() / 1024 / 1024);
-  DEBUG_INFO("Max Cursor Size : %3I64u MB", m_cursorDataSize / 1024 / 1024);
-  DEBUG_INFO("Max Frame Size  : %3I64u MB", m_frameSize / 1024 / 1024);
-  DEBUG_INFO("Cursor          : %p (0x%08I64x)", m_cursorData, m_cursorOffset );
-  DEBUG_INFO("Frame 1         : %p (0x%08I64x)", m_frame[0]  , m_dataOffset[0]);
-  DEBUG_INFO("Frame 2         : %p (0x%08I64x)", m_frame[1]  , m_dataOffset[1]);
+  DEBUG_INFO("Total Available : %3u MB", (unsigned int)(m_ivshmem->GetSize() / 1024 / 1024));
+  DEBUG_INFO("Max Cursor Size : %3u MB", (unsigned int)(m_cursorDataSize / 1024 / 1024));
+  DEBUG_INFO("Max Frame Size  : %3u MB", (unsigned int)(m_frameSize / 1024 / 1024));
+  DEBUG_INFO("Cursor          : %p (0x%08x)", m_cursorData, (int)m_cursorOffset );
+  DEBUG_INFO("Frame 1         : %p (0x%08x)", m_frame[0]  , (int)m_dataOffset[0]);
+  DEBUG_INFO("Frame 2         : %p (0x%08x)", m_frame[1]  , (int)m_dataOffset[1]);
 
   return true;
 }

--- a/host/Util.h
+++ b/host/Util.h
@@ -59,7 +59,7 @@ public:
       if (buffer[i] == '\n' || buffer[i] == '\r')
         buffer[i] = 0;
 
-    fprintf(stderr, "[E] %20s:%-4u | %-30s | %s: 0x%08x (%s)\n", file, line, function, desc, status, buffer);
+    fprintf(stderr, "[E] %20s:%-4u | %-30s | %s: 0x%08x (%s)\n", file, line, function, desc, (int)status, buffer);
     LocalFree(buffer);
   }
 

--- a/host/Util.h
+++ b/host/Util.h
@@ -25,8 +25,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "common/debug.h"
 
-#if __MINGW32__
-#define min(a, b) ((a) < (b) ? (a) : (b))
+#if !defined(min)
+#define LG_MIN(a, b) ((a) < (b) ? (a) : (b))
+#else
+#define LG_MIN min
 #endif
 
 #if __MINGW32__


### PR DESCRIPTION
Not sure if you'd want to merge this as-is, I can split it up into a few commits if it makes sense to do so. The main issue here is that mingw headers are missing some of the newer media foundation APIs.

Also `min` was moved out of the util header because `#define min` conflicts with some libc/libstdc++ headers if they're included after it. Might be nice to just define a `LG_MIN` if it's needed in multiple parts of the code?