### PR TITLE
[client] Use eglGetPlatformDisplay() to fix surface creation

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -53,7 +53,6 @@ struct Inst
   LG_RendererParams params;
   struct Options    opt;
 
-  EGLNativeDisplayType nativeDisp;
   EGLNativeWindowType  nativeWind;
   EGLDisplay           display;
   EGLConfig            configs;
@@ -372,7 +371,7 @@ bool egl_render_startup(void * opaque, SDL_Window * window)
   {
     case SDL_SYSWM_X11:
     {
-      this->nativeDisp = (EGLNativeDisplayType)wminfo.info.x11.display;
+      this->display = eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR, wminfo.info.x11.display, NULL);
       this->nativeWind = (EGLNativeWindowType)wminfo.info.x11.window;
       break;
     }
@@ -382,7 +381,7 @@ bool egl_render_startup(void * opaque, SDL_Window * window)
     {
       int width, height;
       SDL_GetWindowSize(window, &width, &height);
-      this->nativeDisp = (EGLNativeDisplayType)wminfo.info.wl.display;
+      this->display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, wminfo.info.wl.display, NULL);
       this->nativeWind = (EGLNativeWindowType)wl_egl_window_create(wminfo.info.wl.surface, width, height);
       break;
     }
@@ -393,7 +392,6 @@ bool egl_render_startup(void * opaque, SDL_Window * window)
       return false;
   }
 
-  this->display = eglGetDisplay(this->nativeDisp);
   if (this->display == EGL_NO_DISPLAY)
   {
     DEBUG_ERROR("eglGetDisplay failed");


### PR DESCRIPTION
[Why]
Recent versions of Mesa may have trouble with surface creation, resulting in
errors like:
egl.c:428  | egl_render_startup             | Failed to create EGL surface (eglError: 0x300b)

[How]
Replace eglGetDisplay() with eglGetPlatformDisplay(). Requires EGL 1.5, but should
be supported with any desktop driver released in the past few years.

I haven't tested with Wayland but it should be correct.