### PR TITLE
[client] mouse: process mouse up event even if not in view

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1469,7 +1469,7 @@ int eventFilter(void * userdata, SDL_Event * event)
 
     case SDL_MOUSEBUTTONUP:
     {
-      if (!app_inputEnabled() || !g_cursor.inView)
+      if (!app_inputEnabled())
         break;
 
       int button = event->button.button;


### PR DESCRIPTION
Unless the corresponding mouse down event was on our surface, we should
not be receiving the mouse up.

This is always the case on Wayland. On some other platforms,
SDL_CaptureMouse can be used to obtain input that happens outside the
Looking Glass surface, but Looking Glass does not make use of that
function.

We may want to process a mouse up if the corresponding mouse down
initiated a drag (e.g., of a window) that was released slightly outside
of the Looking Glass surface. Previously, Looking Glass would ignore the
mouse up, and the guest would be confused into thinking the button had
never been released, not ending the drag.