### PR TITLE
[client] egl: ensure blended alpha is always opaque

### DIFF
--- a/client/renderers/EGL/alert.c
+++ b/client/renderers/EGL/alert.c
@@ -200,7 +200,7 @@ void egl_alert_render(EGL_Alert * alert, const float scaleX, const float scaleY)
     return;
 
   glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 
   // render the background first
   egl_shader_use(alert->shaderBG);

--- a/client/renderers/EGL/fps.c
+++ b/client/renderers/EGL/fps.c
@@ -178,7 +178,7 @@ void egl_fps_render(EGL_FPS * fps, const float scaleX, const float scaleY)
     return;
 
   glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 
   // render the background first
   egl_shader_use(fps->shaderBG);

--- a/client/renderers/EGL/help.c
+++ b/client/renderers/EGL/help.c
@@ -186,16 +186,13 @@ void egl_help_render(EGL_Help * help, const float scaleX, const float scaleY)
     return;
 
   glEnable(GL_BLEND);
-  glBlendColor(0, 0, 0, 0.5);
-  glBlendFunc(GL_CONSTANT_ALPHA, GL_ONE_MINUS_CONSTANT_ALPHA);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 
   // render the background first
   egl_shader_use(help->shaderBG);
   glUniform2f(help->uScreenBG, scaleX     , scaleY      );
   glUniform2f(help->uSizeBG  , help->width, help->height);
   egl_model_render(help->model);
-
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // render the texture over the background
   egl_shader_use(help->shader);

--- a/client/renderers/EGL/shader/help_bg.frag
+++ b/client/renderers/EGL/shader/help_bg.frag
@@ -4,5 +4,5 @@ out highp vec4 color;
 
 void main()
 {
-  color = vec4(0.0, 0.0, 1.0, 1.0);
+  color = vec4(0.0, 0.0, 1.0, 0.5);
 }


### PR DESCRIPTION
When using glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA), the
resulting alpha channel is not fully opaque. On Wayland, the alpha
channel is used to compose the window onto the desktop, so the
wallpaper would bleed through if our window is not fully opaque.

glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE)
ensures that the alpha channel is opaque while blending colours as
before.

The alternative solution is #442.