### PR TITLE
[client] wm: use correct logic for screensaver inhibition

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1987,7 +1987,7 @@ static int lg_run(void)
   if (!params.center)
     SDL_SetWindowPosition(g_state.window, params.x, params.y);
 
-  if (!params.noScreensaver)
+  if (params.noScreensaver)
     g_state.ds->inhibitIdle();
 
   // ensure the initial window size is stored in the state


### PR DESCRIPTION
Namely, we should inhibitIdle if noScreensaver is true, not the other way
around.