### PR TITLE
[host] windows: move log path to %ProgramData%\Looking Glass (host)

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -40,12 +40,9 @@ PASTE CLIENT OUTPUT HERE
 ```
 
 The entire (not truncated) log file from the host application (if applicable).
-To obtain this locate the log file on your system, it will be in one of the
-following two locations depending on how you are launching the Looking Glass Host
-application:
+Normally, this is found on the guest system at:
 
-  * C:\Windows\Temp\looking-glass.txt
-  * C:\Users\YOUR_USER\AppData\Local\Temp\looking-glass.txt
+    %ProgramData%\Looking Glass (host)\looking-glass-host.txt
 
 This log may be quite long, please delete the file first and then proceed to
 launch the host and reproduce the issue so that the log only contains the

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -2113,7 +2113,8 @@ restart:
     {
       DEBUG_BREAK();
       DEBUG_INFO("Please check the host application is running and is the correct version");
-      DEBUG_INFO("Check the host log in your guest at %%TEMP%%\\looking-glass-host.txt");
+      DEBUG_INFO("Check the host log in your guest at: "
+        "%%ProgramData%%\\Looking Glass (host)\\looking-glass-host.txt");
       DEBUG_INFO("Continuing to wait...");
     }
 

--- a/host/README.md
+++ b/host/README.md
@@ -54,16 +54,19 @@ The resulting installer will be at
 
 ## Where is the log?
 
-It is in your user's temp directory:
+The log file for the host application is located at:
 
-    %TEMP%\looking-glass-host.txt
+    %ProgramData%\Looking Glass (host)\looking-glass-host.txt
 
-Or if running as a system service it will be located in:
+You can also find out where the file is by right clicking on the tray icon and
+selecting "Log File Location".
 
-    C:\Windows\Temp\looking-glass-host.txt
+The log file for the looking glass service is located at:
 
-You can find out where the file is by right clicking on the tray icon and
-selecting "Log File Location"
+	%ProgramData%\Looking Glass (host)\looking-glass-host-service.txt
+
+This is useful for troubleshooting errors related to the host application not
+starting.
 
 ### High priority capture using DXGI and Secure Desktop (UAC) capture support
 

--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(platform_Windows
 	userenv
 	wtsapi32
 	psapi
+	shlwapi
 )
 
 target_include_directories(platform_Windows

--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -172,7 +172,7 @@ Section /o "Desktop Shortcut" Section3
   StrCpy $option_desktop 1
 SectionEnd
 
-Section /o "Start Menu Shortcut" Section4
+Section "Start Menu Shortcut" Section4
   StrCpy $option_startMenu 1
 SectionEnd
 
@@ -180,7 +180,10 @@ Section "-Hidden Start Menu" Section5
   SetShellVarContext all
   
   ${If} $option_startMenu == 1
-    CreateShortCut "$SMPROGRAMS\Looking Glass (host).lnk" $INSTDIR\looking-glass-host.exe
+    CreateDirectory "$APPDATA\Looking Glass (host)"
+    CreateDirectory "$SMPROGRAMS\Looking Glass (host)"
+    CreateShortCut "$SMPROGRAMS\Looking Glass (host)\Looking Glass (host).lnk" $INSTDIR\looking-glass-host.exe
+    CreateShortCut "$SMPROGRAMS\Looking Glass (host)\Looking Glass Logs.lnk" "$APPDATA\Looking Glass (host)"
   ${EndIf}
 
   ${If} $option_desktop == 1

--- a/host/platform/Windows/src/platform.h
+++ b/host/platform/Windows/src/platform.h
@@ -30,4 +30,5 @@ struct MSG_CALL_FUNCTION
   LPARAM       lParam;
 };
 
+const char *getSystemLogDirectory(void);
 LRESULT sendAppMessage(UINT Msg, WPARAM wParam, LPARAM lParam);

--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -20,6 +20,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "interface/platform.h"
 #include "common/ivshmem.h"
 #include "service.h"
+#include "platform.h"
 
 #include <stdio.h>
 #include <stdbool.h>
@@ -29,6 +30,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <time.h>
 
 #include <windows.h>
+#include <shlwapi.h>
 #include <winsvc.h>
 #include <psapi.h>
 #include <sddl.h>
@@ -37,6 +39,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #define SVCNAME   "Looking Glass (host)"
 #define SVC_ERROR ((DWORD)0xC0020001L)
+#define LOG_NAME  "looking-glass-host-service.txt"
 
 /*
  * Windows 10 provides this API via kernel32.dll as well as advapi32.dll and
@@ -112,11 +115,9 @@ static bool setupAPI(void)
 
 static void setupLogging(void)
 {
-  char tempPath[MAX_PATH+1];
-  GetTempPathA(sizeof(tempPath), tempPath);
-  int len = snprintf(NULL, 0, "%slooking-glass-host-service.txt", tempPath);
-  char * logFilePath = malloc(len + 1);
-  sprintf(logFilePath, "%slooking-glass-host-service.txt", tempPath);
+  char logFilePath[MAX_PATH];
+  if (!PathCombineA(logFilePath, getSystemLogDirectory(), LOG_NAME))
+    strcpy(logFilePath, LOG_NAME);
   service.logFile = fopen(logFilePath, "a+");
   setbuf(service.logFile, NULL);
   doLog("Startup\n");


### PR DESCRIPTION
Instead of using %windir%\Temp, which is not accessible by default and
contains a lot of unrelated files, as the location for our log files,
this PR moves it to %ProgramData%\Looking Glass (host), which will
be a dedicated directory just for the LG host log files. This applies
to both the host application logs and the service logs.

Also, we now switched to using PathCombineA from shlwapi.dll instead
of using snprintf, which greatly simplifies the code. PathCombineA
guarantees that the path would not overflow a buffer of MAX_PATH.

Finally, this PR makes the installer create a shortcut to the log directory.