### PR TITLE
Installer log has more details about the process

### DIFF
--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -110,7 +110,7 @@ FunctionEnd
   Pop $0 ; SC.exe error level
 
   ${If} $0 == 0 ; If error level is 0, service exists
-    DetailPrint "Stopping service: Looking Glass (host)"
+    DetailPrint "Stop service: Looking Glass (host)"
     nsExec::ExecToLog 'net.exe STOP "Looking Glass (host)"'
   ${EndIf}
 


### PR DESCRIPTION
Uses `nsExec:ExecToLog` in a few places to log on the installation output
window

To prevent errors in the log, the service is now only stopped if it already exists.