### PR TITLE
[client] spice/wayland: fix multiple mouse issues

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -920,6 +920,9 @@ static void guestCurToLocal(struct DoublePoint *local)
 // capture mode.
 static void handleMouseWayland()
 {
+  if (g_cursor.guest.dpiScale == 0)
+    return;
+
   /* translate the guests position to our coordinate space */
   struct DoublePoint local;
   guestCurToLocal(&local);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -920,8 +920,12 @@ static void guestCurToLocal(struct DoublePoint *local)
 // capture mode.
 static void handleMouseWayland()
 {
-  double ex = (g_cursor.pos.x - g_cursor.guest.x) / g_cursor.dpiScale;
-  double ey = (g_cursor.pos.y - g_cursor.guest.y) / g_cursor.dpiScale;
+  /* translate the guests position to our coordinate space */
+  struct DoublePoint local;
+  guestCurToLocal(&local);
+
+  double ex = (g_cursor.pos.x - local.x) / g_cursor.dpiScale;
+  double ey = (g_cursor.pos.y - local.y) / g_cursor.dpiScale;
 
   int x, y;
   cursorToInt(ex, ey, &x, &y);


### PR DESCRIPTION
This will now correctly respect the cursor hotspot and scaling. It will also avoid division by zero when `dpiScale` is not initialized.