### PR TITLE
Fixing scaled mouse movement

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -58,6 +58,7 @@ struct AppState
   bool                 cursorVisible;
   bool                 haveCursorPos;
   float                scaleX, scaleY;
+  float                accX, accY;
 
   const LG_Renderer  * lgr ;
   void               * lgrData;
@@ -487,6 +488,7 @@ int eventFilter(void * userdata, SDL_Event * event)
         x -= state.cursor.x;
         y -= state.cursor.y;
         realignGuest = false;
+        state.accX = state.accY = 0;
 
         if (!spice_mouse_motion(x, y))
           DEBUG_ERROR("SDL_MOUSEMOTION: failed to send message");
@@ -499,8 +501,12 @@ int eventFilter(void * userdata, SDL_Event * event)
       {
         if (params.scaleMouseInput)
         {
-          x = (float)x * state.scaleX;
-          y = (float)y * state.scaleY;
+          state.accX += (float)x * state.scaleX;
+          state.accY += (float)y * state.scaleY;
+          x = floor(state.accX);
+          y = floor(state.accY);
+          state.accX -= x;
+          state.accY -= y;
         }
         if (!spice_mouse_motion(x, y))
         {

--- a/client/main.c
+++ b/client/main.c
@@ -488,7 +488,8 @@ int eventFilter(void * userdata, SDL_Event * event)
         x -= state.cursor.x;
         y -= state.cursor.y;
         realignGuest = false;
-        state.accX = state.accY = 0;
+        state.accX = 0;
+        state.accY = 0;
 
         if (!spice_mouse_motion(x, y))
           DEBUG_ERROR("SDL_MOUSEMOTION: failed to send message");


### PR DESCRIPTION
This has been bothering me for a while, now that a11 is out decided to jump in and get it fixed.

I have a 1080p server and a 2160p client, so when using fullscreen mode small mouse movements get rounded down to zero across spice, making movements quite erratic.

To solve that, I added a simple mouse movement accumulator, whatever movement is too small to get sent to the server is kept for the next movement. Final result is smooth cursor movement independent of scaling.