### PR TITLE
[client] spice: don't send zero deltas for Wayland input

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1450,6 +1450,9 @@ void app_handleMouseBasic()
   int x = (int) round((px - local.x) / g_cursor.dpiScale);
   int y = (int) round((py - local.y) / g_cursor.dpiScale);
 
+  if (!x && !y)
+    return;
+
   g_cursor.guest.x += x;
   g_cursor.guest.y += y;
 


### PR DESCRIPTION
While a compositor will never send us 0-delta motion events, they can
still end up as 0-deltas post-projection, consuming QEMU buffer space
for no reason.

This should help with mouse skipping issues.