### PR TITLE
KVMFR Module build file update

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -1,11 +1,13 @@
 obj-m += kvmfr.o
 USER  := $(shell whoami)
+KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVER)/build
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) modules
+	make -C $(KDIR) M=$(PWD) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) clean
+	make -C $(KDIR) M=$(PWD) clean
 
 test:	all
 	grep -q '^uio'   /proc/modules || sudo modprobe uio

--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -1,8 +1,7 @@
-PACKAGE_NAME=kvmfr
-PACKAGE_VERSION=0.1
-BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
-MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
-CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
-DEST_MODULE_LOCATION[0]=/extra
-REMAKE_INITRD=yes
-AUTOINSTALL=yes
+PACKAGE_NAME="kvmfr"
+PACKAGE_VERSION="0.0.1"
+BUILT_MODULE_NAME[0]="${PACKAGE_NAME}"
+MAKE[0]="make KDIR=${kernel_source_dir}"
+CLEAN="make KDIR=${kernel_source_dir} clean"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/misc"
+AUTOINSTALL="yes"


### PR DESCRIPTION
Update to allow the module to be build for different kernels. Needed for DKMS.
Also updated the DKMS file to make use of that.

I've not made other changes to the DKMS file  (such as removing the REMAKE_INITRD and changing the module location) as I do not know what system the file was originally targeting and if that actually does need those.