### PR TITLE
[Host] Add NSIS installer

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -44,6 +44,12 @@ cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-mingw64.cmake ..
 make
 ```
 
+## Building the installer
+
+Install NSIS compiler
+Build the host program, see above sections.
+Build installer with `makensis c-host/installer/installer.nsi`
+
 ## Where is the log?
 
 It is in your user's temp directory:

--- a/host/installer/installer.nsi
+++ b/host/installer/installer.nsi
@@ -25,8 +25,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 !include "Sections.nsh"
 
 ;Settings
-Name "Looking Glass c-host"
-OutFile "..\build\Looking-Glass-C-Host-Setup.exe" 
+Name "Looking Glass Host"
+OutFile "..\build\Looking-Glass-Host-Setup.exe" 
 Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"

--- a/host/installer/installer.nsi
+++ b/host/installer/installer.nsi
@@ -26,7 +26,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 ;Settings
 Name "Looking Glass Host"
-OutFile "..\build\Looking-Glass-Host-Setup.exe" 
+OutFile "..\build\looking-glass-host-setup.exe" 
 Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"
@@ -148,11 +148,11 @@ Section "-Hidden Start Menu" Section5
   SetShellVarContext all
   
   ${If} $option_startMenu == 1
-    CreateShortCut $SMPROGRAMS\Looking-Glass-Host.lnk $INSTDIR\looking-glass-host.exe
+    CreateShortCut $SMPROGRAMS\Looking Glass (host).lnk $INSTDIR\looking-glass-host.exe
   ${EndIf}
 
   ${If} $option_desktop == 1
-    CreateShortCut $DESKTOP\Looking-Glass-Host.lnk $INSTDIR\looking-glass-host.exe
+    CreateShortCut $DESKTOP\Looking Glass (host).lnk $INSTDIR\looking-glass-host.exe
   ${EndIf}
   
 SectionEnd

--- a/host/installer/installer.nsi
+++ b/host/installer/installer.nsi
@@ -1,0 +1,128 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2017-2020 Geoffrey McRae <geoff@hostfission.com>
+https://looking-glass.hostfission.com
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+
+;Include  
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+!include "LogicLib.nsh"
+!include "Sections.nsh"
+
+;Settings
+Name "Looking Glass c-host"
+OutFile "..\build\Looking-Glass-C-Host-Setup.exe" 
+Unicode true
+RequestExecutionLevel admin
+ShowInstDetails "show"
+ShowUninstDetails "show"
+InstallDir "$PROGRAMFILES64\Looking-Glass"
+
+!define MUI_ICON "..\..\resources\icon.ico"
+!define MUI_UNICON "..\..\resources\icon.ico"
+!define MUI_LICENSEPAGE_BUTTON "Agree"
+!define /file VERSION "..\..\VERSION"
+
+;Install and uninstall pages
+!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "English"
+
+;Install 
+Section "Install" Section1
+  SectionIn RO
+
+  SetOutPath $INSTDIR
+  File ..\build\looking-glass-host.exe
+  File /oname=LICENSE.txt ..\..\LICENSE
+  WriteUninstaller $INSTDIR\uninstaller.exe
+
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"EstimatedSize" "$0"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"DisplayName" "Looking-Glass"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"UninstallString" "$\"$INSTDIR\uninstaller.exe$\""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"QuietUninstallString" "$\"$INSTDIR\uninstaller.exe$\" /S"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"InstallLocation" "$INSTDIR"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"Publisher" "Geoffrey McRae"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"DisplayIcon" "$\"$INSTDIR\looking-glass-host.exe$\""
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"NoRepair" "1"
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+	"NoModify" "1"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass" \
+    "DisplayVersion" ${VERSION}
+
+SectionEnd
+
+Section "Auto Start Looking-Glass" Section2
+
+  nsExec::Exec 'SCHTASKS /Delete /F /TN "Looking Glass"'
+  nsExec::Exec 'SCHTASKS /Create /TN "Looking Glass" /SC  ONLOGON /RL HIGHEST /TR "C:\Program Files\Looking-Glass\looking-glass-host.exe"'
+
+SectionEnd
+
+Section /o "Desktop Shortcut" Section3
+  SetShellVarContext all
+  CreateShortCut $DESKTOP\Looking-Glass-Host.lnk $INSTDIR\looking-glass-host.exe
+SectionEnd
+
+Section /o "Start Menu Shortcut" Section4
+  SetShellVarContext all
+  CreateShortCut $STARTMENU\Looking-Glass-Host.lnk $INSTDIR\looking-glass-host.exe
+SectionEnd
+
+
+Section "Uninstall" Section5
+  SetShellVarContext all
+
+  nsExec::Exec 'SCHTASKS /Delete /F /TN "Looking Glass"'
+
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking-Glass"
+  Delete $STARTMENU\Looking-Glass-Host.lnk
+  Delete $DESKTOP\Looking-Glass-Host.lnk
+  Delete $INSTDIR\uninstaller.exe
+  Delete $INSTDIR\looking-glass-host.exe
+  Delete $INSTDIR\LICENSE
+
+  RMDir $INSTDIR
+
+SectionEnd
+
+;Description text for selection of install items
+LangString DESC_Section1 ${LANG_ENGLISH} "Install Files into $INSTDIR"
+LangString DESC_Section2 ${LANG_ENGLISH} "Create scheduled task to automatically start Looking-Glass."
+LangString DESC_Section3 ${LANG_ENGLISH} "Create desktop shortcut icon."
+LangString DESC_Section4 ${LANG_ENGLISH} "Create start menu shortcut."
+
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${Section1} $(DESC_Section1)
+  !insertmacro MUI_DESCRIPTION_TEXT ${Section2} $(DESC_Section2)
+  !insertmacro MUI_DESCRIPTION_TEXT ${Section3} $(DESC_Section3)
+  !insertmacro MUI_DESCRIPTION_TEXT ${Section4} $(DESC_Section4)
+!insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/host/installer/installer.nsi
+++ b/host/installer/installer.nsi
@@ -31,7 +31,7 @@ Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"
 ShowUninstDetails "show"
-InstallDir "$PROGRAMFILES64\Looking-Glass"
+InstallDir "$PROGRAMFILES64\Looking Glass"
 
 !define MUI_ICON "..\..\resources\icon.ico"
 !define MUI_UNICON "..\..\resources\icon.ico"


### PR DESCRIPTION
Fixes: #277 

Todo-
- [x] Installation location selection
- [x] Command line options
  - [x] Select start menu/desktop icons
  - [x] Command line options help 
- [x] Make sure that scheduled task creation is reliable
- [x] Update documentation

Later possibilities- 
- Full banner instead of an icon in the installation window. Requires said banner to be created.
- Install `IVSHMEM` driver. Requires investigation about redistribution of RedHat signed builds.
- Put a readme in the install directory.
- Integrate with cmake. Decided to not do this yet, I could not get the cpack nsis module working.

Requires input from @gnif -
- [x] Check that names are acceptable.
  - [x] `Name "Looking Glass Host"` - Name of installer window
  - [x] `OutFile "Looking-Glass-Host-Setup.exe"`  - Filename of installer
  - [x] `nstallDir "$PROGRAMFILES64\Looking-Glass"` - Install directory name
  - [x] `"DisplayName" "Looking-Glass"` - Name in Add and Remove Programs in control panel
- [ ] Setup of desktop + start menu shortcuts. Defaults to no, optionally add either or both.
- [ ] License acceptance page. I put one in, do you want it?
- [ ] Location of `installer.nsi` in repository. It can be changed without very much work. The current location is where I have seen installer files in other repositories. 

--- 

The only build requirement is nsis. Requires `looking-glass-host.exe` to exist in `c-host/build/`

Can be built with `makensis /path/to/installer.nsi`. 
