### PR TITLE
[client] Fix compiler warnings about potentially uninitialized variables

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -34,6 +34,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <wayland-egl.h>
 #endif
 
+#include <assert.h>
+
 #include "app.h"
 #include "model.h"
 #include "shader.h"
@@ -288,6 +290,9 @@ static void egl_calc_mouse_size(struct Inst * this)
       w = this->format.height;
       h = this->format.width;
       break;
+
+    default:
+      assert(!"unreachable");
   }
 
   switch((this->format.rotate + this->rotate) % LG_ROTATE_MAX)

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -192,6 +192,9 @@ static void updatePositionInfo(void)
       srcW = g_state.srcSize.y;
       srcH = g_state.srcSize.x;
       break;
+
+    default:
+      assert(!"unreachable");
   }
 
   if (params.keepAspect)
@@ -1246,6 +1249,9 @@ inline static void localCurToGuest(struct DoublePoint *guest)
         * g_cursor.scale.y;
       guest->y = (point.x - g_state.dstRect.x) * g_cursor.scale.x;
       break;
+
+    default:
+      assert(!"unreachable");
   }
 }
 


### PR DESCRIPTION
Build failed with `_FORTIFY_SOURCE` enabled because the compiler couldn't ensure the switch statements didn't hit the default arm and thus wouldn't define the variables. Adding a statically failing assert makes sure that all code paths either define the variables or fail early.

```
$ cd client
$ env CFLAGS='-O1 -D_FORTIFY_SOURCE=1' cmake -B build/
$ make -C build
[...]
client/renderers/EGL/egl.c: In function ‘egl_calc_mouse_size’:
client/renderers/EGL/egl.c:299:36: error: ‘h’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  299 |         (this->mouseHeight * (1.0f / h)) * this->scaleY
      |                              ~~~~~~^~~~
```