### PR TITLE
[host] windows: add timestamps to service logs

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -25,6 +25,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdarg.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <time.h>
 
 #include <windows.h>
 #include <winsvc.h>
@@ -63,13 +64,24 @@ struct Service
 
 struct Service service = { 0 };
 
-void doLog(const char * fmt, ...)
+char logTime[100];
+
+char * currentTime()
+{
+  time_t t = time(NULL);
+  strftime(logTime, sizeof logTime, "%Y-%m-%d %H:%M:%S", localtime(&t));
+  return logTime;
+}
+
+void doLogReal(const char * fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
   vfprintf(service.logFile, fmt, args);
   va_end(args);
 }
+
+#define doLog(fmt, ...) doLogReal("[%s] " fmt, currentTime(), ##__VA_ARGS__)
 
 static bool setupAPI(void)
 {


### PR DESCRIPTION
This makes it easier to identify when things in the logs happened.