### PR TITLE
Stepped mouse movement for virtio and related tweaks

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -420,6 +420,27 @@ static inline const uint32_t mapScancode(SDL_Scancode scancode)
   return ps2;
 }
 
+// virtio mouse driver only works with move events within the range of a signed byte; in addition,
+// other mouse drivers are not used by spice when virtio mouse is present
+// however, virtio is currently far more stable than emulated PS/2 or USB
+#define VIRTIO_MAX_STEP 120
+bool smart_mouse_motion(int32_t x, int32_t y)
+{
+  int px = 0; int py = 0; // "parity" (sign) x/y (s was taken)
+  if (x != 0) { if (x < 0) px = -1; else px = 1; }
+  if (y != 0) { if (y < 0) py = -1; else py = 1; }
+  
+  while (x != 0 || y != 0) { // move mouse by maximum step at a time
+    int sx = x; int sy = y; // step x/y
+    if (sx * px >= VIRTIO_MAX_STEP) sx = VIRTIO_MAX_STEP * px; // cap X/Y to maximum step size
+    if (sy * py >= VIRTIO_MAX_STEP) sy = VIRTIO_MAX_STEP * py; // //
+    if (!spice_mouse_motion(sx, sy)) return false; // commit step
+    x -= sx; y -= sy; // and count down toward zero
+  }
+  // fix mouse jumping elsewhere on click; there may be a better way to do this
+  return spice_mouse_mode(false);
+}
+
 int eventFilter(void * userdata, SDL_Event * event)
 {
   static bool serverMode   = false;
@@ -476,7 +497,7 @@ int eventFilter(void * userdata, SDL_Event * event)
         y -= state.cursor.y;
         realignGuest = false;
 
-        if (!spice_mouse_motion(x, y))
+        if (!smart_mouse_motion(x, y))
           DEBUG_ERROR("SDL_MOUSEMOTION: failed to send message");
         break;
       }
@@ -490,7 +511,7 @@ int eventFilter(void * userdata, SDL_Event * event)
           x = (float)x * state.scaleX;
           y = (float)y * state.scaleY;
         }
-        if (!spice_mouse_motion(x, y))
+        if (!smart_mouse_motion(x, y))
         {
           DEBUG_ERROR("SDL_MOUSEMOTION: failed to send message");
           break;

--- a/client/main.c
+++ b/client/main.c
@@ -484,7 +484,7 @@ int eventFilter(void * userdata, SDL_Event * event)
 
       int x = 0;
       int y = 0;
-      if (realignGuest && state.haveCursorPos)
+      if (realignGuest)
       {
         x = event->motion.x - state.dstRect.x;
         y = event->motion.y - state.dstRect.y;
@@ -493,8 +493,13 @@ int eventFilter(void * userdata, SDL_Event * event)
           x = (float)x * state.scaleX;
           y = (float)y * state.scaleY;
         }
-        x -= state.cursor.x;
-        y -= state.cursor.y;
+        if (state.haveCursorPos) { // if cursor position reported, use relative motion
+          x -= state.cursor.x;
+          y -= state.cursor.y;
+        } else { // move against edge to zero, then back to absolute position
+          if (!smart_mouse_motion(-state.srcSize.x, -state.srcSize.y))
+            DEBUG_ERROR("SDL_MOUSEMOTION: failed to send message");
+        }
         realignGuest = false;
 
         if (!smart_mouse_motion(x, y))

--- a/client/spice/spice.c
+++ b/client/spice/spice.c
@@ -76,7 +76,7 @@ struct SpiceKeyboard
   uint32_t modifiers;
 };
 
-#define SPICE_MOUSE_QUEUE_SIZE 64
+#define SPICE_MOUSE_QUEUE_SIZE 256
 
 struct SpiceMouse
 {


### PR DESCRIPTION
As you may have noticed, having a virtio mouse present breaks "edge jumping" on Spice; if the cursor needs to move more than a certain distance, no movement occurs. This is because the virtio mouse driver uses a signed byte for each axis, resulting in a silent failure if either axis on a single movement packet is out of that range.

The first commit in this series adds a function that applies the necessary mouse movement in steps of up to +-120px on each axis, allowing functionally uncapped mouse movement. I didn't bother to add an early-out by magnitude, as it wouldn't save any significant amount of calculation over simply going through a single loop (and it shouldn't be enough extra work to be any sort of issue anyway).

The second commit expands the edge jump/cursor realignment code to allow it to function even without a reported position from the guest, by first moving up and left by the size of the screen (catching it in the upper left corner), then moving back down by its target position. This of course assumes a regular workspace shape, but since only a single screen is supported this shouldn't be an issue.

The third commit simply upsizes the mouse queue to accommodate the potential number of steps required to traverse to the upper left corner and back on higher resolutions.