### PR TITLE
[client] update viewport size after window is created

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -46,7 +46,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 struct AppState
 {
   bool                 running;
-  bool                 started;
   bool                 keyDown[SDL_NUM_SCANCODES];
 
   bool                 haveSrcSize;
@@ -453,11 +452,6 @@ int frameThread(void * unused)
     }
 
     ++state.frameCount;
-    if (!state.started)
-    {
-      state.started = true;
-      updatePositionInfo();
-    }
   }
 
   state.running = false;
@@ -884,6 +878,9 @@ int run()
 
   // ensure the initial window size is stored in the state
   SDL_GetWindowSize(state.window, &state.windowW, &state.windowH);
+
+  // ensure renderer viewport is aware of the current window size
+  updatePositionInfo();
 
   // set the compositor hint to bypass for low latency
   SDL_SysWMinfo wminfo;


### PR DESCRIPTION
Make sure glViewport gets called as soon as we know the window
dimensions, otherwise nothing gets rendered until KVMFR communication is
established (mostly the splash).

Without the fix, './looking-glass-client -s' behaves differently than
'./looking-glass-client -s -F' in that the latter triggers a
SDL_WINDOWEVENT_SIZE_CHANGED and updates the viewport immediately after
window creation while the former doesn't and all rendering is delayed
until the frameThread successfully decodes the first frame.

As all the possible ways of updating the viewport (window creation,
window size change, frame size change) are covered with
updatePositionInfo(), the 'started' state becomes redundant and is
removed.

Note: this might be the wrong way to fix it (possible driver bug?),
glViewport's specification mentions that the default viewport size
matches the window size when the GL context is first attached.

Tested on:

Debian Buster with GNOME 3.30.2 on X.Org 1.20.3
Looking Glass (a12-21-g07e4c1c20f)
Locking Method: Atomic
Using: EGL
Vendor  : Intel Open Source Technology Center
Renderer: Mesa DRI Intel(R) Haswell Desktop
Version : OpenGL ES 3.1 Mesa 18.3.2

Signed-off-by: Marius Barbu <msb@avengis.com>