### PR TITLE
[host] windows: avoid leaking process and thread handles

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -353,6 +353,8 @@ void Launch(void)
     goto fail_exe;
   }
 
+  CloseHandle(pi.hProcess);
+  CloseHandle(pi.hThread);
   service.processId = pi.dwProcessId;
   service.running   = true;
 


### PR DESCRIPTION
The handles in PROCESS_INFORMATION must be closed if not used, or they
will leak.