### PR TITLE
[client] fix event loop sleep

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -927,8 +927,8 @@ int run()
             state.running = false;
           break;
         }
-        usleep(1000);
       }
+      usleep(1000);
     }
 
     break;


### PR DESCRIPTION
Moves the sleep so that it (only) gets hit when there are no events in the queue. Previously it would only throttle events after they occur, which is rare and had no impact on the 100%+ cpu usage.