### PR TITLE
[common] fix build for newer versions of binutils

### DIFF
--- a/common/src/platform/linux/crash.c
+++ b/common/src/platform/linux/crash.c
@@ -98,10 +98,18 @@ static void load_symbols()
 
 static bool lookup_address(bfd_vma pc, const char ** filename, const char ** function, unsigned int * line, unsigned int * discriminator)
 {
+#ifdef bfd_get_section_flags
   if ((bfd_get_section_flags(crash.fd, crash.section) & SEC_ALLOC) == 0)
+#else
+  if ((bfd_section_flags(crash.section) & SEC_ALLOC) == 0)
+#endif
     return false;
 
+#ifdef bfd_get_section_size
   bfd_size_type size = bfd_get_section_size(crash.section);
+#else
+  bfd_size_type size = bfd_section_size(crash.section);
+#endif
   if (pc >= size)
     return false;
 


### PR DESCRIPTION
binutils has changed several macros. Added ifdef to allow building with
stable and bleeding edge versions.

refs #232