### PR TITLE
[client] wm/wayload: implement keyboard grabbing

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -147,6 +147,9 @@ if(ENABLE_WAYLAND)
   wayland_generate(
       "${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
       "${PROJECT_TOP}/client/src/wayland-pointer-constraints-unstable-v1-client-protocol")
+  wayland_generate(
+      "${WAYLAND_PROTOCOLS_BASE}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml"
+      "${PROJECT_TOP}/client/src/wayland-keyboard-shortcuts-inhibit-unstable-v1-client-protocol")
 endif()
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1240,12 +1240,26 @@ int eventFilter(void * userdata, SDL_Event * event)
 
         case SDL_WINDOWEVENT_FOCUS_GAINED:
           if (g_state.wminfo.subsystem != SDL_SYSWM_X11)
+          {
             g_state.focused = true;
+
+            if (!inputEnabled())
+              break;
+            if (params.grabKeyboardOnFocus)
+              wmGrabKeyboard();
+          }
           break;
 
         case SDL_WINDOWEVENT_FOCUS_LOST:
           if (g_state.wminfo.subsystem != SDL_SYSWM_X11)
+          {
             g_state.focused = false;
+
+            if (!inputEnabled())
+              break;
+            if (params.grabKeyboardOnFocus)
+              wmUngrabKeyboard();
+          }
           break;
 
         case SDL_WINDOWEVENT_SIZE_CHANGED:


### PR DESCRIPTION
This patch uses the `keyboard-shortcuts-inhibit-unstable-v1` Wayland protocol to inhibit all window manager keyboard shortcuts, effectively grabbing the keyboard.