### PR TITLE
Respect minimizeOnFocusLoss

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1152,7 +1152,7 @@ static int lg_run()
     return 1;
   }
 
-  if (params.fullscreen || !params.minimizeOnFocusLoss)
+  if (params.fullscreen && !params.minimizeOnFocusLoss)
     SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
 
   if (!params.noScreensaver)


### PR DESCRIPTION
According to client/src/config.c#183 the default value for `minimizeOnFocusLoss` is `true`, also `SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS` only works on fullscreen, so by using `params.fullscreen || !params.minimizeOnFocusLoss` the application window was never able to minimize on losing focus (not even if `win:minimizeOnFocusLoss=yes` was used).

With this change, the `minimizeOnFocusLoss` flag will be correctly applied thus the window will minimize by default when it loses focus (when running on fullscreen).

Please let me know if it is preferred to not minimize by default so I can toggle the flag and update the readme.

