### PR TITLE
[client] fix ignoreQuit on Wayland

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1099,9 +1099,9 @@ int eventFilter(void * userdata, SDL_Event * event)
           }
           break;
 
-        // allow a window close event to close the application even if ignoreQuit is set
         case SDL_WINDOWEVENT_CLOSE:
-          g_state.state = APP_STATE_SHUTDOWN;
+          if (!params.ignoreQuit || !g_cursor.inView)
+            g_state.state = APP_STATE_SHUTDOWN;
           break;
       }
       return 0;


### PR DESCRIPTION
On Wayland, SDL_WINDOWEVENT_CLOSE is sent even when exiting with keyboard
shortcuts. This meant that the client is still closed even with -Q.

We now swallow SDL_WINDOWEVENT_CLOSE if the cursor is inside the VM. This
should prevent keyboard shortcuts from closing the client, while still
allowing the window to be closed by clicking X with the mouse per #138.