### PR TITLE
Fix hang in eglSwapBuffers when exiting while not visible

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -159,7 +159,7 @@ Command line arguments will override any options loaded from the config files.
 | Long                 | Short | Value | Description                                 |
 |------------------------------------------------------------------------------------|
 | opengl:mipmap        |       | yes   | Enable mipmapping                           |
-| opengl:vsync         |       | yes   | Enable vsync                                |
+| opengl:vsync         |       | no    | Enable vsync                                |
 | opengl:preventBuffer |       | yes   | Prevent the driver from buffering frames    |
 | opengl:amdPinnedMem  |       | yes   | Use GL_AMD_pinned_memory if it is available |
 |------------------------------------------------------------------------------------|

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -97,6 +97,16 @@ struct Inst
   LG_FontObj        fontObj;
 };
 
+static bool egl_vsync_option_validator(struct Option * opt, const char ** error)
+{
+  if (opt->value.x_bool && getenv("WAYLAND_DISPLAY"))
+  {
+    DEBUG_WARN("Cannot disable vsync on Wayland, forcing egl:vsync=off");
+    opt->value.x_bool = false;
+  }
+
+  return true;
+}
 
 static struct Option egl_options[] =
 {
@@ -105,7 +115,8 @@ static struct Option egl_options[] =
     .name         = "vsync",
     .description  = "Enable vsync",
     .type         = OPTION_TYPE_BOOL,
-    .value.x_bool = false
+    .value.x_bool = false,
+    .validator    = &vsync_option_validator
   },
   {
     .module       = "egl",

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -62,7 +62,7 @@ static struct Option opengl_options[] =
     .name         = "vsync",
     .description  = "Enable vsync",
     .type         = OPTION_TYPE_BOOL,
-    .value.x_bool = true
+    .value.x_bool = false
   },
   {
     .module       = "opengl",

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -48,6 +48,17 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #define FADE_TIME 1000000
 
+static bool opengl_vsync_option_validator(struct Option * opt, const char ** error)
+{
+  if (opt->value.x_bool && getenv("WAYLAND_DISPLAY"))
+  {
+    DEBUG_WARN("Cannot disable vsync on Wayland, forcing opengl:vsync=off");
+    opt->value.x_bool = false;
+  }
+
+  return true;
+}
+
 static struct Option opengl_options[] =
 {
   {
@@ -62,7 +73,8 @@ static struct Option opengl_options[] =
     .name         = "vsync",
     .description  = "Enable vsync",
     .type         = OPTION_TYPE_BOOL,
-    .value.x_bool = false
+    .value.x_bool = false,
+    .validator    = &vsync_option_validator
   },
   {
     .module       = "opengl",

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1478,12 +1478,7 @@ static int lg_run()
        if (g_cursor.sens < -9) g_cursor.sens = -9;
   else if (g_cursor.sens >  9) g_cursor.sens =  9;
 
-  char* XDG_SESSION_TYPE = getenv("XDG_SESSION_TYPE");
-
-  if (XDG_SESSION_TYPE == NULL)
-    XDG_SESSION_TYPE = "unspecified";
-
-  if (strcmp(XDG_SESSION_TYPE, "wayland") == 0)
+  if (getenv("WAYLAND_DISPLAY"))
   {
      DEBUG_INFO("Wayland detected");
      if (getenv("SDL_VIDEODRIVER") == NULL)


### PR DESCRIPTION
eglSwapBuffers is allowed to block when called with a nonzero interval
parameter. On Wayland, Mesa will block until a frame callback arrives.
If an application is not visible, a compositor is free to not schedule
frame callbacks (in order to save CPU time rendering something that is
entirely invisible).

Currently, starting Looking Glass from a terminal, hiding it
entirely, and sending ^C will cause Looking Glass to hang joining the
render thread until the window is made visible again.

Calling eglDestroySurface is insufficient to unblock eglSwapBuffers, as
it attempts to grab the same underlying mutex.

Instead, this PR makes it so that we pass a 0 interval to
eglSwapBuffers when running on Wayland, such that we don't block waiting
for a frame callback. This is not entirely ideal as it *does* mean
Looking Glass submits buffers while hidden, but it seems better than
hanging on exit.

It also removes the opengl:vsync and egl:vsync flags when running on
Wayland, as they are meaningless there.