### PR TITLE
Remove --long from version.cmake

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -1,5 +1,5 @@
 execute_process(
-	COMMAND git describe --always --long --abbrev=10 --tags
+	COMMAND git describe --always --abbrev=10 --tags
 	WORKING_DIRECTORY "${PROJECT_TOP}"
         OUTPUT_VARIABLE GIT_REV
         ERROR_QUIET)


### PR DESCRIPTION
This means if someone checks out a tagged revision, the extra commit N
and commit hash are removed from the VERSION, leaving just the tag name

e.g `Looking Glass (v1.0.3)` vs `Looking Glass (v1.0.3-0-g1e85104b87)`

Adding any commits will cause `v1.0.3-2-gd6e00e4f34` to return.

The dirty worktree '+' still functions as normal, simply appended to
the end of the tag name, like `v1.0.3+`. With both extra commits and a
dirty worktree, it will look like `v1.0.3-2-gd6e00e4f34+`, as usual.