### PR TITLE
[client] clipboard/wayland: fix null mimetype receive error

### DIFF
--- a/client/clipboards/Wayland/src/wayland.c
+++ b/client/clipboards/Wayland/src/wayland.c
@@ -200,6 +200,7 @@ static const struct wl_data_offer_listener dataOfferListener = {
 static void dataDeviceHandleDataOffer(void * data,
     struct wl_data_device * dataDevice, struct wl_data_offer * offer)
 {
+  this->stashedType = LG_CLIPBOARD_DATA_NONE;
   wl_data_offer_add_listener(offer, &dataOfferListener, NULL);
 }
 


### PR DESCRIPTION
This prevents looking-glass-client from failing with an error message like:

error marshalling arguments for receive (signature sh): null value passed for arg 0
Error marshalling request: Invalid argument