### PR TITLE
[host] service: disable buffering on the log file

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -118,6 +118,7 @@ static void setupLogging(void)
   char * logFilePath = malloc(len + 1);
   sprintf(logFilePath, "%slooking-glass-host-service.txt", tempPath);
   service.logFile = fopen(logFilePath, "a+");
+  setbuf(service.logFile, NULL);
   doLog("Startup\n");
 }
 


### PR DESCRIPTION
Before this change, the log is buffered, so if the host application exits
for any reason, it usually would not show up in the log file immediately,
and the service has to be restarted for the logs to be flushed.

This commit disables the buffering so that any log entries shows up
immediately.