### PR TITLE
[client] spice: keep cursor position when only updating hotspot

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -464,6 +464,12 @@ static int cursorThread(void * unused)
           continue;
       }
 
+      if (!(msg.udata & CURSOR_FLAG_POSITION))
+      {
+        g_cursor.guest.x += g_cursor.guest.hx - cursor->hx;
+        g_cursor.guest.y += g_cursor.guest.hy - cursor->hy;
+      }
+
       g_cursor.guest.hx = cursor->hx;
       g_cursor.guest.hy = cursor->hy;
 


### PR DESCRIPTION
g_cursor.guest.x/y stores the coordinates of the top-left corner of the
cursor image. When the cursor message contains CURSOR_FLAG_SHAPE but not
CURSOR_FLAG_POSITION, we update the hotspot location but not the top-left
position. This has the effect of changing the client's view of the guest
cursor position, which is located at (x + hx, y + hy).

In this commit, when we update the cursor shape but not position, we now
keep (x + hx, y + hy) the same. This has the effect of keeping the actual
cursor position the same when the shape changes but not the position.