### PR TITLE
[client] add support for compiling with MemorySanitizer

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -36,6 +36,9 @@ add_feature_info(ENABLE_ASAN ENABLE_ASAN "AddressSanitizer support.")
 option(ENABLE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
 add_feature_info(ENABLE_UBSAN ENABLE_UBSAN "UndefinedBehaviorSanitizer support.")
 
+option(ENABLE_MSAN "Build with MemorySanitizer" OFF)
+add_feature_info(ENABLE_MSAN ENABLE_MSAN "MemorySanitizer support.")
+
 option(ENABLE_WAYLAND "Build with Wayland support" ON)
 add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
 
@@ -60,6 +63,11 @@ endif()
 if(ENABLE_UBSAN)
   add_compile_options("-fsanitize=undefined")
   set(EXE_FLAGS "${EXE_FLAGS} -fsanitize=undefined")
+endif()
+
+if(ENABLE_MSAN)
+  add_compile_options("-fno-omit-frame-pointer" "-fsanitize=memory")
+  set(EXE_FLAGS "${EXE_FLAGS} -fno-omit-frame-pointer -fsanitize=memory")
 endif()
 
 find_package(PkgConfig)


### PR DESCRIPTION
This is a sanitizer for tracking access to uninitialized memory.
Violations will be addressed in future commits.