### PR TITLE
[client] add option to capture input on start

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -309,6 +309,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_BOOL,
     .value.x_bool   = true
   },
+  {
+    .module         = "spice",
+    .name           = "captureOnStart",
+    .description    = "Capture mouse and keyboard on start",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false
+  },
   {0}
 };
 
@@ -413,6 +420,7 @@ bool config_load(int argc, char * argv[])
     }
 
     params.scaleMouseInput = option_get_bool("spice", "scaleCursor");
+    params.captureOnStart  = option_get_bool("spice", "captureOnStart");
   }
 
   return true;

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1428,6 +1428,14 @@ static int lg_run()
     SDL_ShowCursor(SDL_DISABLE);
   }
 
+  if (params.captureOnStart)
+  {
+    state.serverMode = true;
+    spice_mouse_mode(state.serverMode);
+    SDL_SetWindowGrab(state.window, state.serverMode);
+    DEBUG_INFO("Server Mode: %s", state.serverMode ? "on" : "off");
+  }
+
   // setup the startup condition
   if (!(e_startup = lgCreateEvent(false, 0)))
   {

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -124,6 +124,7 @@ struct AppParams
   bool         grabKeyboard;
   SDL_Scancode escapeKey;
   bool         showAlerts;
+  bool         captureOnStart;
 
   unsigned int cursorPollInterval;
   unsigned int framePollInterval;


### PR DESCRIPTION
Adds the option spice:captureOnStart which automatically captures keyboard and mouse input when Looking Glass starts. Defaults to false in order to maintain current default behavior.

This allows for the creation of a single keyboard shortcut which launches Looking Glass in full screen mode and automatically captures input (equivalent functionality to pressing the button on a physical KVM switch). Previously a shortcut could be created to launch Looking Glass, but you still had to press scroll lock (or whatever the escape key has been mapped to) to begin capturing input.