### PR TITLE
[client] wayland: implement more graceful degradation logic

### DIFF
--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -131,7 +131,7 @@ static void sdlUngrabKeyboard(void)
   sdl.keyboardGrabbed = false;
 }
 
-static void sdlWarpMouse(int x, int y, bool exiting)
+static void sdlWarpPointer(int x, int y, bool exiting)
 {
   if (sdl.exiting)
     return;
@@ -160,7 +160,7 @@ struct LG_DisplayServerOps LGDS_SDL =
   .ungrabPointer  = sdlUngrabPointer,
   .grabKeyboard   = sdlGrabKeyboard,
   .ungrabKeyboard = sdlUngrabKeyboard,
-  .warpMouse      = sdlWarpMouse,
+  .warpPointer    = sdlWarpPointer,
 
   /* SDL does not have clipboard support */
   .cbInit    = NULL,

--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -38,9 +38,10 @@ static bool sdlEarlyInit(void)
   return true;
 }
 
-static void sdlInit(SDL_SysWMinfo * info)
+static bool sdlInit(SDL_SysWMinfo * info)
 {
   memset(&sdl, 0, sizeof(sdl));
+  return true;
 }
 
 static void sdlStartup(void)

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -386,7 +386,7 @@ static void waylandUngrabKeyboard(void)
   }
 }
 
-static void waylandWarpMouse(int x, int y, bool exiting)
+static void waylandWarpPointer(int x, int y, bool exiting)
 {
   // This is an unsupported operation on Wayland.
 }
@@ -773,7 +773,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .ungrabPointer  = waylandUngrabPointer,
   .grabKeyboard   = waylandGrabKeyboard,
   .ungrabKeyboard = waylandUngrabKeyboard,
-  .warpMouse      = waylandWarpMouse,
+  .warpPointer    = waylandWarpPointer,
 
   .cbInit    = waylandCBInit,
   .cbNotice  = waylandCBNotice,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -386,6 +386,11 @@ static void waylandUngrabKeyboard(void)
   }
 }
 
+static void waylandWarpMouse(int x, int y, bool exiting)
+{
+  // This is an unsupported operation on Wayland.
+}
+
 static void waylandFree(void)
 {
   waylandUngrabPointer();
@@ -768,7 +773,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .ungrabPointer  = waylandUngrabPointer,
   .grabKeyboard   = waylandGrabKeyboard,
   .ungrabKeyboard = waylandUngrabKeyboard,
-  .warpMouse      = NULL,             // fallback to SDL
+  .warpMouse      = waylandWarpMouse,
 
   .cbInit    = waylandCBInit,
   .cbNotice  = waylandCBNotice,

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -433,7 +433,7 @@ static void x11UngrabKeyboard(void)
   x11.keyboardGrabbed = false;
 }
 
-static void x11WarpMouse(int x, int y, bool exiting)
+static void x11WarpPointer(int x, int y, bool exiting)
 {
   XWarpPointer(
       x11.display,
@@ -785,7 +785,7 @@ struct LG_DisplayServerOps LGDS_X11 =
   .ungrabPointer  = x11UngrabPointer,
   .grabKeyboard   = x11GrabKeyboard,
   .ungrabKeyboard = x11UngrabKeyboard,
-  .warpMouse      = x11WarpMouse,
+  .warpPointer    = x11WarpPointer,
 
   .cbInit    = x11CBInit,
   .cbNotice  = x11CBNotice,

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -81,7 +81,7 @@ static void x11CBSelectionIncr(const XPropertyEvent e);
 static void x11CBSelectionNotify(const XSelectionEvent e);
 static void x11CBXFixesSelectionNotify(const XFixesSelectionNotifyEvent e);
 
-static void x11Init(SDL_SysWMinfo * info)
+static bool x11Init(SDL_SysWMinfo * info)
 {
   memset(&x11, 0, sizeof(x11));
   x11.display = info->info.x11.display;
@@ -110,6 +110,8 @@ static void x11Init(SDL_SysWMinfo * info)
     (unsigned char *)&value,
     1
   );
+
+  return true;
 }
 
 static void x11Startup(void)

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -65,7 +65,7 @@ struct LG_DisplayServerOps
   bool (*earlyInit)(void);
 
   /* called after SDL has been initialized */
-  void (*init)(SDL_SysWMinfo * info);
+  bool (*init)(SDL_SysWMinfo * info);
 
   /* called at startup after window creation, renderer and/or SPICE is ready */
   void (*startup)();

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -93,7 +93,7 @@ struct LG_DisplayServerOps
   void (*ungrabKeyboard)();
 
   //exiting = true if the warp is to leave the window
-  void (*warpMouse)(int x, int y, bool exiting);
+  void (*warpPointer)(int x, int y, bool exiting);
 
   /* clipboard support */
   bool (* cbInit)(void);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -861,7 +861,7 @@ void spiceClipboardRequest(const SpiceDataType type)
     g_state.ds->cbRequest(spice_type_to_clipboard_type(type));
 }
 
-static void warpMouse(int x, int y, bool exiting)
+static void warpPointer(int x, int y, bool exiting)
 {
   if (g_cursor.warpState == WARP_STATE_OFF)
     return;
@@ -872,7 +872,7 @@ static void warpMouse(int x, int y, bool exiting)
   if (g_cursor.pos.x == x && g_cursor.pos.y == y)
     return;
 
-  g_state.ds->warpMouse(x, y, exiting);
+  g_state.ds->warpPointer(x, y, exiting);
 }
 
 static bool isValidCursorLocation(int x, int y)
@@ -1069,7 +1069,7 @@ void app_handleMouseNormal(double ex, double ey)
 
       /* ungrab the pointer and move the local cursor to the exit point */
       g_state.ds->ungrabPointer();
-      warpMouse(tx, ty, true);
+      warpPointer(tx, ty, true);
       return;
     }
   }
@@ -1089,7 +1089,7 @@ void app_handleMouseNormal(double ex, double ey)
     {
       g_cursor.delta.x = 0;
       g_cursor.delta.y = 0;
-      warpMouse(g_state.windowCX, g_state.windowCY, false);
+      warpPointer(g_state.windowCX, g_state.windowCY, false);
     }
 
     g_cursor.guest.x = g_state.srcSize.x / 2;
@@ -1280,7 +1280,7 @@ int eventFilter(void * userdata, SDL_Event * event)
 
         struct DoublePoint local;
         guestCurToLocal(&local);
-        warpMouse(round(local.x), round(local.y), false);
+        warpPointer(round(local.x), round(local.y), false);
         break;
       }
     }
@@ -1707,7 +1707,7 @@ static int lg_run(void)
   SET_FALLBACK(eventFilter);
   SET_FALLBACK(grabPointer);
   SET_FALLBACK(ungrabKeyboard);
-  SET_FALLBACK(warpMouse);
+  SET_FALLBACK(warpPointer);
   SET_FALLBACK(cbInit);
   SET_FALLBACK(cbNotice);
   SET_FALLBACK(cbRelease);


### PR DESCRIPTION
`zwp_relative_pointer_manager_v1` and `zwp_pointer_constraints_v1` are
supported by GNOME/KDE/sway (and many other compositors), but they are
not a required part of the protocol.

Some users also run software in one-off nested compositors like [cage][0]
for an extra layer of isolation; cage, at least, does not support
pointer captures.

This commit makes Looking Glass warn when an optional protocol is
unsupported, and fail if a required one is missing. Pointer grab paths
have a new guard against the aforementioned protocols being missing.

[0]: https://github.com/Hjdskes/cage