### PR TITLE
[client] Fix segfault when envar XDG_SESSION_TYPE isn't set

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -733,6 +733,11 @@ int run()
   state.fpsSleep = 1000000 / params.fpsLimit;
 
   char* XDG_SESSION_TYPE = getenv("XDG_SESSION_TYPE");
+  
+  if (XDG_SESSION_TYPE == NULL) {
+    XDG_SESSION_TYPE = "unspecified";
+  }
+  
   if (strcmp(XDG_SESSION_TYPE, "wayland") == 0) {
      DEBUG_INFO("Wayland detected");
      int err = setenv("SDL_VIDEODRIVER", "wayland", 1);


### PR DESCRIPTION
Minimal systems in cases may not have XDG_SESSION_TYPE set at all, causing the program to segfault at the `strcmp`. This commit sets XDG_SESSION_TYPE to `unspecified` (according to https://www.freedesktop.org/software/systemd/man/pam_systemd.html) if it is not defined in the environment.