### PR TITLE
[client] wayland: update absolute mouse position

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -125,7 +125,8 @@ static void pointerMotionHandler(void * data, struct wl_pointer * pointer,
 {
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
-  app_handleMouseNormal(sx, sy);
+  app_updateCursorPos(sx, sy);
+  app_handleMouseBasic();
 }
 
 static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
@@ -134,7 +135,8 @@ static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
 {
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
-  app_handleMouseNormal(sx, sy);
+  app_updateCursorPos(sx, sy);
+  app_handleMouseBasic();
 }
 
 static void pointerLeaveHandler(void * data, struct wl_pointer * pointer,
@@ -394,13 +396,7 @@ static bool waylandEventFilter(SDL_Event * event)
   switch(event->type)
   {
     case SDL_MOUSEMOTION:
-    {
-      app_updateCursorPos(event->motion.x, event->motion.y);
-
-      // we must use the basic handler as Wayland has no warp support
-      app_handleMouseBasic(event->motion.x, event->motion.y);
       return true;
-    }
   }
 
   return false;

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -34,9 +34,9 @@ void app_updateWindowPos(int x, int y);
 void app_handleResizeEvent(int w, int h);
 void app_handleMouseGrabbed(double ex, double ey);
 void app_handleMouseNormal(double ex, double ey);
-void app_handleMouseBasic(double ex, double ey);
-void app_handleWindowEnter();
-void app_handleWindowLeave();
+void app_handleMouseBasic(void);
+void app_handleWindowEnter(void);
+void app_handleWindowLeave(void);
 
 void app_clipboardRelease(void);
 void app_clipboardNotify(const LG_ClipboardData type, size_t size);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1107,16 +1107,8 @@ void app_handleMouseNormal(double ex, double ey)
 // cursor warp support. Instead, we attempt a best-effort emulation which works
 // with a 1:1 mouse movement patch applied in the guest. For anything fancy, use
 // capture mode.
-void app_handleMouseBasic(double ex, double ey)
+void app_handleMouseBasic()
 {
-  /* if we don't have the current cursor pos just send cursor movements */
-  if (!g_cursor.guest.valid)
-  {
-    if (g_cursor.grab)
-      app_handleMouseGrabbed(ex, ey);
-    return;
-  }
-
   const bool inView =
     g_cursor.pos.x >= g_state.dstRect.x                     &&
     g_cursor.pos.x <  g_state.dstRect.x + g_state.dstRect.w &&


### PR DESCRIPTION
We are actually getting mouse events directly from Wayland instead of going
through SDL, so we call app_updateCursorPos in pointer motion handlers and
swallow the SDL event.

Also removed parameters for app_handleMouseBasic as it relies exclusively on
absolute positions provided by app_updateCursorPos. Wayland does not give
you relative movements at all unless grabbed and passing absolute movements
is semantically incorrect.

Note that when the cursor is grabbed, movements are handled entirely through
relativePointerMotionHandler in wayland.c and does not go through
app_handleMouseBasic at all.