### PR TITLE
[client] wayland: add stubs for OpenGL functions

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -619,6 +619,26 @@ static void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 }
 #endif
 
+static LG_DSGLContext waylandGLCreateContext(void)
+{
+  return NULL;
+}
+
+static void waylandGLDeleteContext(LG_DSGLContext context)
+{
+  // FIXME: implement.
+}
+
+static void waylandGLMakeCurrent(LG_DSGLContext context)
+{
+  // FIXME: implement.
+}
+
+static void waylandGLSetSwapInterval(int interval)
+{
+  // FIXME: implement.
+}
+
 static void waylandGLSwapBuffers(void)
 {
   // FIXME: implement.
@@ -1143,6 +1163,10 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .eglSwapBuffers     = waylandEGLSwapBuffers,
 #endif
 
+  .glCreateContext    = waylandGLCreateContext,
+  .glDeleteContext    = waylandGLDeleteContext,
+  .glMakeCurrent      = waylandGLMakeCurrent,
+  .glSetSwapInterval  = waylandGLSetSwapInterval,
   .glSwapBuffers      = waylandGLSwapBuffers,
 
   .showPointer        = waylandShowPointer,


### PR DESCRIPTION
This allows the client to run on Wayland, even though OpenGL doesn't work.