### PR TITLE
[client] spice: fix input:grabKeyboardOnFocus

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -69,6 +69,9 @@ void core_setCursorInView(bool enable)
 
     if (warpSupport && !g_params.captureInputOnly)
       g_state.ds->grabPointer();
+
+    if (g_params.grabKeyboardOnFocus)
+      g_state.ds->grabKeyboard();
   }
   else
   {


### PR DESCRIPTION
This is a new PR based on information gained in #446.

It appears that the keyboard should only be grabbed if the client is
focused and the cursor is in the view. However, the relevant logic was
missing from core_setCursorInView, and the keyboard was never actually
grabbed.

This commit adds the call to g_state.ds->grabKeyboard(), allowing grabbing
to work.