### PR TITLE
Implement option to disable minimizing window on focus loss

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -101,24 +101,25 @@ Command line arguments will override any options loaded from the config files.
 | app:framePollInterval  |       | 1000                   | How often to check for a frame update in microseconds         |
 |-------------------------------------------------------------------------------------------------------------------------|
 
-|-------------------------------------------------------------------------------------------------------|
-| Long              | Short | Value                  | Description                                      |
-|-------------------------------------------------------------------------------------------------------|
-| win:title         |       | Looking Glass (client) | The window title                                 |
-| win:position      |       | center                 | Initial window position at startup               |
-| win:size          |       | 1024x768               | Initial window size at startup                   |
-| win:autoResize    | -a    | no                     | Auto resize the window to the guest              |
-| win:allowResize   | -n    | yes                    | Aallow the window to be manually resized         |
-| win:keepAspect    | -r    | yes                    | Maintain the correct aspect ratio                |
-| win:borderless    | -d    | no                     | Borderless mode                                  |
-| win:fullScreen    | -F    | no                     | Launch in fullscreen borderless mode             |
-| win:maximize      | -T    | no                     | Launch window maximized                          |
-| win:fpsLimit      | -K    | 200                    | Frame rate limit (0 = disable - not recommended) |
-| win:showFPS       | -k    | no                     | Enable the FPS & UPS display                     |
-| win:ignoreQuit    | -Q    | no                     | Ignore requests to quit (ie: Alt+F4)             |
-| win:noScreensaver | -S    | no                     | Prevent the screensaver from starting            |
-| win:alerts        | -q    | yes                    | Show on screen alert messages                    |
-|-------------------------------------------------------------------------------------------------------|
+|-------------------------------------------------------------------------------------------------------------|
+| Long                    | Short | Value                  | Description                                      |
+|-------------------------------------------------------------------------------------------------------------|
+| win:title               |       | Looking Glass (client) | The window title                                 |
+| win:position            |       | center                 | Initial window position at startup               |
+| win:size                |       | 1024x768               | Initial window size at startup                   |
+| win:autoResize          | -a    | no                     | Auto resize the window to the guest              |
+| win:allowResize         | -n    | yes                    | Aallow the window to be manually resized         |
+| win:keepAspect          | -r    | yes                    | Maintain the correct aspect ratio                |
+| win:borderless          | -d    | no                     | Borderless mode                                  |
+| win:fullScreen          | -F    | no                     | Launch in fullscreen borderless mode             |
+| win:maximize            | -T    | no                     | Launch window maximized                          |
+| win:minimizeOnFocusLoss |       | yes                    | Minimize window on focus loss                    |
+| win:fpsLimit            | -K    | 200                    | Frame rate limit (0 = disable - not recommended) |
+| win:showFPS             | -k    | no                     | Enable the FPS & UPS display                     |
+| win:ignoreQuit          | -Q    | no                     | Ignore requests to quit (ie: Alt+F4)             |
+| win:noScreensaver       | -S    | no                     | Prevent the screensaver from starting            |
+| win:alerts              | -q    | yes                    | Show on screen alert messages                    |
+|-------------------------------------------------------------------------------------------------------------|
 
 |---------------------------------------------------------------------------------------------------------------------------------------|
 | Long               | Short | Value           | Description                                                                            |

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -177,6 +177,13 @@ static struct Option options[] =
   },
   {
     .module         = "win",
+    .name           = "minimizeOnFocusLoss",
+    .description    = "Minimize window on focus loss",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = true,
+  },
+  {
+    .module         = "win",
     .name           = "fpsLimit",
     .description    = "Frame rate limit (0 = disable - not recommended)",
     .shortopt       = 'K',
@@ -395,6 +402,8 @@ bool config_load(int argc, char * argv[])
   params.escapeKey     = option_get_int   ("input", "escapeKey"   );
   params.hideMouse     = option_get_bool  ("input", "hideCursor"  );
   params.mouseSens     = option_get_int   ("input", "mouseSens"   );
+
+  params.minimizeOnFocusLoss = option_get_bool("win", "minimizeOnFocusLoss");
 
   if (option_get_bool("spice", "enable"))
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1102,7 +1102,7 @@ int run()
     return 1;
   }
 
-  if (params.fullscreen)
+  if (params.fullscreen || !params.minimizeOnFocusLoss)
     SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
   if (!params.noScreensaver)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -82,6 +82,7 @@ struct AppParams
   bool         borderless;
   bool         fullscreen;
   bool         maximize;
+  bool         minimizeOnFocusLoss;
   bool         center;
   int          x, y;
   unsigned int w, h;


### PR DESCRIPTION
Default behavior is not changed - not configuring these options unfocused window is minimized.

* Added short option -N (default false).
* Added config entry win:noMinimizeOnFocusLoss (default false).