### PR TITLE
Fix issues blocking Clang-built LookingGlass

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -669,7 +669,7 @@ void spiceClipboardData(const SpiceDataType type, uint8_t * buffer, uint32_t siz
   struct CBRequest * cbr;
   if (ll_shift(state.cbRequestList, (void **)&cbr))
   {
-    cbr->replyFn(cbr->opaque, type, buffer, size);
+    cbr->replyFn(cbr->opaque, spice_type_to_clipboard_type(type), buffer, size);
     free(cbr);
   }
 }

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -105,7 +105,7 @@ struct AppState
   atomic_uint_least64_t frameTime;
   uint64_t              lastFrameTime;
   uint64_t              renderTime;
-  uint64_t              frameCount;
+  atomic_uint_least64_t frameCount;
   uint64_t              renderCount;
 
 


### PR DESCRIPTION
I'm pretty confident this won't mess anything up, and I cleaned it up to be acceptable.