### PR TITLE
[client] spice/wayland: improve cursor tracking logic

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -230,13 +230,11 @@ static const struct wl_registry_listener registryListener = {
 static void pointerMotionHandler(void * data, struct wl_pointer * pointer,
     uint32_t serial, wl_fixed_t sxW, wl_fixed_t syW)
 {
-  if (wm.relativePointer)
-    return;
-
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
   app_updateCursorPos(sx, sy);
-  app_handleMouseBasic();
+  if (!wm.relativePointer)
+    app_handleMouseBasic();
 }
 
 static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
@@ -253,8 +251,10 @@ static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
 
   int sx = wl_fixed_to_int(sxW);
   int sy = wl_fixed_to_int(syW);
+  app_resyncMouseBasic();
   app_updateCursorPos(sx, sy);
-  app_handleMouseBasic();
+  if (!wm.relativePointer)
+    app_handleMouseBasic();
 }
 
 static void pointerLeaveHandler(void * data, struct wl_pointer * pointer,
@@ -810,6 +810,9 @@ static void waylandUngrabPointer(void)
     zwp_confined_pointer_v1_destroy(wm.confinedPointer);
     wm.confinedPointer = NULL;
   }
+
+  app_resyncMouseBasic();
+  app_handleMouseBasic();
 }
 
 static void waylandGrabKeyboard(void)
@@ -837,7 +840,7 @@ static void waylandWarpPointer(int x, int y, bool exiting)
 
 static void waylandRealignPointer(void)
 {
-  app_handleMouseBasic();
+  app_resyncMouseBasic();
 }
 
 static bool waylandIsValidPointerPos(int x, int y)

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -46,6 +46,7 @@ void app_handleResizeEvent(int w, int h, const struct Border border);
 void app_handleMouseGrabbed(double ex, double ey);
 void app_handleMouseNormal(double ex, double ey);
 void app_handleMouseBasic(void);
+void app_resyncMouseBasic(void);
 void app_handleButtonPress(int button);
 void app_handleButtonRelease(int button);
 void app_handleKeyPress(int scancode);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -297,7 +297,10 @@ static int cursorThread(void * unused)
 
       // if the state just became valid
       if (valid != true && app_inputEnabled())
+      {
         core_alignToGuest();
+        app_resyncMouseBasic();
+      }
     }
 
     lgmpClientMessageDone(queue);

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -234,6 +234,9 @@ struct CursorState
 
   /* the guest's cursor position */
   struct CursorInfo guest;
+
+  /* the projected position after move, for app_handleMouseBasic only */
+  struct Point projected;
 };
 
 // forwards


### PR DESCRIPTION
One of the major issues with the old tracking code is a data race
between the cursor thread updating g_cursor.guest and the
app_handleMouseBasic function. Specifically, the latter may have
sent mouse input via spice that has not been processed by the guest
and updated g_cursor.guest, but the guest may overwrite g_cursor.guest
to a previous state before the input is processed. This causes some
movements to be doubled. Eventually, the cursor positions will
synchronize, but this nevertheless causes a lot of jitter.

In this commit, we introduce a new field g_cursor.projected, which
is unambiguously the position of the cursor after taking into account
all the input already sent via spice. This is synced up to the guest
cursor upon entering the window and when the host restarts. Afterwards,
all mouse movements will be based on this position. This eliminates
all cursor jitter as far as I could tell.

Also, the cursor is now synced to the host position when exiting
capture mode.

A downside of this commit is that if the 1:1 movement patch is not
correctly applied, the cursor position would be wildly off instead
of simply jittering, but that is an unsupported configuration and
should not matter.

Also unsupported is when an application in guest moves the cursor
programmatically and bypassing spice. When using those applications,
capture mode must be on. Before this commit, we try to move the guest
cursor back to where it should be, but it's inherently fragile and
may lead to scenarios such as wild movements in first-person shooters.