### PR TITLE
[client] spice: correctly ungrab keyboard when grabKeyboardOnFocus=no

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1563,7 +1563,7 @@ static void setGrabQuiet(bool enable)
   {
     if (params.grabKeyboard)
     {
-      if (!g_state.focused || params.captureInputOnly)
+      if (!params.grabKeyboardOnFocus || !g_state.focused || params.captureInputOnly)
         g_state.ds->ungrabKeyboard();
     }
 


### PR DESCRIPTION
When input:grabKeyboardOnFocus=no, exiting capture mode should ungrab
the keyboard. Otherwise, focusing the window doesn't grab the keyboard,
but toggling capture mode would leave the keyboard stuck in a grabbed
state until defocused.