### PR TITLE
[client] add Wayland clipboard support

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -24,6 +24,9 @@ add_feature_info(ENABLE_EGL ENABLE_EGL "EGL renderer.")
 option(ENABLE_CB_X11 "Enable X11 clipboard integration" ON)
 add_feature_info(ENABLE_CB_X11 ENABLE_CB_X11 "X11 Clipboard Integration.")
 
+option(ENABLE_CB_WAYLAND "Enable Wayland clipboard integration" ON)
+add_feature_info(ENABLE_CB_WAYLAND ENABLE_CB_WAYLAND "Wayland Clipboard Integration.")
+
 option(ENABLE_BACKTRACE "Enable backtrace support on crash" ON)
 add_feature_info(ENABLE_BACKTRACE ENABLE_BACKTRACE "Backtrace support.")
 

--- a/client/clipboards/CMakeLists.txt
+++ b/client/clipboards/CMakeLists.txt
@@ -23,6 +23,10 @@ if (ENABLE_CB_X11)
   add_clipboard(X11)
 endif()
 
+if (ENABLE_CB_WAYLAND)
+  add_clipboard(Wayland)
+endif()
+
 list(REMOVE_AT CLIPBOARDS      0)
 list(REMOVE_AT CLIPBOARDS_LINK 0)
 

--- a/client/clipboards/Wayland/CMakeLists.txt
+++ b/client/clipboards/Wayland/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.0)
+project(clipboard_Wayland LANGUAGES C)
+
+find_package(PkgConfig)
+pkg_check_modules(CLIPBOARD_PKGCONFIG REQUIRED
+	wayland-client
+)
+
+add_library(clipboard_Wayland STATIC
+	src/wayland.c
+)
+
+target_link_libraries(clipboard_Wayland
+	${CLIPBOARD_PKGCONFIG_LIBRARIES}
+	lg_common
+)
+
+target_include_directories(clipboard_Wayland
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+	PRIVATE
+		src
+		${CLIPBOARD_PKGCONFIG_INCLUDE_DIRS}
+)

--- a/client/clipboards/Wayland/src/wayland.c
+++ b/client/clipboards/Wayland/src/wayland.c
@@ -398,7 +398,6 @@ static bool wayland_cb_init(
 {
   if (wminfo->subsystem != SDL_SYSWM_WAYLAND)
   {
-    DEBUG_ERROR("wrong subsystem");
     return false;
   }
 

--- a/client/clipboards/Wayland/src/wayland.c
+++ b/client/clipboards/Wayland/src/wayland.c
@@ -410,6 +410,7 @@ static bool wayland_cb_init(
   this->dataFn    = dataFn;
   this->display   = wminfo->info.wl.display;
   this->registry  = wl_display_get_registry(this->display);
+  this->stashed_type = LG_CLIPBOARD_DATA_NONE;
 
   // Wait for the initial set of globals to appear.
   wl_registry_add_listener(this->registry, &registry_listener, NULL);
@@ -451,7 +452,8 @@ static void data_source_handle_send(void * data, struct wl_data_source * source,
       ssize_t written = write(fd, transfer->data + pos, transfer->size - pos);
       if (written < 0)
       {
-        DEBUG_ERROR("Failed to write clipboard data: %s", strerror(errno));
+        if (errno != EPIPE)
+          DEBUG_ERROR("Failed to write clipboard data: %s", strerror(errno));
         goto error;
       }
 

--- a/client/clipboards/Wayland/src/wayland.c
+++ b/client/clipboards/Wayland/src/wayland.c
@@ -20,8 +20,28 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "interface/clipboard.h"
 #include "common/debug.h"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <wayland-client.h>
+
+struct transfer {
+  void * data;
+  size_t size;
+};
+
 struct state
 {
+  struct wl_display * display;
+  struct wl_registry * registry;
+  struct wl_data_device_manager * data_device_manager;
+  struct wl_seat * seat;
+  struct wl_data_device * data_device;
+
+  struct wl_keyboard * keyboard;
+  uint32_t keyboard_enter_serial;
+  uint32_t capabilities;
+
   LG_ClipboardReleaseFn releaseFn;
   LG_ClipboardRequestFn requestFn;
   LG_ClipboardNotifyFn  notifyFn;
@@ -31,10 +51,109 @@ struct state
 
 static struct state * this = NULL;
 
+static const char * text_mimetypes[] =
+{
+  "text/plain",
+  "text/plain;charset=utf-8",
+  "TEXT",
+  "STRING",
+  "UTF8_STRING",
+};
+
 static const char * wayland_cb_getName()
 {
   return "Wayland";
 }
+
+// Keyboard-handling listeners.
+
+static void keyboard_keymap_handler(
+    void * data,
+    struct wl_keyboard * keyboard,
+    uint32_t format,
+    int fd,
+    uint32_t size
+) {
+    close(fd);
+}
+
+static void keyboard_enter_handler(void * data, struct wl_keyboard * keyboard,
+    uint32_t serial, struct wl_surface * surface, struct wl_array * keys)
+{
+  this->keyboard_enter_serial = serial;
+}
+
+static void keyboard_leave_handler(void * data, struct wl_keyboard * keyboard,
+    uint32_t serial, struct wl_surface * surface)
+{
+  // Do nothing.
+}
+
+static void keyboard_key_handler(void * data, struct wl_keyboard * keyboard,
+    uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
+{
+  // Do nothing.
+}
+
+static void keyboard_modifiers_handler(void * data,
+    struct wl_keyboard * keyboard, uint32_t serial, uint32_t mods_depressed,
+    uint32_t mods_latched, uint32_t mods_locked, uint32_t group)
+{
+  // Do nothing.
+}
+
+static const struct wl_keyboard_listener keyboard_listener = {
+    .keymap = keyboard_keymap_handler,
+    .enter = keyboard_enter_handler,
+    .leave = keyboard_leave_handler,
+    .key = keyboard_key_handler,
+    .modifiers = keyboard_modifiers_handler,
+};
+
+// Seat-handling listeners.
+
+static void seat_capabilities_handler(void * data, struct wl_seat * seat,
+    uint32_t capabilities)
+{
+    this->capabilities = capabilities;
+}
+
+static void seat_name_handler(void * data, struct wl_seat * seat,
+    const char * name)
+{
+  // Do nothing.
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_capabilities_handler,
+    .name = seat_name_handler
+};
+
+// Registry-handling listeners.
+
+static void registry_global_handler(void * data,
+    struct wl_registry * wl_registry, uint32_t name, const char * interface,
+    uint32_t version) {
+  if (!strcmp(interface, wl_data_device_manager_interface.name))
+    this->data_device_manager = wl_registry_bind(this->registry, name,
+        &wl_data_device_manager_interface, 3);
+  else if (!strcmp(interface, wl_seat_interface.name) && !this->seat)
+    // TODO: multi-seat support.
+    this->seat = wl_registry_bind(this->registry, name,
+        &wl_seat_interface, 1);
+}
+
+static void registry_global_remove_handler(void * data,
+    struct wl_registry * wl_registry, uint32_t name) {
+  // Do nothing.
+}
+
+static const struct wl_registry_listener registry_listener = {
+  .global = registry_global_handler,
+  .global_remove = registry_global_remove_handler,
+};
+
+// End of Wayland handlers.
 
 static bool wayland_cb_init(
     SDL_SysWMinfo         * wminfo,
@@ -54,6 +173,28 @@ static bool wayland_cb_init(
   this->releaseFn = releaseFn;
   this->notifyFn  = notifyFn;
   this->dataFn    = dataFn;
+  this->display   = wminfo->info.wl.display;
+  this->registry  = wl_display_get_registry(this->display);
+
+  // Wait for the initial set of globals to appear.
+  wl_registry_add_listener(this->registry, &registry_listener, NULL);
+  wl_display_roundtrip(this->display);
+
+  this->data_device = wl_data_device_manager_get_data_device(
+      this->data_device_manager, this->seat);
+
+  // Wait for the compositor to let us know of capabilities.
+  wl_seat_add_listener(this->seat, &seat_listener, NULL);
+  wl_display_roundtrip(this->display);
+  if (!(this->capabilities & WL_SEAT_CAPABILITY_KEYBOARD))
+  {
+    // TODO: keyboard hotplug support.
+    DEBUG_ERROR("no keyboard");
+    return false;
+  }
+
+  this->keyboard = wl_seat_get_keyboard(this->seat);
+  wl_keyboard_add_listener(this->keyboard, &keyboard_listener, NULL);
   return true;
 }
 
@@ -67,8 +208,91 @@ static void wayland_cb_wmevent(SDL_SysWMmsg * msg)
 {
 }
 
+static bool is_text_mimetype(const char * mime_type)
+{
+  for (int i = 0; i < sizeof(text_mimetypes)/sizeof(char *); i++)
+    if (!strcmp(mime_type, text_mimetypes[i]))
+      return true;
+
+  return false;
+}
+
+static void data_source_handle_send(void * data, struct wl_data_source * source,
+    const char * mime_type, int fd) {
+  struct transfer * transfer = (struct transfer *) data;
+  if (is_text_mimetype(mime_type))
+  {
+    // Consider making this do non-blocking sends to not stall the Wayland
+    // event loop if it becomes a problem. This is "fine" in the sense that
+    // wl-copy also stalls like this, but it's not necessary.
+    fcntl(fd, F_SETFL, 0);
+
+    size_t pos = 0;
+    while (pos < transfer->size)
+    {
+      ssize_t written = write(fd, transfer->data + pos, transfer->size - pos);
+      if (written < 0)
+      {
+        DEBUG_ERROR("Failed to write clipboard data: %s", strerror(errno));
+        goto error;
+      }
+
+      pos += written;
+    }
+  }
+
+error:
+  close(fd);
+}
+
+static void data_source_handle_cancelled(void * data,
+    struct wl_data_source * source) {
+  struct transfer * transfer = (struct transfer *) data;
+  free(transfer->data);
+  free(transfer);
+  wl_data_source_destroy(source);
+}
+
+static const struct wl_data_source_listener data_source_listener = {
+  .send = data_source_handle_send,
+  .cancelled = data_source_handle_cancelled,
+};
+
+static void wayland_cb_reply_fn(void * opaque, LG_ClipboardData type, uint8_t * data, uint32_t size)
+{
+  struct transfer * transfer = malloc(sizeof(struct transfer));
+  void * data_copy = malloc(size);
+  memcpy(data_copy, data, size);
+  transfer->data = data_copy;
+  transfer->size = size;
+
+  struct wl_data_source *source =
+    wl_data_device_manager_create_data_source(this->data_device_manager);
+  wl_data_source_add_listener(source, &data_source_listener, transfer);
+  for (int i = 0; i < sizeof(text_mimetypes)/sizeof(*text_mimetypes); i++)
+  {
+    wl_data_source_offer(source, text_mimetypes[i]);
+  }
+
+  wl_data_device_set_selection(this->data_device, source,
+    this->keyboard_enter_serial);
+}
+
 static void wayland_cb_notice(LG_ClipboardRequestFn requestFn, LG_ClipboardData type)
 {
+  if (type != LG_CLIPBOARD_DATA_TEXT)
+  {
+    DEBUG_ERROR("Only text selection currently supported");
+    return;
+  }
+
+  this->requestFn = requestFn;
+  this->type      = type;
+
+  if (!this->requestFn)
+    return;
+
+  this->requestFn(wayland_cb_reply_fn, NULL);
 }
 
 static void wayland_cb_release()

--- a/client/clipboards/Wayland/src/wayland.c
+++ b/client/clipboards/Wayland/src/wayland.c
@@ -1,0 +1,92 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2017-2019 Geoffrey McRae <geoff@hostfission.com>
+https://looking-glass.hostfission.com
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "interface/clipboard.h"
+#include "common/debug.h"
+
+struct state
+{
+  LG_ClipboardReleaseFn releaseFn;
+  LG_ClipboardRequestFn requestFn;
+  LG_ClipboardNotifyFn  notifyFn;
+  LG_ClipboardDataFn    dataFn;
+  LG_ClipboardData      type;
+};
+
+static struct state * this = NULL;
+
+static const char * wayland_cb_getName()
+{
+  return "Wayland";
+}
+
+static bool wayland_cb_init(
+    SDL_SysWMinfo         * wminfo,
+    LG_ClipboardReleaseFn   releaseFn,
+    LG_ClipboardNotifyFn    notifyFn,
+    LG_ClipboardDataFn      dataFn)
+{
+  if (wminfo->subsystem != SDL_SYSWM_WAYLAND)
+  {
+    DEBUG_ERROR("wrong subsystem");
+    return false;
+  }
+
+  this = (struct state *)malloc(sizeof(struct state));
+  memset(this, 0, sizeof(struct state));
+
+  this->releaseFn = releaseFn;
+  this->notifyFn  = notifyFn;
+  this->dataFn    = dataFn;
+  return true;
+}
+
+static void wayland_cb_free()
+{
+  free(this);
+  this = NULL;
+}
+
+static void wayland_cb_wmevent(SDL_SysWMmsg * msg)
+{
+}
+
+static void wayland_cb_notice(LG_ClipboardRequestFn requestFn, LG_ClipboardData type)
+{
+}
+
+static void wayland_cb_release()
+{
+  this->requestFn = NULL;
+}
+
+static void wayland_cb_request(LG_ClipboardData type)
+{
+}
+
+const LG_Clipboard LGC_Wayland =
+{
+  .getName = wayland_cb_getName,
+  .init    = wayland_cb_init,
+  .free    = wayland_cb_free,
+  .wmevent = wayland_cb_wmevent,
+  .notice  = wayland_cb_notice,
+  .release = wayland_cb_release,
+  .request = wayland_cb_request
+};

--- a/client/clipboards/X11/src/x11.c
+++ b/client/clipboards/X11/src/x11.c
@@ -70,9 +70,7 @@ static bool x11_cb_init(
 {
   // final sanity check
   if (wminfo->subsystem != SDL_SYSWM_X11)
-  {
     return false;
-  }
 
   this = (struct state *)malloc(sizeof(struct state));
   memset(this, 0, sizeof(struct state));

--- a/client/clipboards/X11/src/x11.c
+++ b/client/clipboards/X11/src/x11.c
@@ -71,7 +71,6 @@ static bool x11_cb_init(
   // final sanity check
   if (wminfo->subsystem != SDL_SYSWM_X11)
   {
-    DEBUG_ERROR("wrong subsystem");
     return false;
   }
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -2015,6 +2015,10 @@ static int lg_run()
 
       g_state.lgc = LG_Clipboards[0];
     }
+    else if (g_state.wminfo.subsystem == SDL_SYSWM_WAYLAND)
+    {
+      g_state.lgc = LG_Clipboards[1];
+    }
   } else {
     DEBUG_ERROR("Could not get SDL window information %s", SDL_GetError());
     return -1;

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1854,6 +1854,12 @@ static int lg_run()
   signal(SIGINT , int_handler);
   signal(SIGTERM, int_handler);
 
+  // Request to receive EPIPE instead of SIGPIPE when one end of a pipe
+  // disconnects while a write is pending. This is useful to the Wayland
+  // clipboard backend, where an arbitrary application is on the other end of
+  // that pipe.
+  signal(SIGPIPE, SIG_IGN);
+
   // try map the shared memory
   if (!ivshmemOpen(&g_state.shm))
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -2018,29 +2018,26 @@ static int lg_run()
         (unsigned char *)&value,
         1
       );
-
-      g_state.lgc = LG_Clipboards[0];
-    }
-    else if (g_state.wminfo.subsystem == SDL_SYSWM_WAYLAND)
-    {
-      g_state.lgc = LG_Clipboards[1];
     }
   } else {
     DEBUG_ERROR("Could not get SDL window information %s", SDL_GetError());
     return -1;
   }
 
+  for (LG_Clipboard ** clipboard = LG_Clipboards; *clipboard; clipboard++)
+    if ((*clipboard)->init(&g_state.wminfo, clipboardRelease, clipboardNotify, clipboardData))
+    {
+      g_state.lgc = *clipboard;
+      break;
+    }
+
   if (g_state.lgc)
   {
     DEBUG_INFO("Using Clipboard: %s", g_state.lgc->getName());
-    if (!g_state.lgc->init(&g_state.wminfo, clipboardRelease, clipboardNotify, clipboardData))
-    {
-      DEBUG_WARN("Failed to initialize the clipboard interface, continuing anyway");
-      g_state.lgc = NULL;
-    }
-
     g_state.cbRequestList = ll_new();
   }
+  else
+    DEBUG_WARN("Failed to initialize the clipboard interface, continuing anyway");
 
   initSDLCursor();
   if (params.hideMouse)

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -2024,21 +2024,6 @@ static int lg_run()
     return -1;
   }
 
-  for (LG_Clipboard ** clipboard = LG_Clipboards; *clipboard; clipboard++)
-    if ((*clipboard)->init(&g_state.wminfo, clipboardRelease, clipboardNotify, clipboardData))
-    {
-      g_state.lgc = *clipboard;
-      break;
-    }
-
-  if (g_state.lgc)
-  {
-    DEBUG_INFO("Using Clipboard: %s", g_state.lgc->getName());
-    g_state.cbRequestList = ll_new();
-  }
-  else
-    DEBUG_WARN("Failed to initialize the clipboard interface, continuing anyway");
-
   initSDLCursor();
   if (params.hideMouse)
     SDL_ShowCursor(SDL_DISABLE);
@@ -2073,6 +2058,21 @@ static int lg_run()
   lgWaitEvent(e_startup, TIMEOUT_INFINITE);
 
   wmInit();
+
+  for (LG_Clipboard ** clipboard = LG_Clipboards; *clipboard; clipboard++)
+    if ((*clipboard)->init(&g_state.wminfo, clipboardRelease, clipboardNotify, clipboardData))
+    {
+      g_state.lgc = *clipboard;
+      break;
+    }
+
+  if (g_state.lgc)
+  {
+    DEBUG_INFO("Using Clipboard: %s", g_state.lgc->getName());
+    g_state.cbRequestList = ll_new();
+  }
+  else
+    DEBUG_WARN("Failed to initialize the clipboard interface, continuing anyway");
 
   LGMP_STATUS status;
 

--- a/client/src/wm.h
+++ b/client/src/wm.h
@@ -17,6 +17,43 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include <stdbool.h>
+#include <stdint.h>
+
+struct WMState
+{
+  bool pointerGrabbed;
+  bool keyboardGrabbed;
+
+  void * opaque;
+};
+
+struct WMDataWayland
+{
+  struct wl_display * display;
+  struct wl_surface * surface;
+  struct wl_registry * registry;
+  struct wl_seat * seat;
+
+  struct wl_data_device_manager * dataDeviceManager;
+  struct wl_data_device * dataDevice;
+
+  uint32_t capabilities;
+
+  struct wl_keyboard * keyboard;
+  struct zwp_keyboard_shortcuts_inhibit_manager_v1 * keyboardInhibitManager;
+  struct zwp_keyboard_shortcuts_inhibitor_v1 * keyboardInhibitor;
+  uint32_t keyboardEnterSerial;
+
+  struct wl_pointer * pointer;
+  struct zwp_relative_pointer_manager_v1 * relativePointerManager;
+  struct zwp_pointer_constraints_v1 * pointerConstraints;
+  struct zwp_relative_pointer_v1 * relativePointer;
+  struct zwp_confined_pointer_v1 * confinedPointer;
+};
+
+struct WMState g_wmState;
+
 void wmInit();
 void wmFree();
 void wmGrabPointer();


### PR DESCRIPTION
To do:

- [x] Build scaffolding
- [x] VM-to-host
  - [x] Text selection
  - [x] Image selection
- [x] Host-to-VM
  - [x] Text selection
  - [x] Image selection
- [x] Keyboard hotplug
- [x] Textual data mimetype detection
- [x] ~Multi-seat~ post-ADL only, must have ref to seat that triggered copy operation