### PR TITLE
[client] egl: create 24-bit colour context

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -530,7 +530,7 @@ bool egl_render_startup(void * opaque)
 
   EGLint attr[] =
   {
-    EGL_BUFFER_SIZE    , 32,
+    EGL_BUFFER_SIZE    , 24,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
     EGL_SAMPLE_BUFFERS , maxSamples > 0 ? 1 : 0,
     EGL_SAMPLES        , maxSamples,

--- a/client/renderers/EGL/help.c
+++ b/client/renderers/EGL/help.c
@@ -186,16 +186,13 @@ void egl_help_render(EGL_Help * help, const float scaleX, const float scaleY)
     return;
 
   glEnable(GL_BLEND);
-  glBlendColor(0, 0, 0, 0.5);
-  glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // render the background first
   egl_shader_use(help->shaderBG);
   glUniform2f(help->uScreenBG, scaleX     , scaleY      );
   glUniform2f(help->uSizeBG  , help->width, help->height);
   egl_model_render(help->model);
-
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // render the texture over the background
   egl_shader_use(help->shader);

--- a/client/renderers/EGL/shader/help_bg.frag
+++ b/client/renderers/EGL/shader/help_bg.frag
@@ -4,5 +4,5 @@ out highp vec4 color;
 
 void main()
 {
-  color = vec4(0.0, 0.0, 1.0, 1.0);
+  color = vec4(0.0, 0.0, 1.0, 0.5);
 }


### PR DESCRIPTION
This should prevent the looking-glass-client window from having an alpha
channel. On Wayland, the alpha channel is used to compose the window onto
the desktop, so the wallpaper would bleed through unless set to complete
opaque.

We worked around this by using constant alpha for rendering, but it was
not sustainable. Instead, we should just ask for 24-bit context.

An alternative would to continue using 32-bit colour and the following
blend function:
glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);

This approach is implemented in #443.