### PR TITLE
[client] wm/wayland: bypass SDL loop for pointer events

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -88,9 +88,6 @@ struct AppParams params = { 0 };
 static void setGrab(bool enable);
 static void setGrabQuiet(bool enable);
 
-void handleMouseGrabbed(double ex, double ey);
-static void handleMouseNormal(double ex, double ey);
-
 static void lgInit()
 {
   g_state.state         = APP_STATE_RUNNING;
@@ -940,7 +937,7 @@ static void handleMouseWayland()
     DEBUG_ERROR("failed to send mouse motion message");
 }
 
-static void handleMouseNormal(double ex, double ey)
+void handleMouseNormal(double ex, double ey)
 {
   /* if we don't have the current cursor pos just send cursor movements */
   if (!g_cursor.guest.valid)
@@ -1489,15 +1486,17 @@ int eventFilter(void * userdata, SDL_Event * event)
       g_cursor.pos.x = event->motion.x;
       g_cursor.pos.y = event->motion.y;
 
-      if (g_cursor.grab)
+      if (g_state.wminfo.subsystem != SDL_SYSWM_WAYLAND)
       {
-        // On Wayland, wm.c calls handleMouseGrabbed, bypassing the SDL event
-        // loop.
-        if (g_state.wminfo.subsystem != SDL_SYSWM_WAYLAND)
-          handleMouseGrabbed(event->motion.xrel, event->motion.yrel);
+        // On Wayland, wm.c calls these functions, bypassing the SDL event loop.
+        if (g_cursor.grab)
+        {
+          if (g_state.wminfo.subsystem != SDL_SYSWM_WAYLAND)
+            handleMouseGrabbed(event->motion.xrel, event->motion.yrel);
+        }
+        else
+          handleMouseNormal(event->motion.xrel, event->motion.yrel);
       }
-      else
-        handleMouseNormal(event->motion.xrel, event->motion.yrel);
       break;
     }
 

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -237,3 +237,4 @@ extern struct AppState  g_state;
 extern struct AppParams params;
 
 void handleMouseGrabbed(double, double);
+void handleMouseNormal(double, double);

--- a/client/src/wm.c
+++ b/client/src/wm.c
@@ -242,6 +242,51 @@ static const struct wl_registry_listener registryListener = {
   .global_remove = registryGlobalRemoveHandler,
 };
 
+// Mouse-handling listeners.
+
+static void pointerMotionHandler(void * data, struct wl_pointer * pointer,
+    uint32_t serial, wl_fixed_t sxW, wl_fixed_t syW)
+{
+  int sx = wl_fixed_to_int(sxW);
+  int sy = wl_fixed_to_int(syW);
+  handleMouseNormal(sx, sy);
+}
+
+static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
+    uint32_t serial, struct wl_surface * surface, wl_fixed_t sxW,
+    wl_fixed_t syW)
+{
+  int sx = wl_fixed_to_int(sxW);
+  int sy = wl_fixed_to_int(syW);
+  handleMouseNormal(sx, sy);
+}
+
+static void pointerLeaveHandler(void * data, struct wl_pointer * pointer,
+    uint32_t serial, struct wl_surface * surface)
+{
+  // Do nothing.
+}
+
+static void pointerAxisHandler(void * data, struct wl_pointer * pointer,
+  uint32_t serial, uint32_t axis, wl_fixed_t value)
+{
+  // Do nothing.
+}
+
+static void pointerButtonHandler(void *data, struct wl_pointer *pointer, 
+    uint32_t serial, uint32_t time, uint32_t button, uint32_t stateW)
+{
+  // Do nothing.
+}
+
+static const struct wl_pointer_listener pointerListener = {
+  .enter = pointerEnterHandler,
+  .leave = pointerLeaveHandler,
+  .motion = pointerMotionHandler,
+  .button = pointerButtonHandler,
+  .axis = pointerAxisHandler,
+};
+
 // Keyboard-handling listeners.
 
 static void keyboardKeymapHandler(void * data, struct wl_keyboard * keyboard,
@@ -296,7 +341,10 @@ static void handlePointerCapability(struct WMDataWayland * wm,
     wm->pointer = NULL;
   }
   else if (hasPointer && !wm->pointer)
+  {
     wm->pointer = wl_seat_get_pointer(wm->seat);
+    wl_pointer_add_listener(wm->pointer, &pointerListener, wm);
+  }
 }
 
 static void handleKeyboardCapability(struct WMDataWayland * wm,


### PR DESCRIPTION
Depends on https://github.com/gnif/LookingGlass/pull/353 for conflict reasons, but only the last commit in this chain has changes.