### PR TITLE
[client] spice: properly handle high-precision scroll wheel input

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1287,8 +1287,8 @@ int eventFilter(void * userdata, SDL_Event * event)
         break;
 
       if (
-        !spice_mouse_press  (event->wheel.y == 1 ? 4 : 5) ||
-        !spice_mouse_release(event->wheel.y == 1 ? 4 : 5)
+        !spice_mouse_press  (event->wheel.y > 0 ? 4 : 5) ||
+        !spice_mouse_release(event->wheel.y > 0 ? 4 : 5)
         )
       {
         DEBUG_ERROR("SDL_MOUSEWHEEL: failed to send messages");


### PR DESCRIPTION
Some setups (e.g. Wayland) have high precision scroll wheel input, such
that the y-delta on an event may exceed 1. In these cases, scrolling up
currently gets treated as scrolling down.

This commit changes the checks to use > 0 rather than == 1.

This is the approach suggested in
https://wiki.libsdl.org/SDL_MouseWheelEvent.