### PR TITLE
Add missing linker libraries

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -99,6 +99,10 @@ target_link_libraries(looking-glass-client
 	renderers
 	clipboards
 	fonts
+    -lbfd
+    -ldl
+    -lz
+    /usr/lib64/libiberty.a
 )
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/looking-glass-client DESTINATION bin/ COMPONENT binary)


### PR DESCRIPTION
On opensuse tumbleweed those missing libs are stopping lookingglass from linking.