### PR TITLE
[host/client] scale mouse input based on host DPI information

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -154,10 +154,12 @@ static void updatePositionInfo()
 
     g_cursor.scale = (
         g_state.srcSize.y != g_state.dstRect.h ||
-        g_state.srcSize.x != g_state.dstRect.w);
+        g_state.srcSize.x != g_state.dstRect.w ||
+        g_state.mouseScalePercent != 100);
 
     g_cursor.scaleX = (float)g_state.srcSize.y / (float)g_state.dstRect.h;
     g_cursor.scaleY = (float)g_state.srcSize.x / (float)g_state.dstRect.w;
+    g_state.mouseScale = g_state.mouseScalePercent / 100.0f;
   }
 
   atomic_fetch_add(&g_state.lgrResize, 1);
@@ -510,6 +512,7 @@ static int frameThread(void * unused)
       if (params.autoResize)
         SDL_SetWindowSize(g_state.window, lgrFormat.width, lgrFormat.height);
 
+      g_state.mouseScalePercent = frame->mouseScalePercent;
       updatePositionInfo();
     }
 
@@ -933,8 +936,8 @@ static void handleMouseMoveEvent(int ex, int ey)
 
   if (g_cursor.scale && params.scaleMouseInput && !g_cursor.grab)
   {
-    g_cursor.accX += (float)delta.x * g_cursor.scaleX;
-    g_cursor.accY += (float)delta.y * g_cursor.scaleY;
+    g_cursor.accX += (float)delta.x * g_cursor.scaleX / g_state.mouseScale;
+    g_cursor.accY += (float)delta.y * g_cursor.scaleY / g_state.mouseScale;
     delta.x = floor(g_cursor.accX);
     delta.y = floor(g_cursor.accY);
     g_cursor.accX -= delta.x;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -53,6 +53,8 @@ struct AppState
   SDL_Rect             border;
   SDL_Point            srcSize;
   LG_RendererRect      dstRect;
+  float                mouseScale;
+  uint32_t             mouseScalePercent;
 
   const LG_Renderer  * lgr;
   void               * lgrData;

--- a/common/include/common/KVMFR.h
+++ b/common/include/common/KVMFR.h
@@ -57,7 +57,7 @@ typedef enum CursorType
 CursorType;
 
 #define KVMFR_MAGIC   "KVMFR---"
-#define KVMFR_VERSION 5
+#define KVMFR_VERSION 6
 
 typedef struct KVMFR
 {
@@ -80,12 +80,13 @@ KVMFRCursor;
 
 typedef struct KVMFRFrame
 {
-  uint32_t  formatVer;   // the frame format version number
-  FrameType type;        // the frame data type
-  uint32_t  width;       // the width
-  uint32_t  height;      // the height
-  uint32_t  stride;      // the row stride (zero if compressed data)
-  uint32_t  pitch;       // the row pitch  (stride in bytes or the compressed frame size)
-  uint32_t  offset;      // offset from the start of this header to the FrameBuffer header
+  uint32_t  formatVer;         // the frame format version number
+  FrameType type;              // the frame data type
+  uint32_t  width;             // the width
+  uint32_t  height;            // the height
+  uint32_t  stride;            // the row stride (zero if compressed data)
+  uint32_t  pitch;             // the row pitch  (stride in bytes or the compressed frame size)
+  uint32_t  offset;            // offset from the start of this header to the FrameBuffer header
+  uint32_t  mouseScalePercent; // movement scale factor of the mouse (relates to DPI of display, 100 = no scale)
 }
 KVMFRFrame;

--- a/common/include/common/dpi.h
+++ b/common/include/common/dpi.h
@@ -1,0 +1,25 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2017-2020 Geoffrey McRae <geoff@hostfission.com>
+https://looking-glass.hostfission.com
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include <windows.h>
+
+// At 100% scaling, Windows reports 96 DPI.
+#define DPI_100_PERCENT 96
+
+UINT monitor_dpi(HMONITOR hMonitor);

--- a/common/src/platform/windows/CMakeLists.txt
+++ b/common/src/platform/windows/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(
 
 add_library(lg_common_platform_code STATIC
     crash.c
+    dpi.c
     sysinfo.c
     thread.c
     event.c

--- a/common/src/platform/windows/dpi.c
+++ b/common/src/platform/windows/dpi.c
@@ -1,0 +1,37 @@
+#include "common/dpi.h"
+#include "common/windebug.h"
+
+typedef enum MONITOR_DPI_TYPE {
+  MDT_EFFECTIVE_DPI,
+  MDT_ANGULAR_DPI,
+  MDT_RAW_DPI,
+  MDT_DEFAULT
+} MONITOR_DPI_TYPE;
+typedef HRESULT (WINAPI *GetDpiForMonitor_t)(HMONITOR hmonitor, MONITOR_DPI_TYPE dpiType, UINT * dpiX, UINT * dpiY);
+
+UINT monitor_dpi(HMONITOR hMonitor)
+{
+  HMODULE shcore = LoadLibraryA("shcore.dll");
+  if (!shcore)
+  {
+    DEBUG_ERROR("Could not load shcore.dll");
+    return DPI_100_PERCENT;
+  }
+
+  GetDpiForMonitor_t GetDpiForMonitor = (GetDpiForMonitor_t) GetProcAddress(shcore, "GetDpiForMonitor");
+  if (!GetDpiForMonitor)
+  {
+    DEBUG_ERROR("Could not find GetDpiForMonitor");
+    return DPI_100_PERCENT;
+  }
+
+  UINT dpiX, dpiY;
+  HRESULT status = GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+  if (FAILED(status))
+  {
+    DEBUG_WINERROR("GetDpiForMonitor failed", status);
+    return DPI_100_PERCENT;
+  }
+
+  return dpiX;
+}

--- a/host/include/interface/capture.h
+++ b/host/include/interface/capture.h
@@ -93,6 +93,7 @@ typedef struct CaptureInterface
   bool          (*deinit         )();
   void          (*free           )();
   unsigned int  (*getMaxFrameSize)();
+  unsigned int  (*getMouseScale  )();
 
   CaptureResult (*capture   )();
   CaptureResult (*waitFrame )(CaptureFrame * frame);

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -169,6 +169,11 @@ static unsigned int xcb_getMaxFrameSize()
   return this->width * this->height * 4;
 }
 
+static unsigned int xcb_getMouseScale()
+{
+  return 100;
+}
+
 static CaptureResult xcb_capture()
 {
   assert(this);
@@ -241,6 +246,7 @@ struct CaptureInterface Capture_XCB =
   .deinit          = xcb_deinit,
   .free            = xcb_free,
   .getMaxFrameSize = xcb_getMaxFrameSize,
+  .getMouseScale   = xcb_getMouseScale,
   .capture         = xcb_capture,
   .waitFrame       = xcb_waitFrame,
   .getFrame        = xcb_getFrame,

--- a/host/platform/Windows/src/platform.c
+++ b/host/platform/Windows/src/platform.c
@@ -226,6 +226,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
   // setup a handler for ctrl+c
   SetConsoleCtrlHandler(CtrlHandler, TRUE);
 
+  // enable high DPI awareness
+  // this is required for DXGI 1.5 support to function and also capturing desktops with high DPI
+  DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
+  #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2  ((DPI_AWARENESS_CONTEXT)-4)
+  typedef BOOL (*User32_SetProcessDpiAwarenessContext)(DPI_AWARENESS_CONTEXT value);
+
+  HMODULE user32 = GetModuleHandle("user32.dll");
+  User32_SetProcessDpiAwarenessContext fn;
+  fn = (User32_SetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
+  if (fn)
+    fn(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
   // create a message window so that our message pump works
   WNDCLASSEX wx    = {};
   wx.cbSize        = sizeof(WNDCLASSEX);
@@ -249,7 +261,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
   app.messageWnd = CreateWindowEx(0, MAKEINTATOM(class), NULL, 0, 0, 0, 0, 0, NULL, NULL, hInstance, NULL);
 
   // this is needed so that unprivileged processes can send us this message
-  HMODULE user32 = GetModuleHandle("user32.dll");
   _ChangeWindowMessageFilterEx = (PChangeWindowMessageFilterEx)GetProcAddress(user32, "ChangeWindowMessageFilterEx");
   if (_ChangeWindowMessageFilterEx)
     _ChangeWindowMessageFilterEx(app.messageWnd, app.trayRestartMsg, MSGFLT_ALLOW, NULL);

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -186,13 +186,14 @@ static int frameThread(void * opaque)
         continue;
     }
 
-    fi->formatVer = frame.formatVer;
-    fi->width     = frame.width;
-    fi->height    = frame.height;
-    fi->stride    = frame.stride;
-    fi->pitch     = frame.pitch;
-    fi->offset    = pageSize - FrameBufferStructSize;
-    frameValid    = true;
+    fi->formatVer         = frame.formatVer;
+    fi->width             = frame.width;
+    fi->height            = frame.height;
+    fi->stride            = frame.stride;
+    fi->pitch             = frame.pitch;
+    fi->offset            = pageSize - FrameBufferStructSize;
+    fi->mouseScalePercent = app.iface->getMouseScale();
+    frameValid            = true;
 
     // put the framebuffer on the border of the next page
     // this is to allow for aligned DMA transfers by the receiver


### PR DESCRIPTION
When running Windows with UI scaling, Windows also scales the speed of mouse movement. This causes the mouse movements to get out of sync. For example, running with `-M` with 125% UI scaling shows the Windows cursor moving 125% faster than the host machine cursor.

This PR fetches the UI scaling information for the captured monitor and passes it along inside `KVMFRFrame`. This is then used to scale the mouse movements sent to spice.

To obtain UI scaling information, the host is unconditionally made per-monitor DPI aware, and not just in the DXGI path. As a bonus, this also fixes an NvFBC bug with scaling that results in the image being cropped at the virtual resolution reported to non-DPI aware apps.