### PR TITLE
[host] ask for unicode with mingw-w64 makefile

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -6,7 +6,7 @@ CFLAGS  += -ffast-math
 CFLAGS  += -fdata-sections -ffunction-sections
 CFLAGS  += -I../ -I.
 LDFLAGS += -Wl,--gc-sections -mwindows
-CFLAGS  += -DWINVER=0x0602
+CFLAGS  += -DWINVER=0x0602 -DUNICODE
 
 PREFIX ?= x86_64-w64-mingw32-
 STRIP  = $(PREFIX)strip


### PR DESCRIPTION
Pass -DUNICODE as a CFLAG.  The visual studio project asks for
a unicode (wide-string) build, but the unix makefile did not, and
so the compiler was trying to bring the ansi functions instead
of the wide functions.

This fixes the build on MSYS2 with `make --eval=PREFIX=`.

```
Service.cpp: In member function 'bool Service::Initialize(ICapture*)':
Service.cpp:99:67: error: cannot convert 'const wchar_t*' to 'LPCSTR {aka const char*}' for argument '4' to 'void* CreateEventA(LPSECURITY_ATTRIBUTES, WINBOOL, WINBOOL, LPCSTR)'
   m_cursorEvent  = CreateEvent (NULL, FALSE, FALSE, L"CursorEvent");
```