### PR TITLE
[client] do not force disable compositor

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1192,30 +1192,12 @@ static int lg_run()
 
   register_key_binds();
 
-  // set the compositor hint to bypass for low latency
   SDL_SysWMinfo wminfo;
   SDL_VERSION(&wminfo.version);
   if (SDL_GetWindowWMInfo(state.window, &wminfo))
   {
     if (wminfo.subsystem == SDL_SYSWM_X11)
     {
-      Atom NETWM_BYPASS_COMPOSITOR = XInternAtom(
-        wminfo.info.x11.display,
-        "NETWM_BYPASS_COMPOSITOR",
-        False);
-
-      unsigned long value = 1;
-      XChangeProperty(
-        wminfo.info.x11.display,
-        wminfo.info.x11.window,
-        NETWM_BYPASS_COMPOSITOR,
-        XA_CARDINAL,
-        32,
-        PropModeReplace,
-        (unsigned char *)&value,
-        1
-      );
-
       state.lgc = LG_Clipboards[0];
     }
   } else {


### PR DESCRIPTION
This PR avoids force disabling the compositor so the `SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR` environment variable gets honored.

By default SDL disables compositor so the default behavior will not be changed, however if the user sets `SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR=0`, SDL will not disable compositor which is necessary to avoid tearing when running under kwin.

I didn't add an additional command line argument to avoid cluttering and `SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR` is supported out of the box by SDL.

Please let me know if it looks good to you, if there is a specific compositor that does not get disabled by SDL I would like to add an additional check rather than disabling compositor completely e.g.
```
const char* bypass = getenv("SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR");
SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, bypass == NULL || strcmp(bypass, "1") == 0 ? "1" : "0");
```