### PR TITLE
[client] mouse: remove erroneous guard for setCursorInView

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1121,13 +1121,8 @@ void app_handleMouseBasic()
     g_cursor.pos.y >= g_state.dstRect.y                     &&
     g_cursor.pos.y <  g_state.dstRect.y + g_state.dstRect.h;
 
-  if (params.hideMouse && inView != g_cursor.inView)
-
   if (inView != g_cursor.inView)
-  {
-    g_cursor.inView = inView;
     setCursorInView(inView);
-  }
 
   if (g_cursor.guest.dpiScale == 0)
     return;


### PR DESCRIPTION
This seems like a leftover from ef678ba, but the guard already exists in
setCursorInView itself.