### PR TITLE
[client] wayland: better handling of keypresses

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -245,7 +245,9 @@ static void keyboardEnterHandler(void * data, struct wl_keyboard * keyboard,
 static void keyboardLeaveHandler(void * data, struct wl_keyboard * keyboard,
     uint32_t serial, struct wl_surface * surface)
 {
-  // Do nothing.
+  for (int key = 0; key < KEY_MAX; key++)
+    if (wm.keyPressCount[key] && !--wm.keyPressCount[key])
+      app_handleKeyRelease(key);
 }
 
 static void keyboardKeyHandler(void * data, struct wl_keyboard * keyboard,


### PR DESCRIPTION
This PR implements better behavior for when LG loses keyboard focus while keys are held. Previously, any keys held down would remain down, since we did nothing in the leave handler. Now, we send synthetic keyups so the guest isn't left in a confused state.