### PR TITLE
Fix kernel module compilation on Linux 5.10+

### DIFF
--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="kvmfr"
-PACKAGE_VERSION="0.0.4"
+PACKAGE_VERSION="0.0.5"
 BUILT_MODULE_NAME[0]="${PACKAGE_NAME}"
 MAKE[0]="make KDIR=${kernel_source_dir}"
 CLEAN="make KDIR=${kernel_source_dir} clean"

--- a/module/kvmfr.c
+++ b/module/kvmfr.c
@@ -37,7 +37,7 @@ DEFINE_MUTEX(minor_lock);
 DEFINE_IDR(kvmfr_idr);
 
 #define KVMFR_UIO_NAME    "KVMFR"
-#define KVMFR_UIO_VER     "0.0.4"
+#define KVMFR_UIO_VER     "0.0.5"
 #define KVMFR_DEV_NAME    "kvmfr"
 #define KVMFR_MAX_DEVICES 10
 
@@ -277,9 +277,14 @@ static int kvmfr_pci_probe(struct pci_dev *dev, const struct pci_device_id *id)
   if (IS_ERR(kdev->pDev))
     goto out_unminor;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
   kdev->pgmap.res.start = pci_resource_start(dev, 2);
   kdev->pgmap.res.end   = pci_resource_end  (dev, 2);
   kdev->pgmap.res.flags = pci_resource_flags(dev, 2);
+#else
+  kdev->pgmap.range.start = pci_resource_start(dev, 2);
+  kdev->pgmap.range.end   = pci_resource_end  (dev, 2);
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
   kdev->pgmap.type = MEMORY_DEVICE_DEVDAX;


### PR DESCRIPTION
[linux@a4574f63](https://github.com/torvalds/linux/commit/a4574f63edc6f76fb46dcd65d3eb4d5a8e23ba38#diff-a9ae4f1f9f053e72d9839bd8a9a5e28f7a3adf18b7b540fe4d112904b0342024) caused the kernel module to fail to compile, due to changing the `dev_pagemap->res` field to `dev_pagemap->range`.