### PR TITLE
[host] windows: avoid quoting issues with CreateProcessAsUserA

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -340,11 +340,10 @@ void Launch(void)
     .lpDesktop   = "WinSta0\\Default"
   };
 
-  char * exe = strdup(os_getExecutable());
   if (!f_CreateProcessAsUserA(
       hToken,
+      os_getExecutable(),
       NULL,
-      exe,
       NULL,
       NULL,
       TRUE,
@@ -358,15 +357,12 @@ void Launch(void)
     service.running = false;
     doLog("failed to launch\n");
     winerr();
-    goto fail_exe;
+    goto fail_token;
   }
 
   CloseHandle(pi.hThread);
   service.process = pi.hProcess;
   service.running = true;
-
-fail_exe:
-  free(exe);
 
 fail_token:
   CloseHandle(hToken);


### PR DESCRIPTION
To quote MSDN documentation:

> The lpApplicationName parameter can be NULL, in which case the executable
> name must be the first white space–delimited string in lpCommandLine. If
> the executable or path name has a space in it, there is a risk that a
> different executable could be run because of the way the function parses
> spaces. The following example is dangerous because the function will
> attempt to run "Program.exe", if it exists, instead of "MyApp.exe".
>
>   LPTSTR szCmdline[] = _tcsdup(TEXT("C:\\Program Files\\MyApp"));
>   CreateProcessAsUser(hToken, NULL, szCmdline, /*...*/ );
>
> If a malicious user were to create an application called "Program.exe" on
> a system, any program that incorrectly calls CreateProcessAsUser using the
> Program Files directory will run this application instead of the intended
> application.
>
> To avoid this problem, do not pass NULL for lpApplicationName.

So instead, we pass the executable to lpApplicationName instead, which avoids
the issue. MSDN says:

> The lpCommandLine parameter can be NULL. In that case, the function uses
> the string pointed to by lpApplicationName as the command line.

This also avoids the strdup since lpApplicationName is LPCSTR unlike
lpCommandLine which is LPSTR.