### PR TITLE
Replace git diff logic in version.cmake with --dirty

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -6,7 +6,7 @@ execute_process(
 
 if (NOT "${GIT_REV}" STREQUAL "")
 	execute_process(
-		COMMAND bash -c "git diff --quiet --exit-code || echo +"
+		COMMAND bash -c "git diff --quiet --exit-code && git diff --cached --quiet --exit-code || echo +"
 		WORKING_DIRECTORY "${PROJECT_TOP}"
 		OUTPUT_VARIABLE GIT_DIFF)
 else()

--- a/version.cmake
+++ b/version.cmake
@@ -1,26 +1,18 @@
 execute_process(
-	COMMAND git describe --always --long --abbrev=10 --tags
+	COMMAND git describe --always --long --abbrev=10 --dirty=+ --tags
 	WORKING_DIRECTORY "${PROJECT_TOP}"
         OUTPUT_VARIABLE GIT_REV
         ERROR_QUIET)
 
-if (NOT "${GIT_REV}" STREQUAL "")
-	execute_process(
-		COMMAND bash -c "git diff --quiet --exit-code && git diff --cached --quiet --exit-code || echo +"
-		WORKING_DIRECTORY "${PROJECT_TOP}"
-		OUTPUT_VARIABLE GIT_DIFF)
-else()
+if ("${GIT_REV}" STREQUAL "")
 	if (EXISTS ${PROJECT_TOP}/VERSION)
 		file(READ ${PROJECT_TOP}/VERSION GIT_REV)
 	else()
 		set(GIT_REV "UNKNOWN")
-		set(GIT_DIFF "")
 	endif()
 endif()
 
-string(STRIP "${GIT_REV}" GIT_REV)
-string(STRIP "${GIT_DIFF}" GIT_DIFF)
-set(GIT_VERSION "${GIT_REV}${GIT_DIFF}")
+string(STRIP "${GIT_REV}" GIT_VERSION)
 set(BUILD_VERSION "const char * BUILD_VERSION = \"${GIT_VERSION}\";")
 
 if(EXISTS "${CMAKE_BINARY_DIR}/version.c")


### PR DESCRIPTION
`git describe` has a `--dirty` argument which does the same thing as the git diff logic, while also including the case of a populated index, which the existing logic missed.

Providing '+' as the argument replicates old behavior.