### PR TITLE
[host] nvfbc: cleanup threads created by nvfbc_init on failure

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -201,6 +201,8 @@ static bool nvfbc_init(void)
   if (!lgCreateThread("NvFBCPointer", pointerThread, NULL, &this->pointerThread))
   {
     DEBUG_ERROR("Failed to create the NvFBCPointer thread");
+    mouseHook_remove();
+    dwmUnforceComposition();
     return false;
   }
 


### PR DESCRIPTION
mouseHook_install and dwmForceComposition both create threads, but these
are only freed in nvfbc_deinit which is not called if nvfbc_init fails.
These should be freed if the pointer thread fails to be created, as
nothing else could be cleaning it up.