### PR TITLE
[host] windows: improve restart logic and remove mutex hack

### DIFF
--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -11,6 +11,9 @@ add_library(platform_Windows STATIC
 	src/mousehook.c
 )
 
+# allow use of functions for Windows Vista or later
+add_definitions(-D _WIN32_WINNT=0x6000)
+
 add_subdirectory("capture")
 
 FIND_PROGRAM(WINDRES_EXECUTABLE NAMES "x86_64-w64-mingw32-windres" "windres.exe" DOC "windres executable")


### PR DESCRIPTION
Use the process handle returned by CreateProcessAsUserA to wait on the
process. This results in faster response times and less polling.
For example, it now restarts instantly when UAC is activated.

This also removes the call to OpenProcess and rendering the mutex unnecessary.

As a bonus, it should fix #298.