### PR TITLE
[host] nvfbc: fix resource leak when pointer thread creation fails

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -65,7 +65,8 @@ struct iface
 
 static struct iface * this = NULL;
 
-static void nvfbc_free();
+static bool nvfbc_deinit(void);
+static void nvfbc_free(void);
 static int pointerThread(void * unused);
 
 static void getDesktopSize(unsigned int * width, unsigned int * height, unsigned int * dpi)
@@ -201,8 +202,7 @@ static bool nvfbc_init(void)
   if (!lgCreateThread("NvFBCPointer", pointerThread, NULL, &this->pointerThread))
   {
     DEBUG_ERROR("Failed to create the NvFBCPointer thread");
-    mouseHook_remove();
-    dwmUnforceComposition();
+    nvfbc_deinit();
     return false;
   }
 


### PR DESCRIPTION
Moving NvFBCToSysSetup to nvfbc_init means that when the pointer thread
fails to be created, NvFBCToSysRelease needs to be called.

To resolve such cleanup issues in the future, we instead call nvfbc_deinit,
which should cleanup everything that needs to be cleaned up. fails.