### PR TITLE
[host] windows: define exit codes for future use

### DIFF
--- a/host/platform/Windows/src/service.h
+++ b/host/platform/Windows/src/service.h
@@ -1,3 +1,12 @@
 #include <stdbool.h>
 
+// exit code for user opted to exit looking-glass-host
+#define LG_HOST_EXIT_USER    0xfee1dead
+// exit code for capture errors that should result in a restart, e.g. UAC
+#define LG_HOST_EXIT_CAPTURE 0xdead0000
+// exit code for terminated
+#define LG_HOST_EXIT_KILLED  0xdeadbeef
+// exit code for failed to start
+#define LG_HOST_EXIT_FAILED  0xdeadbaad
+
 bool HandleService(int argc, char * argv[]);


### PR DESCRIPTION
The host process will be changed to return these codes, from which the
service process could decide whether to exit or restart the process and log.

Note that on Windows, return values are 32-bit unlike POSIX which is only 8.