### PR TITLE
[c-host] nvfbc: support relative path to SDK

### DIFF
--- a/c-host/platform/Windows/capture/NVFBC/CMakeLists.txt
+++ b/c-host/platform/Windows/capture/NVFBC/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library(capture_NVFBC STATIC
 	src/wrapper.cpp
 )
 
+if(NOT IS_ABSOLUTE ${NVFBC_SDK})
+  set(NVFBC_SDK "../../../${NVFBC_SDK}")
+endif()
+
 file(TO_CMAKE_PATH "${NVFBC_SDK}" nvfbc_sdk)
 include_directories(file, "${nvfbc_sdk}/inc")
 


### PR DESCRIPTION
Adds support to define `NVFBC_SDK` path as relative:
```bash
$ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-mingw64.cmake -DNVFBC_SDK='../NVIDIA Capture SDK' -DUSE_NVFBC=1 ..
```

Really just a small quality of life thing when having SDK located in some deep folder.