### PR TITLE
[client] spice/wayland: fix jitter when moving the cursor slowly

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1438,11 +1438,8 @@ void app_handleMouseBasic()
   struct DoublePoint local;
   guestCurToLocal(&local);
 
-  double lx = (px - local.x) / g_cursor.dpiScale;
-  double ly = (py - local.y) / g_cursor.dpiScale;
-
-  int x, y;
-  cursorToInt(lx, ly, &x, &y);
+  int x = (int) round((px - local.x) / g_cursor.dpiScale);
+  int y = (int) round((py - local.y) / g_cursor.dpiScale);
 
   g_cursor.guest.x += x;
   g_cursor.guest.y += y;


### PR DESCRIPTION
It does not make sense to accumulate fractional error in non-capture mode
as you know exactly where the cursor is supposed to be, at least on Wayland.

On Wayland, we base movements on the current guest position and desired
target position, and the accumulated errors only skew our movements.