### PR TITLE
[client] add option to always show cursor

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -144,6 +144,7 @@ Command line arguments will override any options loaded from the config files.
 | spice:clipboardToLocal |       | yes       | Allow the clipboard to be syncronized FROM the VM                   |
 | spice:scaleCursor      | -j    | yes       | Scale cursor input position to screen size when up/down scaled      |
 | spice:captureOnStart   |       | no        | Capture mouse and keyboard on start                                 |
+| spice:alwaysShowCursor |       | no        | Always show host cursor                                             |
 |------------------------------------------------------------------------------------------------------------------|
 
 |--------------------------------------------------------------------------|

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -344,6 +344,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_BOOL,
     .value.x_bool   = false
   },
+  {
+    .module         = "spice",
+    .name           = "alwaysShowCursor",
+    .description    = "Always show host cursor",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false
+  },
   {0}
 };
 
@@ -453,6 +460,7 @@ bool config_load(int argc, char * argv[])
 
     params.scaleMouseInput = option_get_bool("spice", "scaleCursor");
     params.captureOnStart  = option_get_bool("spice", "captureOnStart");
+    params.alwaysShowCursor  = option_get_bool("spice", "alwaysShowCursor");
   }
 
   return true;

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -821,7 +821,7 @@ static void handleMouseMoveEvent(int ex, int ey)
       state.updateCursor = true;
       state.warpState    = WARP_STATE_OFF;
 
-      if (params.useSpiceInput)
+      if (params.useSpiceInput && !params.alwaysShowCursor)
         state.drawCursor = false;
       return;
     }
@@ -906,7 +906,9 @@ static void handleWindowLeave()
   if (!params.useSpiceInput)
     return;
 
-  state.drawCursor   = false;
+  if (!params.alwaysShowCursor)
+    state.drawCursor = false;
+
   state.cursorInView = false;
   state.updateCursor = true;
   state.warpState    = WARP_STATE_OFF;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -155,6 +155,7 @@ struct AppParams
   bool         showAlerts;
   bool         captureOnStart;
   bool         quickSplash;
+  bool         alwaysShowCursor;
 
   unsigned int cursorPollInterval;
   unsigned int framePollInterval;


### PR DESCRIPTION
Adds the option spice:alwaysShowCursor which prevents Looking Glass from hiding the host cursor when leaving the window. Defaults to false in order to maintain current default behavior.

This allows use of both SPICE input as well as a directly connected (pass-through) mouse for use cases where both ease of use through SPICE is required and low-latency without restarting the client. As a side effect, it also provides compatibility with Barrier/Synergy.

Closes #321 