### PR TITLE
[client] wayland: fix copying rich text into guest

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -644,11 +644,12 @@ static void dataOfferHandleOffer(void * data, struct wl_data_offer * offer,
     const char * mimetype)
 {
   enum LG_ClipboardData type = mimetypeToCbType(mimetype);
-  // Oftentimes we'll get text/html alongside text/png, but would prefer to send
-  // image/png. In general, prefer images over text content.
+  // We almost never prefer text/html, as that's used to represent rich text.
+  // Since we can't copy or paste rich text, we should instead prefer actual
+  // images or plain text.
   if (type != LG_CLIPBOARD_DATA_NONE &&
       (wcb.stashedType == LG_CLIPBOARD_DATA_NONE ||
-       wcb.stashedType == LG_CLIPBOARD_DATA_TEXT))
+       strstr(wcb.stashedMimetype, "html")))
   {
     wcb.stashedType = type;
     if (wcb.stashedMimetype)


### PR DESCRIPTION
Before this, copying rich text ends up with a lot of funky behaviour,
for example:
* copying text from Discord shows up as HTML unless pasted into a text
  editor first
* copying text from Firefox shows up as the single letter h

This commit fixes all the above issues.

Due to the change in logic, we now use the first text format offered
instead of the last, which is almost certainly the preferred form.
Doing this gets us proper Unicode support, or Unicode characters would
end up as escapes of the form \uXXXX (this is used in the fallback
forms for applications without UTF-8 support).