### PR TITLE
[client] wm/wayland: correctly handle double keyboard grab

### DIFF
--- a/client/src/wm.c
+++ b/client/src/wm.c
@@ -460,7 +460,7 @@ static void wmWaylandGrabKeyboard()
 {
   struct WMDataWayland * wm = g_wmState.opaque;
 
-  if (wm->keyboardInhibitManager)
+  if (wm->keyboardInhibitManager && !wm->keyboardInhibitor)
   {
     wm->keyboardInhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
         wm->keyboardInhibitManager, wm->surface, wm->seat);


### PR DESCRIPTION
When input:grabKeyboardOnFocus is set (default), entering capture mode grabs
the keyboard a second time. This commit makes the second grab a no-op on
Wayland to avoid a crash.