### PR TITLE
[client] clipboard: fix heap-buffer overflow in clipboardRequest

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -763,7 +763,7 @@ void clipboardRequest(const LG_ClipboardReplyFn replyFn, void * opaque)
   if (!params.clipboardToLocal)
     return;
 
-  struct CBRequest * cbr = (struct CBRequest *)malloc(sizeof(struct CBRequest()));
+  struct CBRequest * cbr = (struct CBRequest *)malloc(sizeof(struct CBRequest));
 
   cbr->type    = g_state.cbType;
   cbr->replyFn = replyFn;


### PR DESCRIPTION
`sizeof(struct Foo())` is always 1, because it's treated as the type of a function returning a `struct Foo`, and functions are size 1.

```
==================================================================
==7680==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000ec010 at pc 0x5622fcf9f386 bp 0x7f36084ff680 sp 0x7f36084ff678
WRITE of size 4 at 0x6020000ec010 thread T1
    #0 0x5622fcf9f385 in clipboardRequest /code/LookingGlass/client/src/main.c:707
    #1 0x5622fd0036c9 in wayland_cb_notice /code/LookingGlass/client/clipboards/Wayland/src/wayland.c:521
    #2 0x5622fcf9f4dc in spiceClipboardNotice /code/LookingGlass/client/src/main.c:724
    #3 0x5622fcfc4d59 in spice_agent_process /code/LookingGlass/repos/PureSpice/src/spice.c:1106
    #4 0x5622fcfc16d6 in spice_on_main_channel_read /code/LookingGlass/repos/PureSpice/src/spice.c:655
    #5 0x5622fcfbee4f in spice_process /code/LookingGlass/repos/PureSpice/src/spice.c:361
    #6 0x5622fcf9e3a2 in spiceThread /code/LookingGlass/client/src/main.c:598
    #7 0x5622fd006b5e in threadWrapper /code/LookingGlass/common/src/platform/linux/thread.c:39
    #8 0x7f3614b2bf26 in start_thread /build/glibc-WZtAaN/glibc-2.30/nptl/pthread_create.c:479
    #9 0x7f3614a4c2ee in __clone (/lib/x86_64-linux-gnu/libc.so.6+0xfd2ee)

0x6020000ec011 is located 0 bytes to the right of 1-byte region [0x6020000ec010,0x6020000ec011)
allocated by thread T1 here:
    #0 0x7f36156f9628 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x107628)
    #1 0x5622fcf9f33f in clipboardRequest /code/LookingGlass/client/src/main.c:705
    #2 0x5622fd0036c9 in wayland_cb_notice /code/LookingGlass/client/clipboards/Wayland/src/wayland.c:521
    #3 0x5622fcf9f4dc in spiceClipboardNotice /code/LookingGlass/client/src/main.c:724
    #4 0x5622fcfc4d59 in spice_agent_process /code/LookingGlass/repos/PureSpice/src/spice.c:1106
    #5 0x5622fcfc16d6 in spice_on_main_channel_read /code/LookingGlass/repos/PureSpice/src/spice.c:655
    #6 0x5622fcfbee4f in spice_process /code/LookingGlass/repos/PureSpice/src/spice.c:361
    #7 0x5622fcf9e3a2 in spiceThread /code/LookingGlass/client/src/main.c:598
    #8 0x5622fd006b5e in threadWrapper /code/LookingGlass/common/src/platform/linux/thread.c:39
    #9 0x7f3614b2bf26 in start_thread /build/glibc-WZtAaN/glibc-2.30/nptl/pthread_create.c:479

Thread T1 created by T0 here:
    #0 0x7f361562b9b2 in pthread_create (/lib/x86_64-linux-gnu/libasan.so.5+0x399b2)
    #1 0x5622fd006cd0 in lgCreateThread /code/LookingGlass/common/src/platform/linux/thread.c:50
    #2 0x5622fcfa5a7d in lg_run /code/LookingGlass/client/src/main.c:1615
    #3 0x5622fcface28 in main /code/LookingGlass/client/src/main.c:2035
    #4 0x7f3614975e0a in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: heap-buffer-overflow /code/LookingGlass/client/src/main.c:707 in clipboardRequest
Shadow bytes around the buggy address:
  0x0c04800157b0: fa fa 00 00 fa fa fd fa fa fa fd fa fa fa fd fd
  0x0c04800157c0: fa fa fd fd fa fa fd fa fa fa 00 fa fa fa 00 fa
  0x0c04800157d0: fa fa 00 fa fa fa fd fa fa fa fd fd fa fa fa fa
  0x0c04800157e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c04800157f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c0480015800: fa fa[01]fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480015810: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480015820: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480015830: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480015840: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0480015850: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==7680==ABORTING
```