### PR TITLE
[client] probe Wayland backend first

### DIFF
--- a/client/displayservers/CMakeLists.txt
+++ b/client/displayservers/CMakeLists.txt
@@ -19,12 +19,12 @@ function(add_displayserver name)
 endfunction()
 
 # Add/remove displayservers here!
-if (ENABLE_X11)
-  add_displayserver(X11)
-endif()
-
 if (ENABLE_WAYLAND)
   add_displayserver(Wayland)
+endif()
+
+if (ENABLE_X11)
+  add_displayserver(X11)
 endif()
 
 # SDL must be last as it's the fallback implemntation


### PR DESCRIPTION
`$DISPLAY` will be set even in a Wayland session, which causes LG to
initialize itself under Xwayland unless it is explicitly compiled with
`-DENABLE_X11=OFF`.

We could add a Wayland check within the X11 backend, but reordering the
code-generated array seems like a better solution.