### PR TITLE
[common] windows: implement crash handler for stack traces

### DIFF
--- a/common/src/platform/windows/CMakeLists.txt
+++ b/common/src/platform/windows/CMakeLists.txt
@@ -20,3 +20,7 @@ target_link_libraries(lg_common_platform_code
 	lg_common
 	setupapi
 )
+
+if (ENABLE_BACKTRACE)
+    target_link_libraries(lg_common_platform_code dbghelp)
+endif()

--- a/common/src/platform/windows/crash.c
+++ b/common/src/platform/windows/crash.c
@@ -18,9 +18,142 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 #include "common/crash.h"
+#include "common/debug.h"
+#include "common/version.h"
+
+#ifdef ENABLE_BACKTRACE
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <windows.h>
+#include <dbghelp.h>
+
+static const char * exception_name(DWORD code)
+{
+  switch (code)
+  {
+    case EXCEPTION_ACCESS_VIOLATION:
+      return "ACCESS_VIOLATION";
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+      return "ARRAY_BOUNDS_EXCEEDED";
+    case EXCEPTION_BREAKPOINT:
+      return "BREAKPOINT";
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+      return "DATATYPE_MISALIGNMENT";
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+      return "FLT_DENORMAL_OPERAND";
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+      return "FLT_DIVIDE_BY_ZERO";
+    case EXCEPTION_FLT_INEXACT_RESULT:
+      return "FLT_INEXACT_RESULT";
+    case EXCEPTION_FLT_INVALID_OPERATION:
+      return "FLT_INVALID_OPERATION";
+    case EXCEPTION_FLT_OVERFLOW:
+      return "FLT_OVERFLOW";
+    case EXCEPTION_FLT_STACK_CHECK:
+      return "FLT_STACK_CHECK";
+    case EXCEPTION_FLT_UNDERFLOW:
+      return "FLT_UNDERFLOW";
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+      return "ILLEGAL_INSTRUCTION";
+    case EXCEPTION_IN_PAGE_ERROR:
+      return "IN_PAGE_ERROR";
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+      return "INT_DIVIDE_BY_ZERO";
+    case EXCEPTION_INT_OVERFLOW:
+      return "INT_OVERFLOW";
+    case EXCEPTION_INVALID_DISPOSITION:
+      return "INVALID_DISPOSITION";
+    case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+      return "NONCONTINUABLE_EXCEPTION";
+    case EXCEPTION_PRIV_INSTRUCTION:
+      return "PRIV_INSTRUCTION";
+    case EXCEPTION_SINGLE_STEP:
+      return "SINGLE_STEP";
+    case EXCEPTION_STACK_OVERFLOW:
+      return "STACK_OVERFLOW";
+    default:
+      return "unknown";
+  }
+}
+
+static LONG CALLBACK exception_filter(EXCEPTION_POINTERS * exc)
+{
+  PEXCEPTION_RECORD excInfo = exc->ExceptionRecord;
+  CONTEXT context;
+  memcpy(&context, exc->ContextRecord, sizeof context);
+
+  DEBUG_ERROR("==== FATAL CRASH (%s) ====", BUILD_VERSION);
+  DEBUG_ERROR("exception 0x%08lx (%s), address is %p", excInfo->ExceptionCode,
+    exception_name(excInfo->ExceptionCode), excInfo->ExceptionAddress);
+
+  if (!SymInitialize(GetCurrentProcess(), NULL, TRUE))
+  {
+    DEBUG_ERROR("Failed to SymInitialize: 0x%08lx, could not generate stack trace", GetLastError());
+    goto fail;
+  }
+  SymSetOptions(SYMOPT_LOAD_LINES);
+
+  STACKFRAME64 frame     = { 0 };
+  frame.AddrPC.Offset    = context.Rip;
+  frame.AddrPC.Mode      = AddrModeFlat;
+  frame.AddrFrame.Offset = context.Rbp;
+  frame.AddrFrame.Mode   = AddrModeFlat;
+  frame.AddrStack.Offset = context.Rsp;
+  frame.AddrStack.Mode   = AddrModeFlat;
+
+  HANDLE hProcess = GetCurrentProcess();
+  HANDLE hThread  = GetCurrentThread();
+
+  for (int i = 1; StackWalk64(IMAGE_FILE_MACHINE_AMD64, hProcess, hThread, &frame, &context, NULL,
+                              SymFunctionTableAccess64, SymGetModuleBase64, NULL); ++i)
+  {
+    DWORD64 moduleBase = SymGetModuleBase64(hProcess, frame.AddrPC.Offset);
+    char moduleName[MAX_PATH];
+
+    if (moduleBase && GetModuleFileNameA((HMODULE) moduleBase, moduleName, MAX_PATH))
+    {
+      DWORD64 disp;
+
+      char symbolBuf[sizeof(SYMBOL_INFO) + 255];
+      PSYMBOL_INFO symbol = (PSYMBOL_INFO) symbolBuf;
+      symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+      symbol->MaxNameLen = 256;
+
+      if (SymFromAddr(hProcess, frame.AddrPC.Offset, &disp, symbol))
+      {
+        IMAGEHLP_LINE line = { sizeof(IMAGEHLP_LINE), 0 };
+        DWORD lineDisp;
+
+        if (SymGetLineFromAddr64(hProcess, frame.AddrPC.Offset, &lineDisp, &line))
+          DEBUG_ERROR("[trace]: %2d: %s:%s+0x%" PRIx64 " (%s:%ld+0x%lx)", i, moduleName, symbol->Name, disp,
+            line.FileName, line.LineNumber, lineDisp);
+        else
+          DEBUG_ERROR("[trace]: %2d: %s:%s+0x%" PRIx64, i, moduleName, symbol->Name, disp);
+      }
+      else
+        DEBUG_ERROR("[trace]: %2d: %s+0x%08" PRIx64, i, moduleName, frame.AddrPC.Offset - moduleBase);
+    }
+    else
+      DEBUG_ERROR("[trace]: %2d: 0x%016" PRIx64, i, frame.AddrPC.Offset);
+  }
+
+  SymCleanup(hProcess);
+
+fail:
+  fflush(stderr);
+  return EXCEPTION_CONTINUE_SEARCH;
+}
 
 bool installCrashHandler(const char * exe)
 {
-  //TODO
+  SetUnhandledExceptionFilter(exception_filter);
   return true;
 }
+
+#else
+bool installCrashHandler(const char * exe)
+{
+  return true;
+}
+#endif


### PR DESCRIPTION
This commit uses the DbgHelp library which is shipped with Windows to
generate stack traces with function names and line number information.
It takes advantage of the pdb file generated by cv2pdb that is now
installed with looking-glass-host.exe.

Example output from reverting the NvFBC fixes:

```
407818761245 [E]              crash.c:86   | exception_filter               | ==== FATAL CRASH (B3-rc1-20-g8de5386bd5+) ====
407818761664 [E]              crash.c:88   | exception_filter               | exception 0xc0000005 (ACCESS_VIOLATION), address is 0000000000411784
407818808932 [E]              crash.c:130  | exception_filter               | [trace]:  1: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:lgSignalEvent+0x4 (\home\quantum\build\LookingGlass\common\src\platform\windows\event.c:213+0x0)
407818809790 [E]              crash.c:130  | exception_filter               | [trace]:  2: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:nvfbc_stop+0x1a (\home\quantum\build\LookingGlass\host\platform\Windows\capture\NVFBC\src\nvfbc.c:215+0x0)
407818810635 [E]              crash.c:130  | exception_filter               | [trace]:  3: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:stopThreads+0x10 (\home\quantum\build\LookingGlass\host\src\app.c:245+0x0)
407818811357 [E]              crash.c:130  | exception_filter               | [trace]:  4: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:app_main+0xf6b (\home\quantum\build\LookingGlass\host\src\app.c:644+0x0)
407818812156 [E]              crash.c:130  | exception_filter               | [trace]:  5: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:appThread+0x1c (\home\quantum\build\LookingGlass\host\platform\Windows\src\platform.c:148+0x0)
407818812957 [E]              crash.c:130  | exception_filter               | [trace]:  6: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:threadWrapper+0xf (\home\quantum\build\LookingGlass\common\src\platform\windows\thread.c:40+0x0)
407818813809 [E]              crash.c:132  | exception_filter               | [trace]:  7: C:\WINDOWS\System32\KERNEL32.DLL:BaseThreadInitThunk+0x14
407818814347 [E]              crash.c:132  | exception_filter               | [trace]:  8: C:\WINDOWS\SYSTEM32\ntdll.dll:RtlUserThreadStart+0x21
```