### PR TITLE
Implement relative mouse mode for Wayland

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -30,6 +30,9 @@ add_feature_info(ENABLE_BACKTRACE ENABLE_BACKTRACE "Backtrace support.")
 option(ENABLE_ASAN "Build with AddressSanitizer" OFF)
 add_feature_info(ENABLE_ASAN ENABLE_ASAN "AddressSanitizer support.")
 
+option(ENABLE_WAYLAND "Build with Wayland support" ON)
+add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
+
 add_compile_options(
   "-Wall"
   "-Werror"
@@ -119,5 +122,32 @@ target_link_libraries(looking-glass-client
 )
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/looking-glass-client DESTINATION bin/ COMPONENT binary)
+
+if(ENABLE_WAYLAND)
+  find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+  pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.15)
+  pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
+
+  macro(wayland_generate protocol_file output_file)
+      add_custom_command(OUTPUT "${output_file}.h"
+          COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" client-header "${protocol_file}" "${output_file}.h"
+          DEPENDS "${protocol_file}"
+          VERBATIM)
+
+      add_custom_command(OUTPUT "${output_file}.c"
+          COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_file}" "${output_file}.c"
+          DEPENDS "${protocol_file}"
+          VERBATIM)
+
+      target_sources(looking-glass-client PRIVATE "${output_file}.h" "${output_file}.c")
+  endmacro()
+
+  wayland_generate(
+      "${WAYLAND_PROTOCOLS_BASE}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
+      "${PROJECT_TOP}/client/src/wayland-relative-pointer-unstable-v1-client-protocol")
+  wayland_generate(
+      "${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
+      "${PROJECT_TOP}/client/src/wayland-pointer-constraints-unstable-v1-client-protocol")
+endif()
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -235,3 +235,5 @@ struct CursorState
 // forwards
 extern struct AppState  g_state;
 extern struct AppParams params;
+
+void handleMouseGrabbed(double, double);

--- a/client/src/wm.c
+++ b/client/src/wm.c
@@ -88,6 +88,9 @@ void wmGrabKeyboard()
         CurrentTime);
       break;
 
+    case SDL_SYSWM_WAYLAND:
+      break;
+
     default:
       if (g_wmState.pointerGrabbed)
         SDL_SetWindowGrab(g_state.window, SDL_FALSE);
@@ -111,6 +114,9 @@ void wmUngrabKeyboard()
   {
     case SDL_SYSWM_X11:
       XUngrabKeyboard(g_state.wminfo.info.x11.display, CurrentTime);
+      break;
+
+    case SDL_SYSWM_WAYLAND:
       break;
 
     default:

--- a/client/src/wm.c
+++ b/client/src/wm.c
@@ -23,15 +23,53 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdbool.h>
 #include <SDL2/SDL.h>
 
+#include <wayland-client.h>
+
 #include "common/debug.h"
+
+#include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
+#include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 
 struct WMState
 {
   bool pointerGrabbed;
   bool keyboardGrabbed;
+
+  void * opaque;
 };
 
 static struct WMState g_wmState;
+
+static void wmWaylandInit();
+static void wmWaylandFree();
+static void wmWaylandGrabPointer();
+static void wmWaylandUngrabPointer();
+
+void wmInit()
+{
+  switch (g_state.wminfo.subsystem)
+  {
+    case SDL_SYSWM_WAYLAND:
+      wmWaylandInit();
+      break;
+
+    default:
+      break;
+  }
+}
+
+void wmFree()
+{
+  switch (g_state.wminfo.subsystem)
+  {
+    case SDL_SYSWM_WAYLAND:
+      wmWaylandFree();
+      break;
+
+    default:
+      break;
+  }
+}
 
 void wmGrabPointer()
 {
@@ -50,6 +88,10 @@ void wmGrabPointer()
         CurrentTime);
       break;
 
+    case SDL_SYSWM_WAYLAND:
+      wmWaylandGrabPointer();
+      break;
+
     default:
       SDL_SetWindowGrab(g_state.window, SDL_TRUE);
       break;
@@ -64,6 +106,10 @@ void wmUngrabPointer()
   {
     case SDL_SYSWM_X11:
       XUngrabPointer(g_state.wminfo.info.x11.display, CurrentTime);
+      break;
+
+    case SDL_SYSWM_WAYLAND:
+      wmWaylandUngrabPointer();
       break;
 
     default:
@@ -160,4 +206,170 @@ void wmWarpMouse(int x, int y)
       SDL_WarpMouseInWindow(g_state.window, x, y);
       break;
   }
+}
+
+// Wayland support.
+
+struct WMDataWayland
+{
+  struct wl_display * display;
+  struct wl_surface * surface;
+  struct wl_registry * registry;
+  struct wl_seat * seat;
+
+  uint32_t capabilities;
+
+  struct wl_pointer * pointer;
+  struct zwp_relative_pointer_manager_v1 * relativePointerManager;
+  struct zwp_pointer_constraints_v1 * pointerConstraints;
+  struct zwp_relative_pointer_v1 * relativePointer;
+  struct zwp_confined_pointer_v1 * confinedPointer;
+};
+
+// Registry-handling listeners.
+
+static void registryGlobalHandler(void * data, struct wl_registry * registry,
+    uint32_t name, const char * interface, uint32_t version)
+{
+  struct WMDataWayland * wm = data;
+
+  if (!strcmp(interface, wl_seat_interface.name) && !wm->seat)
+    wm->seat = wl_registry_bind(wm->registry, name, &wl_seat_interface, 1);
+  else if (!strcmp(interface, zwp_relative_pointer_manager_v1_interface.name))
+    wm->relativePointerManager = wl_registry_bind(wm->registry, name,
+        &zwp_relative_pointer_manager_v1_interface, 1);
+  else if (!strcmp(interface, zwp_pointer_constraints_v1_interface.name))
+    wm->pointerConstraints = wl_registry_bind(wm->registry, name,
+        &zwp_pointer_constraints_v1_interface, 1);
+}
+
+static void registryGlobalRemoveHandler(void * data,
+    struct wl_registry * registry, uint32_t name)
+{
+  // Do nothing.
+}
+
+static const struct wl_registry_listener registryListener = {
+  .global = registryGlobalHandler,
+  .global_remove = registryGlobalRemoveHandler,
+};
+
+// Seat-handling listeners.
+
+static void handlePointerCapability(struct WMDataWayland * wm,
+    uint32_t capabilities)
+{
+  bool hasPointer = capabilities & WL_SEAT_CAPABILITY_POINTER;
+  if (!hasPointer && wm->pointer)
+  {
+    wl_pointer_destroy(wm->pointer);
+    wm->pointer = NULL;
+  }
+  else if (hasPointer && !wm->pointer)
+    wm->pointer = wl_seat_get_pointer(wm->seat);
+}
+
+static void seatCapabilitiesHandler(void * data, struct wl_seat * seat,
+    uint32_t capabilities)
+{
+  struct WMDataWayland * wm = data;
+  wm->capabilities = capabilities;
+  handlePointerCapability(wm, capabilities);
+}
+
+static void seatNameHandler(void * data, struct wl_seat * seat,
+    const char * name)
+{
+  // Do nothing.
+}
+
+static const struct wl_seat_listener seatListener = {
+    .capabilities = seatCapabilitiesHandler,
+    .name = seatNameHandler,
+};
+
+void wmWaylandInit()
+{
+  struct WMDataWayland * wm = malloc(sizeof(struct WMDataWayland));
+  memset(wm, 0, sizeof(struct WMDataWayland));
+
+  wm->display = g_state.wminfo.info.wl.display;
+  wm->surface = g_state.wminfo.info.wl.surface;
+  wm->registry = wl_display_get_registry(wm->display);
+
+  wl_registry_add_listener(wm->registry, &registryListener, wm);
+  wl_display_roundtrip(wm->display);
+
+  wl_seat_add_listener(wm->seat, &seatListener, wm);
+  wl_display_roundtrip(wm->display);
+
+  g_wmState.opaque = wm;
+}
+
+static void relativePointerMotionHandler(void * data,
+    struct zwp_relative_pointer_v1 *pointer, uint32_t timeHi, uint32_t timeLo,
+    wl_fixed_t dxW, wl_fixed_t dyW, wl_fixed_t dxUnaccelW,
+    wl_fixed_t dyUnaccelW)
+{
+  double dxUnaccel = wl_fixed_to_double(dxUnaccelW);
+  double dyUnaccel = wl_fixed_to_double(dyUnaccelW);
+  handleMouseGrabbed(dxUnaccel, dyUnaccel);
+}
+
+static const struct zwp_relative_pointer_v1_listener relativePointerListener = {
+    .relative_motion = relativePointerMotionHandler,
+};
+
+static void wmWaylandGrabPointer()
+{
+  struct WMDataWayland * wm = g_wmState.opaque;
+
+  if (!wm->relativePointer)
+  {
+    wm->relativePointer =
+      zwp_relative_pointer_manager_v1_get_relative_pointer(
+        wm->relativePointerManager, wm->pointer);
+    zwp_relative_pointer_v1_add_listener(wm->relativePointer,
+      &relativePointerListener, wm);
+  }
+
+  if (!wm->confinedPointer)
+  {
+    wm->confinedPointer = zwp_pointer_constraints_v1_confine_pointer(
+        wm->pointerConstraints, wm->surface, wm->pointer, NULL,
+        ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+  }
+}
+
+static void wmWaylandUngrabPointer()
+{
+  struct WMDataWayland * wm = g_wmState.opaque;
+
+  if (wm->relativePointer)
+  {
+    zwp_relative_pointer_v1_destroy(wm->relativePointer);
+    wm->relativePointer = NULL;
+  }
+
+  if (wm->confinedPointer)
+  {
+    zwp_confined_pointer_v1_destroy(wm->confinedPointer);
+    wm->confinedPointer = NULL;
+  }
+}
+
+static void wmWaylandFree()
+{
+  struct WMDataWayland * wm = g_wmState.opaque;
+
+  wmWaylandUngrabPointer();
+
+  // TODO: these also need to be freed, but are currently owned by SDL.
+  // wl_display_destroy(wm->display);
+  // wl_surface_destroy(wm->surface);
+  wl_pointer_destroy(wm->pointer);
+  wl_seat_destroy(wm->seat);
+  wl_registry_destroy(wm->registry);
+
+  free(g_wmState.opaque);
 }

--- a/client/src/wm.h
+++ b/client/src/wm.h
@@ -17,6 +17,8 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+void wmInit();
+void wmFree();
 void wmGrabPointer();
 void wmUngrabPointer();
 void wmGrabKeyboard();


### PR DESCRIPTION
This patch series removes SDL from the grabbed mouse handling path on Wayland.

Some build infra changes are necessary to build unstable Wayland protocols `relative-pointer-unstable-v1` and `pointer-constraints-unstable-v1-client-protocol`. These protocols have ~universal adoption, and are what SDL uses internally too.

I've attempted to cleanly separate the Wayland bits through an opaque pointer, in hopes that this will make it easy to move into ADL later.

This PR likely still contains bugs, but I'm dogfooding it for now.