### PR TITLE
[client] add quit keybind

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -46,6 +46,7 @@ Below are a list of current key bindings:
 | <kbd>ScrLk</kbd>+<kbd>F</kbd>      | Full Screen toggle |
 | <kbd>ScrLk</kbd>+<kbd>I</kbd>      | Spice keyboard & mouse enable toggle |
 | <kbd>ScrLk</kbd>+<kbd>N</kbd>      | Toggle night vision mode (EGL renderer only!) |
+| <kbd>ScrLk</kbd>+<kbd>Q</kbd>      | Quit |
 | <kbd>ScrLk</kbd>+<kbd>Insert</kbd> | Increase mouse sensitivity (in capture mode only) |
 | <kbd>ScrLk</kbd>+<kbd>Del</kbd>    | Decrease mouse sensitivity (in capture mode only) |
 | <kbd>ScrLk</kbd>+<kbd>F1</kbd>     | Send <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd> to the guest |

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -918,6 +918,11 @@ static void toggle_input(SDL_Scancode key, void * opaque)
   );
 }
 
+static void quit(SDL_Scancode key, void * opaque)
+{
+  state.running = false;
+}
+
 static void mouse_sens_inc(SDL_Scancode key, void * opaque)
 {
   char * msg;
@@ -966,6 +971,7 @@ static void register_key_binds()
 {
   state.kbFS           = app_register_keybind(SDL_SCANCODE_F     , toggle_fullscreen, NULL);
   state.kbInput        = app_register_keybind(SDL_SCANCODE_I     , toggle_input     , NULL);
+  state.kbQuit         = app_register_keybind(SDL_SCANCODE_Q     , quit             , NULL);
   state.kbMouseSensInc = app_register_keybind(SDL_SCANCODE_INSERT, mouse_sens_inc   , NULL);
   state.kbMouseSensDec = app_register_keybind(SDL_SCANCODE_DELETE, mouse_sens_dec   , NULL);
 
@@ -987,6 +993,7 @@ static void release_key_binds()
 {
   app_release_keybind(&state.kbFS);
   app_release_keybind(&state.kbInput);
+  app_release_keybind(&state.kbQuit);
   for(int i = 0; i < 12; ++i)
     app_release_keybind(&state.kbCtrlAltFn[i]);
 }

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -66,6 +66,7 @@ struct AppState
 
   KeybindHandle kbFS;
   KeybindHandle kbInput;
+  KeybindHandle kbQuit;
   KeybindHandle kbMouseSensInc;
   KeybindHandle kbMouseSensDec;
   KeybindHandle kbCtrlAltFn[12];


### PR DESCRIPTION
Adds a <kbd>ScrLk</kbd>+<kbd>Q</kbd> keybind to conveniently quit the client.

On a side note, I noticed that all the keybinds are in `release_key_binds()` except for the mouse sensitivity ones. Is this intentional, or an oversight?