### PR TITLE
[client] fix return value in spice_read_nl error path

### DIFF
--- a/client/spice/src/spice.c
+++ b/client/spice/src/spice.c
@@ -1286,7 +1286,7 @@ bool spice_read_nl(const struct SpiceChannel * channel, void * buffer, const ssi
   if (!channel->connected)
   {
     DEBUG_ERROR("not connected");
-    return -1;
+    return false;
   }
 
   if (!buffer)


### PR DESCRIPTION
Returning -1 from a function with bool as return argument is the same as
returning true. If the channel is not connected, return false instead to
indicate the error.