### PR TITLE
[client] Added option for custom window title

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -1602,8 +1602,9 @@ static bool load_config(const char * configFile)
 
 int main(int argc, char * argv[])
 {
-  params.shmFile   = strdup(params.shmFile  );
+  params.shmFile   = strdup(params.shmFile);
   params.spiceHost = strdup(params.spiceHost);
+  params.windowTitle = strdup(params.windowTitle);
 
   {
     // load any global then local config options first
@@ -1885,6 +1886,7 @@ int main(int argc, char * argv[])
         continue;
 
       case 't':
+        free(params.windowTitle);
         params.windowTitle = strdup(optarg);
         continue;
 

--- a/client/main.c
+++ b/client/main.c
@@ -1602,8 +1602,8 @@ static bool load_config(const char * configFile)
 
 int main(int argc, char * argv[])
 {
-  params.shmFile   = strdup(params.shmFile);
-  params.spiceHost = strdup(params.spiceHost);
+  params.shmFile     = strdup(params.shmFile    );
+  params.spiceHost   = strdup(params.spiceHost  );
   params.windowTitle = strdup(params.windowTitle);
 
   {

--- a/client/main.c
+++ b/client/main.c
@@ -120,6 +120,8 @@ struct AppParams
   bool         forceRenderer;
   unsigned int forceRendererIndex;
   RendererOpts rendererOpts[LG_RENDERER_COUNT];
+
+  char       * windowTitle;
 };
 
 struct AppState  state;
@@ -153,7 +155,8 @@ struct AppParams params =
   .grabKeyboard      = true,
   .captureKey        = SDL_SCANCODE_SCROLLLOCK,
   .disableAlerts     = false,
-  .forceRenderer     = false
+  .forceRenderer     = false,
+  .windowTitle       = "Looking Glass (Client)"
 };
 
 struct CBRequest
@@ -1035,7 +1038,7 @@ int run()
   }
 
   state.window = SDL_CreateWindow(
-    "Looking Glass (Client)",
+    params.windowTitle,
     params.center ? SDL_WINDOWPOS_CENTERED : params.x,
     params.center ? SDL_WINDOWPOS_CENTERED : params.y,
     params.w,
@@ -1366,6 +1369,7 @@ void doHelp(char * app)
     "  -m CODE    Specify the capture key [current: %u (%s)]\n"
     "             See https://wiki.libsdl.org/SDLScancodeLookup for valid values\n"
     "  -q         Disable alert messages [current: %s]\n"
+    "  -t TITLE   Use a custom title for the main window\n"
     "\n"
     "  -l         License information\n"
     "\n",
@@ -1517,6 +1521,13 @@ static bool load_config(const char * configFile)
       }
       params.captureKey = (SDL_Scancode)itmp;
     }
+
+    if (config_setting_lookup_string(global, "windowTitle", &stmp))
+    {
+      free(params.windowTitle);
+      params.windowTitle = strdup(stmp);
+    }
+
   }
 
   config_setting_t * spice = config_lookup(&cfg, "spice");
@@ -1619,7 +1630,7 @@ int main(int argc, char * argv[])
 
   for(;;)
   {
-    switch(getopt(argc, argv, "hC:f:L:s:c:p:jMvK:kg:o:anrdFx:y:w:b:QSGm:lq"))
+    switch(getopt(argc, argv, "hC:f:L:s:c:p:jMvK:kg:o:anrdFx:y:w:b:QSGm:lqt:"))
     {
       case '?':
       case 'h':
@@ -1871,6 +1882,10 @@ int main(int argc, char * argv[])
 
       case 'q':
         params.disableAlerts = true;
+        continue;
+
+      case 't':
+        params.windowTitle = strdup(optarg);
         continue;
 
       case 'l':


### PR DESCRIPTION
When one need to access more than one VM simultaneously through multiple instances of Looking Glass on the same host, currently it's difficult to tell from the window title alone as they'll all be the same.

I'd think it'd be nice to add an option so that the end user could set their own window title (either through the config file or scripting) - this should make it easier for the user to tell which VM they're using.