### PR TITLE
[client] egl: disable EGL when running on Wayland

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -159,6 +159,13 @@ void egl_setup()
 
 bool egl_create(void ** opaque, const LG_RendererParams params)
 {
+  // Fail if running on Wayland so that OpenGL is used instead. Wayland-EGL
+  // is broken (https://github.com/gnif/LookingGlass/issues/306) and isn't
+  // fixable until SDL is dropped entirely. Until then, the OpenGL renderer
+  // "mostly works".
+  if (getenv("WAYLAND_DISPLAY"))
+    return false;
+
   // check if EGL is even available
   if (!eglQueryString(EGL_NO_DISPLAY, EGL_VERSION))
     return false;


### PR DESCRIPTION
This commit makes Looking Glass always use the OpenGL renderer when
running on Wayland. The EGL renderer is broken on Wayland and can't
reasonably be fixed until SDL is dropped entirely (as per
https://github.com/gnif/LookingGlass/issues/306).

Until that time, the OpenGL renderer provides a much better
Wayland-native experience.