### PR TITLE
Implement idle inhibition on Wayland

### DIFF
--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -55,4 +55,7 @@ wayland_generate(
 wayland_generate(
     "${WAYLAND_PROTOCOLS_BASE}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml"
     "${CMAKE_BINARY_DIR}/wayland/wayland-keyboard-shortcuts-inhibit-unstable-v1-client-protocol")
+wayland_generate(
+    "${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
+    "${CMAKE_BINARY_DIR}/wayland/wayland-idle-inhibit-unstable-v1-client-protocol")
 


### PR DESCRIPTION
This PR implements the plumbing for idle inhibition on Wayland, preventing the WM's screen locker from activating if Looking Glass has keyboard focus.

Potential (future?) improvements:

- adhere to `win:noScreensaver`; would need some more hooks from main
- query whether there is something inhibiting idle on the guest side, and only inhibiting idle on the host side if so

Note: I've checked SDL sources, and `SDL_HINT_VIDEO_ALLOW_SCREENSAVER` (used in main.c) is currently no-op on Wayland.