### PR TITLE
[client] unconditionally quit on second SIGINT

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1597,14 +1597,23 @@ int eventFilter(void * userdata, SDL_Event * event)
   return 0;
 }
 
-void int_handler(int signal)
+void int_handler(int sig)
 {
-  switch(signal)
+  switch(sig)
   {
     case SIGINT:
     case SIGTERM:
-      DEBUG_INFO("Caught signal, shutting down...");
-      g_state.state = APP_STATE_SHUTDOWN;
+      if (g_state.state != APP_STATE_SHUTDOWN)
+      {
+        DEBUG_INFO("Caught signal, shutting down...");
+        g_state.state = APP_STATE_SHUTDOWN;
+      }
+      else
+      {
+        DEBUG_INFO("Caught second signal, force quitting...");
+        signal(sig, SIG_DFL);
+        raise(sig);
+      }
       break;
   }
 }


### PR DESCRIPTION
Under some circumstances, Looking Glass can hang when SIGINT'd, for
instance, if it's stuck waiting on spice I/O that won't complete because
the guest is misbehaving.

This commit provides an escape hatch for such cases, so one doesn't have
to reach for `kill -9 $(pidof looking-glass-client)`.