### PR TITLE
[host] windows: sleep for 1 second instead of 1 millisecond

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -727,7 +727,7 @@ VOID WINAPI SvcMain(DWORD dwArgc, LPTSTR *lpszArgv)
 
         // avoid restarting too often
         if (GetTickCount64() - launchTime < 1000)
-          Sleep(1);
+          Sleep(1000);
         break;
       }
 


### PR DESCRIPTION
This is definitely supposed to sleep for 1 second.
1 ms is basically no throttling.