### PR TITLE
[host] nvfbc: generate cursor position update on startup

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -351,6 +351,8 @@ static CaptureResult nvfbc_getFrame(FrameBuffer * frame)
 
 static int pointerThread(void * unused)
 {
+  lgSignalEvent(this->cursorEvents[1]);
+
   while(!this->stop)
   {
     LGEvent * events[2];

--- a/host/platform/Windows/src/mousehook.c
+++ b/host/platform/Windows/src/mousehook.c
@@ -56,6 +56,13 @@ static bool switchDesktopAndHook(void)
   }
   CloseDesktop(desk);
 
+  POINT position;
+  GetCursorPos(&position);
+
+  mouseHook.x = position.x;
+  mouseHook.y = position.y;
+  mouseHook.callback(position.x, position.y);
+
   mouseHook.hook = SetWindowsHookEx(WH_MOUSE_LL, mouseHook_hook, NULL, 0);
   if (!mouseHook.hook)
   {
@@ -84,11 +91,11 @@ static DWORD WINAPI threadProc(LPVOID lParam) {
     return 0;
   }
 
+  mouseHook.callback = (MouseHookFn)lParam;
   if (!switchDesktopAndHook())
     return 0;
 
   mouseHook.installed = true;
-  mouseHook.callback  = (MouseHookFn)lParam;
 
   HWINEVENTHOOK eventHook = SetWinEventHook(
       EVENT_SYSTEM_DESKTOPSWITCH, EVENT_SYSTEM_DESKTOPSWITCH, NULL,


### PR DESCRIPTION
Before this commit, the NvFBC backend only generated the first cursor
position update when the mouse moves. Therefore, if the user does
not move the mouse, the cursor will be shown at (0, 0), which is not
ideal.

This commit changes this behaviour to unconditionally generate a
cursor update when the mouse hook initializes.