### PR TITLE
[client] opengl: require 8 bit colour when creating context

### DIFF
--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -261,6 +261,9 @@ bool opengl_initialize(void * opaque, Uint32 * sdlFlags)
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER      , 1);
   SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
   SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
+  SDL_GL_SetAttribute(SDL_GL_RED_SIZE          , 8);
+  SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE        , 8);
+  SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE         , 8);
   return true;
 }
 


### PR DESCRIPTION
For some reason, if we don't ask for 8-bit, wayland will give a context with
lower bit depth, which looks terrible.