### PR TITLE
[client] wayland: use acceleration in capture mode unless rawMouse

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -391,9 +391,18 @@ static void relativePointerMotionHandler(void * data,
     wl_fixed_t dxW, wl_fixed_t dyW, wl_fixed_t dxUnaccelW,
     wl_fixed_t dyUnaccelW)
 {
-  double dxUnaccel = wl_fixed_to_double(dxUnaccelW);
-  double dyUnaccel = wl_fixed_to_double(dyUnaccelW);
-  app_handleMouseGrabbed(dxUnaccel, dyUnaccel);
+  double dx, dy;
+  if (app_cursorWantsRaw())
+  {
+    dx = wl_fixed_to_double(dxUnaccelW);
+    dy = wl_fixed_to_double(dyUnaccelW);
+  }
+  else
+  {
+    dx = wl_fixed_to_double(dxW);
+    dy = wl_fixed_to_double(dyW);
+  }
+  app_handleMouseGrabbed(dx, dy);
 }
 
 static const struct zwp_relative_pointer_v1_listener relativePointerListener = {


### PR DESCRIPTION
We are forced to use accelerated movement in regular mode as that is how the
host machine cursor moves and we want the cursors to line up (since Wayland
cannot do warps). To avoid a change in sensitivity when toggling capture
mode on/off, we should use accelerated deltas for capture mode as well,
unless the user explicitly asks for raw input with input:rawMouse.