### PR TITLE
[client] wm: specify SDL_FALSE to SDL_SetWindowGrab in wmUngrabPointer

### DIFF
--- a/client/src/wm.c
+++ b/client/src/wm.c
@@ -67,7 +67,7 @@ void wmUngrabPointer()
       break;
 
     default:
-      SDL_SetWindowGrab(g_state.window, SDL_TRUE);
+      SDL_SetWindowGrab(g_state.window, SDL_FALSE);
       break;
   }
 


### PR DESCRIPTION
Tiny fixup preventing the cursor from ever being released in the fallback branch.