### PR TITLE
[client] use continous box drawing characters for help option

### DIFF
--- a/common/src/option.c
+++ b/common/src/option.c
@@ -654,30 +654,30 @@ void option_print(void)
       if (i == 0)
       {
         // print a horizontal rule
-        printf("  |");
+        printf("  ┌");
         for(int i = 0; i < maxLen + 2; ++i)
-          putc('-', stdout);
-        printf("|\n");
+          fputs("─", stdout);
+        printf("┐\n");
       }
 
       char * line = stringlist_at(lines, i);
-      printf("  | %-*s |\n", maxLen, line);
+      printf("  │ %-*s │\n", maxLen, line);
 
       if (i == 0)
       {
         // print a horizontal rule
-        printf("  |");
+        printf("  ├");
         for(int i = 0; i < maxLen + 2; ++i)
-          putc('-', stdout);
-        printf("|\n");
+          fputs("─", stdout);
+        printf("┤\n");
       }
     }
 
     // print a horizontal rule
-    printf("  |");
+    printf("  └");
     for(int i = 0; i < maxLen + 2; ++i)
-      putc('-', stdout);
-    printf("|\n");
+      fputs("─", stdout);
+    printf("┘\n");
 
     stringlist_free(&lines);
 


### PR DESCRIPTION
This adds extended ASCII box drawing characters to make --help output a bit more pretty
I sourced the characters from [here](https://theasciicode.com.ar/extended-ascii-code/box-drawings-single-vertical-line-character-ascii-code-179.html)
Example output:
![image](https://user-images.githubusercontent.com/11753414/105621588-5f35a580-5e09-11eb-8613-578127bff0fe.png)
