### PR TITLE
[client] wayland: check for the Wayland platform extension

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -639,14 +639,14 @@ static EGLDisplay waylandGetEGLDisplay(void)
 
   const char *early_exts = eglQueryString(NULL, EGL_EXTENSIONS);
 
-  if (strstr(early_exts, "EGL_KHR_platform_base") != NULL &&
+  if (strstr(early_exts, "EGL_KHR_platform_wayland") != NULL &&
       g_egl_dynProcs.eglGetPlatformDisplay)
   {
     DEBUG_INFO("Using eglGetPlatformDisplay");
     return g_egl_dynProcs.eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, native, NULL);
   }
 
-  if (strstr(early_exts, "EGL_EXT_platform_base") != NULL &&
+  if (strstr(early_exts, "EGL_EXT_platform_wayland") != NULL &&
       g_egl_dynProcs.eglGetPlatformDisplayEXT)
   {
     DEBUG_INFO("Using eglGetPlatformDisplayEXT");


### PR DESCRIPTION
We used to test for the EGL_KHR_platform_base and EGL_EXT_platform_base,
but those only really signal the availability of eglGetPlatformDisplay(EXT)
functions, not whether the constant EGL_PLATFORM_WAYLAND_KHR or
EGL_PLATFORM_WAYLAND_EXT is accepted by their respective functions.

Instead, we switch to test for the extensions that tells us whether the
Wayland platform is supported.