### PR TITLE
[client] spice/wayland: fix capture mode relative movement

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -122,6 +122,9 @@ static const struct wl_registry_listener registryListener = {
 static void pointerMotionHandler(void * data, struct wl_pointer * pointer,
     uint32_t serial, wl_fixed_t sxW, wl_fixed_t syW)
 {
+  if (wm.relativePointer)
+    return;
+
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
   app_updateCursorPos(sx, sy);
@@ -132,6 +135,9 @@ static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
     uint32_t serial, struct wl_surface * surface, wl_fixed_t sxW,
     wl_fixed_t syW)
 {
+  if (wm.relativePointer)
+    return;
+
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
   app_updateCursorPos(sx, sy);


### PR DESCRIPTION
It appears that Wayland pointer motion handlers are called even when relative
mouse mode is enabled. The events they generate break first-person games.
This commit disables those handlers when relative mouse is enabled.