### PR TITLE
[host] windows: close handle to token in enablePriv

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -163,6 +163,7 @@ bool enablePriv(const char * name)
     goto fail;
   }
 
+  CloseHandle(hToken);
   return true;
 
 fail:


### PR DESCRIPTION
This should eliminate all handle leaks resulting from killing the host.