### PR TITLE
[host] windows: remove ImpersonateLoggedOnUser call

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -307,16 +307,6 @@ void Launch(void)
     goto fail_token;
   }
 
-  if (!enablePriv(SE_IMPERSONATE_NAME))
-    goto fail_token;
-
-  if (!ImpersonateLoggedOnUser(hToken))
-  {
-    doLog("fail_tokened to impersonate\n");
-    winerr();
-    goto fail_token;
-  }
-
   if (!enablePriv(SE_ASSIGNPRIMARYTOKEN_NAME))
     goto fail_token;
 


### PR DESCRIPTION
It shouldn't have any effect, since the host application is created with
the token, and there is no need for the service itself to impersonate.

In practice, removal doesn't appear to have any effect on the ability to
capture privileged things like secure desktop.