### PR TITLE
[client] renderer: add ability to toggle the FPS display

### DIFF
--- a/client/include/app.h
+++ b/client/include/app.h
@@ -115,4 +115,9 @@ void app_releaseAllKeybinds(void);
  */
 void app_showHelp(bool show);
 
+/**
+ * Changes whether the FPS is displayed or not.
+ */
+void app_showFPS(bool showFPS);
+
 #endif

--- a/client/include/interface/renderer.h
+++ b/client/include/interface/renderer.h
@@ -36,6 +36,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
    (x)->on_mouse_event && \
    (x)->on_alert       && \
    (x)->on_help        && \
+   (x)->on_show_fps    && \
    (x)->render_startup && \
    (x)->render         && \
    (x)->update_fps)
@@ -44,7 +45,6 @@ typedef struct LG_RendererParams
 {
 //  TTF_Font * font;
 //  TTF_Font * alertFont;
-  bool       showFPS;
   bool       quickSplash;
 }
 LG_RendererParams;
@@ -116,6 +116,7 @@ typedef bool         (* LG_RendererOnFrameFormat)(void * opaque, const LG_Render
 typedef bool         (* LG_RendererOnFrame      )(void * opaque, const FrameBuffer * frame, int dmaFD);
 typedef void         (* LG_RendererOnAlert      )(void * opaque, const LG_MsgAlert alert, const char * message, bool ** closeFlag);
 typedef void         (* LG_RendererOnHelp       )(void * opaque, const char * message);
+typedef void         (* LG_RendererOnShowFPS    )(void * opaque, bool showFPS);
 typedef bool         (* LG_RendererRenderStartup)(void * opaque);
 typedef bool         (* LG_RendererRender       )(void * opaque, LG_RendererRotate rotate);
 typedef void         (* LG_RendererUpdateFPS    )(void * opaque, const float avgUPS, const float avgFPS);
@@ -137,6 +138,7 @@ typedef struct LG_Renderer
   LG_RendererOnFrame        on_frame;
   LG_RendererOnAlert        on_alert;
   LG_RendererOnHelp         on_help;
+  LG_RendererOnShowFPS      on_show_fps;
   LG_RendererRenderStartup  render_startup;
   LG_RendererRender         render;
   LG_RendererUpdateFPS      update_fps;

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -511,6 +511,12 @@ void egl_on_help(void * opaque, const char * message)
   egl_help_set_text(this->help, message);
 }
 
+void egl_on_show_fps(void * opaque, bool showFPS)
+{
+  struct Inst * this = (struct Inst *)opaque;
+  egl_fps_set_display(this->fps, showFPS);
+}
+
 bool egl_render_startup(void * opaque)
 {
   struct Inst * this = (struct Inst *)opaque;
@@ -750,9 +756,6 @@ bool egl_render(void * opaque, LG_RendererRotate rotate)
 void egl_update_fps(void * opaque, const float avgUPS, const float avgFPS)
 {
   struct Inst * this = (struct Inst *)opaque;
-  if (!this->params.showFPS)
-    return;
-
   egl_fps_update(this->fps, avgUPS, avgFPS);
 }
 
@@ -772,6 +775,7 @@ struct LG_Renderer LGR_EGL =
   .on_frame        = egl_on_frame,
   .on_alert        = egl_on_alert,
   .on_help         = egl_on_help,
+  .on_show_fps     = egl_on_show_fps,
   .render_startup  = egl_render_startup,
   .render          = egl_render,
   .update_fps      = egl_update_fps

--- a/client/renderers/EGL/fps.c
+++ b/client/renderers/EGL/fps.c
@@ -42,6 +42,7 @@ struct EGL_FPS
   EGL_Shader  * shaderBG;
   EGL_Model   * model;
 
+  bool  display;
   bool  ready;
   int   iwidth, iheight;
   float width, height;
@@ -132,8 +133,16 @@ void egl_fps_free(EGL_FPS ** fps)
   *fps = NULL;
 }
 
+void egl_fps_set_display(EGL_FPS * fps, bool display)
+{
+  fps->display = display;
+}
+
 void egl_fps_update(EGL_FPS * fps, const float avgFPS, const float renderFPS)
 {
+  if (!fps->display)
+    return;
+
   char str[128];
   snprintf(str, sizeof(str), "UPS: %8.4f, FPS: %8.4f", avgFPS, renderFPS);
 
@@ -174,7 +183,7 @@ void egl_fps_update(EGL_FPS * fps, const float avgFPS, const float renderFPS)
 
 void egl_fps_render(EGL_FPS * fps, const float scaleX, const float scaleY)
 {
-  if (!fps->ready)
+  if (!fps->display || !fps->ready)
     return;
 
   glEnable(GL_BLEND);

--- a/client/renderers/EGL/fps.h
+++ b/client/renderers/EGL/fps.h
@@ -28,5 +28,6 @@ typedef struct EGL_FPS EGL_FPS;
 bool egl_fps_init(EGL_FPS ** fps, const LG_Font * font, LG_FontObj fontObj);
 void egl_fps_free(EGL_FPS ** fps);
 
+void egl_fps_set_display(EGL_FPS * fps, bool display);
 void egl_fps_update(EGL_FPS * fps, const float avgUPS, const float avgFPS);
 void egl_fps_render(EGL_FPS * fps, const float scaleX, const float scaleY);

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -161,6 +161,7 @@ struct Inst
   uint64_t          waitFadeTime;
   bool              waitDone;
 
+  bool              showFPS;
   bool              fpsTexture;
   SDL_Rect          fpsRect;
 
@@ -479,6 +480,12 @@ void opengl_on_help(void * opaque, const char * message)
   // TODO: Implement this.
 }
 
+void opengl_on_show_fps(void * opaque, bool showFPS)
+{
+  struct Inst * this = (struct Inst *)opaque;
+  this->showFPS = showFPS;
+}
+
 void bitmap_to_texture(LG_FontBitmap * bitmap, GLuint texture)
 {
   glBindTexture(GL_TEXTURE_2D       , texture      );
@@ -596,7 +603,7 @@ bool opengl_render(void * opaque, LG_RendererRotate rotate)
       render_wait(this);
   }
 
-  if (this->fpsTexture)
+  if (this->showFPS && this->fpsTexture)
     glCallList(this->fpsList);
 
   struct Alert * alert;
@@ -681,7 +688,7 @@ bool opengl_render(void * opaque, LG_RendererRotate rotate)
 void opengl_update_fps(void * opaque, const float avgUPS, const float avgFPS)
 {
   struct Inst * this = (struct Inst *)opaque;
-  if (!this->params.showFPS)
+  if (!this->showFPS)
     return;
 
   char str[128];
@@ -842,6 +849,7 @@ const LG_Renderer LGR_OpenGL =
   .on_frame        = opengl_on_frame,
   .on_alert        = opengl_on_alert,
   .on_help         = opengl_on_help,
+  .on_show_fps     = opengl_on_show_fps,
   .render_startup  = opengl_render_startup,
   .render          = opengl_render,
   .update_fps      = opengl_update_fps

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -552,3 +552,11 @@ void app_showHelp(bool show)
   g_state.lgr->on_help(g_state.lgrData, help);
   free(help);
 }
+
+void app_showFPS(bool showFPS)
+{
+  if (!g_state.lgr)
+    return;
+
+  g_state.lgr->on_show_fps(g_state.lgrData, showFPS);
+}

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -47,6 +47,12 @@ static void bind_video(int sc, void * opaque)
     core_startFrameThread();
 }
 
+static void bind_showFPS(int sc, void * opaque)
+{
+  g_state.showFPS = !g_state.showFPS;
+  app_showFPS(g_state.showFPS);
+}
+
 static void bind_rotate(int sc, void * opaque)
 {
   if (g_params.winRotate == LG_ROTATE_MAX-1)
@@ -126,6 +132,7 @@ void keybind_register(void)
 {
   app_registerKeybind(KEY_F, bind_fullscreen, NULL, "Full screen toggle");
   app_registerKeybind(KEY_V, bind_video     , NULL, "Video stream toggle");
+  app_registerKeybind(KEY_D, bind_showFPS   , NULL, "FPS display toggle");
   app_registerKeybind(KEY_R, bind_rotate    , NULL, "Rotate the output clockwise by 90° increments");
   app_registerKeybind(KEY_Q, bind_quit      , NULL, "Quit");
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -104,6 +104,8 @@ static int renderThread(void * unused)
     return 1;
   }
 
+  g_state.lgr->on_show_fps(g_state.lgrData, g_state.showFPS);
+
   /* signal to other threads that the renderer is ready */
   lgSignalEvent(e_startup);
 
@@ -131,7 +133,7 @@ static int renderThread(void * unused)
     if (!g_state.lgr->render(g_state.lgrData, g_params.winRotate))
       break;
 
-    if (g_params.showFPS)
+    if (g_state.showFPS)
     {
       const uint64_t t    = nanotime();
       g_state.renderTime   += t - g_state.lastFrameTime;
@@ -629,6 +631,8 @@ static int lg_run(void)
        if (g_cursor.sens < -9) g_cursor.sens = -9;
   else if (g_cursor.sens >  9) g_cursor.sens =  9;
 
+  g_state.showFPS = g_params.showFPS;
+
   // search for the best displayserver ops to use
   for(int i = 0; i < LG_DISPLAYSERVER_COUNT; ++i)
     if (LG_DisplayServers[i]->probe())
@@ -693,7 +697,6 @@ static int lg_run(void)
   // select and init a renderer
   bool needsOpenGL;
   LG_RendererParams lgrParams;
-  lgrParams.showFPS     = g_params.showFPS;
   lgrParams.quickSplash = g_params.quickSplash;
 
   if (g_params.forceRenderer)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -47,6 +47,7 @@ struct AppState
 
   bool                 stopVideo;
   bool                 ignoreInput;
+  bool                 showFPS;
   bool                 escapeActive;
   int                  escapeAction;
   KeybindHandle        bindings[KEY_MAX];


### PR DESCRIPTION
Before, if you want to see the FPS, you need to close the client and
restart it with the -k switch to see the FPS. This is annoying.

This PR introduces a new keybind, ScrollLock+P, which, when pressed,
toggles the display of the FPS.

This is implemented for both EGL and OpenGL backends.