### PR TITLE
Add edge case else block to fix clang compilation

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -912,6 +912,11 @@ static void handleMouseMoveEvent(int ex, int ey)
         nx = newPos.x + state.dstRect.x;
         ny = newPos.y + state.dstRect.y * 2;
       }
+      else
+      {
+        nx = newPos.x;
+        ny = newPos.y;
+      }
 
       /* put the mouse where it should be and disable warp */
       state.warpState = WARP_STATE_WIN_EXIT;


### PR DESCRIPTION
Currently trying to compile LG on master gives this error

```../looking-glass-9999/client/src/main.c:910:16: fatal error: variable 'nx' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
      else if (newPos.y >= state.dstRect.h)
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../looking-glass-9999/client/src/main.c:918:17: note: uninitialized use occurs here
      warpMouse(nx, ny);
                ^~
../looking-glass-9999/client/src/main.c:910:12: note: remove the 'if' if its condition is always true
      else if (newPos.y >= state.dstRect.h)
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../looking-glass-9999/client/src/main.c:894:13: note: initialize the variable 'nx' to silence this warning
      int nx, ny;
            ^
             = 0
1 error generated.
```

From what I gather in the code, it doesn't seem like a situation where nx or ny is uninitialized *could* happen, but it blocks compilation either way. This method of initializing nx and ny if it falls through all other if conditions seems non-intrusive, and better than zero initializing them.