### PR TITLE
Implement OpenGL backend for Wayland

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -53,6 +53,10 @@ add_compile_options(
 set(EXE_FLAGS "-Wl,--gc-sections -z noexecstack")
 set(CMAKE_C_STANDARD 11)
 
+if (ENABLE_OPENGL)
+  add_definitions(-D ENABLE_OPENGL)
+endif()
+
 if (ENABLE_EGL)
   add_definitions(-D ENABLE_EGL)
 endif()

--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -76,6 +76,7 @@ static bool sdlInit(const LG_DSInitParams params)
     return false;
   }
 
+#ifdef ENABLE_OPENGL
   if (params.opengl)
   {
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER      , 1);
@@ -85,6 +86,7 @@ static bool sdlInit(const LG_DSInitParams params)
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE        , 8);
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE         , 8);
   }
+#endif
 
   sdl.window = SDL_CreateWindow(
     params.title,
@@ -254,6 +256,7 @@ static void sdlEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 }
 #endif //ENABLE_EGL
 
+#ifdef ENABLE_OPENGL
 static LG_DSGLContext sdlGLCreateContext(void)
 {
   return (LG_DSGLContext)SDL_GL_CreateContext(sdl.window);
@@ -278,6 +281,7 @@ static void sdlGLSwapBuffers(void)
 {
   SDL_GL_SwapWindow(sdl.window);
 }
+#endif //ENABLE_OPENGL
 
 static int sdlEventFilter(void * userdata, SDL_Event * event)
 {
@@ -517,11 +521,13 @@ struct LG_DisplayServerOps LGDS_SDL =
   .eglSwapBuffers      = sdlEGLSwapBuffers,
 #endif
 
+#ifdef ENABLE_OPENGL
   .glCreateContext     = sdlGLCreateContext,
   .glDeleteContext     = sdlGLDeleteContext,
   .glMakeCurrent       = sdlGLMakeCurrent,
   .glSetSwapInterval   = sdlGLSetSwapInterval,
   .glSwapBuffers       = sdlGLSwapBuffers,
+#endif
 
   .showPointer         = sdlShowPointer,
   .grabPointer         = sdlGrabPointer,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -31,9 +31,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <SDL2/SDL.h>
 #include <wayland-client.h>
 
-#include <wayland-egl.h>
-#include "egl_dynprocs.h"
-#include <EGL/eglext.h>
+#if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
+# include <wayland-egl.h>
+# include "egl_dynprocs.h"
+# include <EGL/eglext.h>
+#endif
 
 #include "app.h"
 #include "common/debug.h"
@@ -66,9 +68,11 @@ struct WaylandDSState
   struct wl_egl_window * eglWindow;
 #endif
 
+#ifdef ENABLE_OPENGL
   EGLDisplay glDisplay;
   EGLConfig glConfig;
   EGLSurface glSurface;
+#endif
 
   struct xdg_wm_base * xdgWmBase;
   struct xdg_surface * xdgSurface;
@@ -559,6 +563,7 @@ static bool waylandInit(const LG_DSInitParams params)
     wl_surface_commit(wm.cursor);
   }
 
+#ifdef ENABLE_OPENGL
   if (params.opengl)
   {
     EGLint attr[] =
@@ -604,6 +609,7 @@ static bool waylandInit(const LG_DSInitParams params)
       return false;
     }
   }
+#endif
 
   wm.width = params.w;
   wm.height = params.h;
@@ -619,6 +625,14 @@ static void waylandShutdown(void)
 {
 }
 
+#ifdef ENABLE_EGL
+static EGLNativeWindowType waylandGetEGLNativeWindow(void)
+{
+  return (EGLNativeWindowType) wm.eglWindow;
+}
+#endif
+
+#if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
 static EGLDisplay waylandGetEGLDisplay(void)
 {
   EGLNativeDisplayType native = (EGLNativeDisplayType) wm.display;
@@ -643,13 +657,6 @@ static EGLDisplay waylandGetEGLDisplay(void)
   return eglGetDisplay(native);
 }
 
-#ifdef ENABLE_EGL
-static EGLNativeWindowType waylandGetEGLNativeWindow(void)
-{
-  return (EGLNativeWindowType) wm.eglWindow;
-}
-#endif
-
 static void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 {
   eglSwapBuffers(display, surface);
@@ -668,6 +675,9 @@ static void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
     wm.resizeSerial = 0;
   }
 }
+#endif
+
+#ifdef ENABLE_OPENGL
 static LG_DSGLContext waylandGLCreateContext(void)
 {
   eglBindAPI(EGL_OPENGL_API);
@@ -693,6 +703,7 @@ static void waylandGLSwapBuffers(void)
 {
   waylandEGLSwapBuffers(wm.glDisplay, wm.glSurface);
 }
+#endif
 
 static void waylandShowPointer(bool show)
 {
@@ -1213,11 +1224,13 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .eglSwapBuffers     = waylandEGLSwapBuffers,
 #endif
 
+#ifdef ENABLE_OPENGL
   .glCreateContext    = waylandGLCreateContext,
   .glDeleteContext    = waylandGLDeleteContext,
   .glMakeCurrent      = waylandGLMakeCurrent,
   .glSetSwapInterval  = waylandGLSetSwapInterval,
   .glSwapBuffers      = waylandGLSwapBuffers,
+#endif
 
   .showPointer        = waylandShowPointer,
   .grabPointer        = waylandGrabPointer,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -619,6 +619,26 @@ static void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 }
 #endif
 
+static LG_DSGLContext waylandGLCreateContext(void)
+{
+  return NULL;
+}
+
+static void waylandGLDeleteContext(LG_DSGLContext context)
+{
+  // FIXME: implement.
+}
+
+static void waylandGLMakeCurrent(LG_DSGLContext context)
+{
+  // FIXME: implement.
+}
+
+static void waylandGLSetSwapInterval(int interval)
+{
+  // FIXME: implement.
+}
+
 static void waylandGLSwapBuffers(void)
 {
   // FIXME: implement.
@@ -1143,6 +1163,10 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .eglSwapBuffers     = waylandEGLSwapBuffers,
 #endif
 
+  .glCreateContext    = waylandGLCreateContext,
+  .glDeleteContext    = waylandGLDeleteContext,
+  .glMakeCurrent      = waylandGLMakeCurrent,
+  .glSetSwapInterval  = waylandGLSetSwapInterval,
   .glSwapBuffers      = waylandGLSwapBuffers,
 
   .showPointer        = waylandShowPointer,

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -146,6 +146,7 @@ static bool x11Init(const LG_DSInitParams params)
   };
   unsigned long swaMask = CWEventMask;
 
+#ifdef ENABLE_OPENGL
   if (params.opengl)
   {
     GLint glXAttribs[] =
@@ -174,6 +175,7 @@ static bool x11Init(const LG_DSInitParams params)
         x11.visual->visual, AllocNone);
     swaMask |= CWColormap;
   }
+#endif
 
   x11.window = XCreateWindow(
       x11.display,
@@ -911,6 +913,7 @@ static void x11EGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 }
 #endif
 
+#ifdef ENABLE_OPENGL
 static LG_DSGLContext x11GLCreateContext(void)
 {
   return (LG_DSGLContext)
@@ -936,6 +939,7 @@ static void x11GLSwapBuffers(void)
 {
   glXSwapBuffers(x11.display, x11.window);
 }
+#endif
 
 static void x11ShowPointer(bool show)
 {
@@ -1488,11 +1492,13 @@ struct LG_DisplayServerOps LGDS_X11 =
   .getEGLNativeWindow = x11GetEGLNativeWindow,
   .eglSwapBuffers     = x11EGLSwapBuffers,
 #endif
+#ifdef ENABLE_OPENGL
   .glCreateContext    = x11GLCreateContext,
   .glDeleteContext    = x11GLDeleteContext,
   .glMakeCurrent      = x11GLMakeCurrent,
   .glSetSwapInterval  = x11GLSetSwapInterval,
   .glSwapBuffers      = x11GLSwapBuffers,
+#endif
   .showPointer        = x11ShowPointer,
   .grabPointer        = x11GrabPointer,
   .ungrabPointer      = x11UngrabPointer,

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -64,11 +64,13 @@ EGLNativeWindowType app_getEGLNativeWindow(void);
 void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface);
 #endif
 
+#ifdef ENABLE_OPENGL
 LG_DSGLContext app_glCreateContext(void);
 void app_glDeleteContext(LG_DSGLContext context);
 void app_glMakeCurrent(LG_DSGLContext context);
 void app_glSetSwapInterval(int interval);
 void app_glSwapBuffers(void);
+#endif
 
 void app_clipboardRelease(void);
 void app_clipboardNotify(const LG_ClipboardData type, size_t size);

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -109,12 +109,14 @@ struct LG_DisplayServerOps
   void (*eglSwapBuffers)(EGLDisplay display, EGLSurface surface);
 #endif
 
+#ifdef ENABLE_OPENGL
   /* opengl platform specific methods */
   LG_DSGLContext (*glCreateContext)(void);
   void (*glDeleteContext)(LG_DSGLContext context);
   void (*glMakeCurrent)(LG_DSGLContext context);
   void (*glSetSwapInterval)(int interval);
   void (*glSwapBuffers)(void);
+#endif
 
   /* dm specific cursor implementations */
   void (*showPointer)(bool show);
@@ -159,6 +161,12 @@ struct LG_DisplayServerOps
   #define ASSERT_EGL_FN(x)
 #endif
 
+#ifdef ENABLE_OPENGL
+  #define ASSERT_OPENGL_FN(x) assert(x)
+#else
+  #define ASSERT_OPENGL_FN(x)
+#endif
+
 #define ASSERT_LG_DS_VALID(x) \
   assert((x)->probe              ); \
   assert((x)->earlyInit          ); \
@@ -170,11 +178,11 @@ struct LG_DisplayServerOps
   ASSERT_EGL_FN((x)->getEGLDisplay      ); \
   ASSERT_EGL_FN((x)->getEGLNativeWindow ); \
   ASSERT_EGL_FN((x)->eglSwapBuffers     ); \
-  assert((x)->glCreateContext    ); \
-  assert((x)->glDeleteContext    ); \
-  assert((x)->glMakeCurrent      ); \
-  assert((x)->glSetSwapInterval  ); \
-  assert((x)->glSwapBuffers      ); \
+  ASSERT_OPENGL_FN((x)->glCreateContext  ); \
+  ASSERT_OPENGL_FN((x)->glDeleteContext  ); \
+  ASSERT_OPENGL_FN((x)->glMakeCurrent    ); \
+  ASSERT_OPENGL_FN((x)->glSetSwapInterval); \
+  ASSERT_OPENGL_FN((x)->glSwapBuffers    ); \
   assert((x)->showPointer        ); \
   assert((x)->grabPointer        ); \
   assert((x)->ungrabPointer      ); \

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -585,6 +585,7 @@ void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface)
 }
 #endif
 
+#ifdef ENABLE_OPENGL
 LG_DSGLContext app_glCreateContext(void)
 {
   return g_state.ds->glCreateContext();
@@ -609,6 +610,7 @@ void app_glSwapBuffers(void)
 {
   g_state.ds->glSwapBuffers();
 }
+#endif
 
 void app_alert(LG_MsgAlert type, const char * fmt, ...)
 {


### PR DESCRIPTION
This PR basically borrows the context creation code from the EGL backend to create OpenGL contexts on Wayland, since that is the only supported way to do so. I also made OpenGL support code optional.

This supersedes #427.