### PR TITLE
[client] spice: fix input:grabKeyboardOnFocus

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -53,10 +53,17 @@ void app_handleFocusEvent(bool focused)
   if (!core_inputEnabled())
     return;
 
-  if (!focused)
+  if (focused)
+  {
+    if (g_params.grabKeyboardOnFocus)
+      g_state.ds->grabKeyboard();
+  }
+  else
   {
     core_setGrabQuiet(false);
     core_setCursorInView(false);
+    if (g_params.grabKeyboardOnFocus)
+      g_state.ds->ungrabKeyboard();
   }
 
   g_cursor.realign = true;

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -77,8 +77,6 @@ void core_setCursorInView(bool enable)
 
     if (warpSupport)
       g_state.ds->ungrabPointer();
-
-    g_state.ds->ungrabKeyboard();
   }
 
   g_cursor.warpState = WARP_STATE_ON;
@@ -126,7 +124,7 @@ void core_setGrabQuiet(bool enable)
   {
     if (g_params.grabKeyboard)
     {
-      if (!g_state.focused || g_params.captureInputOnly)
+      if (!g_params.grabKeyboardOnFocus || !g_state.focused || g_params.captureInputOnly)
         g_state.ds->ungrabKeyboard();
     }
 


### PR DESCRIPTION
It appears that at some point in the refactoring process, the logic for
grabKeyboardOnFocus was lost. This commit adds back the logic, allowing
grabKeyboardOnFocus to work once again.