### PR TITLE
Store the initial window size in the state

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -862,6 +862,9 @@ int run()
   if (!params.center)
     SDL_SetWindowPosition(state.window, params.x, params.y);
 
+  // ensure the initial window size is stored in the state
+  SDL_GetWindowSize(state.window, &state.windowW, &state.windowH);
+
   // set the compositor hint to bypass for low latency
   SDL_SysWMinfo wminfo;
   SDL_VERSION(&wminfo.version);


### PR DESCRIPTION
The SDL resize event only gets fired when the window is resized from it's starting size, so if the user doesn't resize the window, then no size will ever be recorded into the state.

Without a size in place there both the OpenGL and the EGL renderer seem to break, though in different ways - OpenGL crashes with a glGenBuffer error (#101 #107), and EGL simply renders a black screen.

This reads the window size initially as well as on resizes, and fixes said issues at least on my system.