### PR TITLE
change spice port type to unsigned short

### DIFF
--- a/client/spice/spice.c
+++ b/client/spice/spice.c
@@ -138,7 +138,7 @@ bool    spice_discard  (const struct SpiceChannel * channel, ssize_t size);
 
 // ============================================================================
 
-bool spice_connect(const char * host, const short port, const char * password)
+bool spice_connect(const char * host, const unsigned short port, const char * password)
 {
   strncpy(spice.password, password, sizeof(spice.password) - 1);
   memset(&spice.addr, 0, sizeof(spice.addr));

--- a/client/spice/spice.h
+++ b/client/spice/spice.h
@@ -21,7 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdbool.h>
 #include <stdint.h>
 
-bool spice_connect(const char * host, const short port, const char * password);
+bool spice_connect(const char * host, const unsigned short port, const char * password);
 void spice_disconnect();
 bool spice_process();
 bool spice_ready();


### PR DESCRIPTION
so that ports >32767 get displayed correctly,
also signed overflow is undefined behaviour

Signed-off-by: Dominik Csapak <d.csapak@proxmox.com>