### PR TITLE
[client] Build with -Wextra and fix errors

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -41,6 +41,10 @@ add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
 
 add_compile_options(
   "-Wall"
+  "-Wextra"
+  "-Wno-sign-compare"
+  "-Wno-unused-parameter"
+  "$<$<C_COMPILER_ID:GNU>:-Wimplicit-fallthrough=2>"
   "-Werror"
   "-Wfatal-errors"
   "-ffast-math"

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -1109,7 +1109,6 @@ static void update_mouse_shape(struct Inst * this, bool * newShape)
   switch(cursor)
   {
     case LG_CURSOR_MASKED_COLOR:
-    {
       for(int i = 0; i < width * height; ++i)
       {
         const uint32_t c = ((uint32_t *)data)[i];
@@ -1120,7 +1119,6 @@ static void update_mouse_shape(struct Inst * this, bool * newShape)
       //
       // technically we should also create an XOR texture from the data but this
       // usage seems very rare in modern software.
-    }
 
     case LG_CURSOR_COLOR:
     {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -668,7 +668,7 @@ int spiceThread(void * arg)
   return 0;
 }
 
-static inline const uint32_t mapScancode(SDL_Scancode scancode)
+static inline uint32_t mapScancode(SDL_Scancode scancode)
 {
   uint32_t ps2;
   if (scancode > (sizeof(usb_to_ps2) / sizeof(uint32_t)) || (ps2 = usb_to_ps2[scancode]) == 0)


### PR DESCRIPTION
-Wno-sign-compare is used to suppress warnings related to comparing signed
values with unsigned ones. It's too pedantic.

-Wunused-parameter is also too pedantic, especially since all parameters
have to be named in C.

Otherwise, -Wextra lets us catch bugs, such as x < 0 for unsigned x.

On gcc, we pass -Wimplicit-fallthrough=2 so it will recognize our fall
through comment. Braces had to be removed in one instance so
that gcc can recognize the fallthrough comment correctly.

This should be merged after gnif/PureSpice#5.