### PR TITLE
Automatically disable screensaver when requested in the guest

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -226,6 +226,13 @@ static struct Option options[] =
   },
   {
     .module         = "win",
+    .name           = "autoScreensaver",
+    .description    = "Prevent the screensaver from starting when guest requests it",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false,
+  },
+  {
+    .module         = "win",
     .name           = "alerts",
     .description    = "Show on screen alert messages",
     .shortopt       = 'q',
@@ -473,21 +480,29 @@ bool config_load(int argc, char * argv[])
   g_params.framePollInterval  = option_get_int   ("app", "framePollInterval" );
   g_params.allowDMA           = option_get_bool  ("app", "allowDMA"          );
 
-  g_params.windowTitle   = option_get_string("win", "title"        );
-  g_params.autoResize    = option_get_bool  ("win", "autoResize"   );
-  g_params.allowResize   = option_get_bool  ("win", "allowResize"  );
-  g_params.keepAspect    = option_get_bool  ("win", "keepAspect"   );
-  g_params.forceAspect   = option_get_bool  ("win", "forceAspect"  );
-  g_params.dontUpscale   = option_get_bool  ("win", "dontUpscale"  );
-  g_params.borderless    = option_get_bool  ("win", "borderless"   );
-  g_params.fullscreen    = option_get_bool  ("win", "fullScreen"   );
-  g_params.maximize      = option_get_bool  ("win", "maximize"     );
-  g_params.fpsMin        = option_get_int   ("win", "fpsMin"       );
-  g_params.showFPS       = option_get_bool  ("win", "showFPS"      );
-  g_params.ignoreQuit    = option_get_bool  ("win", "ignoreQuit"   );
-  g_params.noScreensaver = option_get_bool  ("win", "noScreensaver");
-  g_params.showAlerts    = option_get_bool  ("win", "alerts"       );
-  g_params.quickSplash   = option_get_bool  ("win", "quickSplash"  );
+  g_params.windowTitle     = option_get_string("win", "title"          );
+  g_params.autoResize      = option_get_bool  ("win", "autoResize"     );
+  g_params.allowResize     = option_get_bool  ("win", "allowResize"    );
+  g_params.keepAspect      = option_get_bool  ("win", "keepAspect"     );
+  g_params.forceAspect     = option_get_bool  ("win", "forceAspect"    );
+  g_params.dontUpscale     = option_get_bool  ("win", "dontUpscale"    );
+  g_params.borderless      = option_get_bool  ("win", "borderless"     );
+  g_params.fullscreen      = option_get_bool  ("win", "fullScreen"     );
+  g_params.maximize        = option_get_bool  ("win", "maximize"       );
+  g_params.fpsMin          = option_get_int   ("win", "fpsMin"         );
+  g_params.showFPS         = option_get_bool  ("win", "showFPS"        );
+  g_params.ignoreQuit      = option_get_bool  ("win", "ignoreQuit"     );
+  g_params.noScreensaver   = option_get_bool  ("win", "noScreensaver"  );
+  g_params.autoScreensaver = option_get_bool  ("win", "autoScreensaver");
+  g_params.showAlerts      = option_get_bool  ("win", "alerts"         );
+  g_params.quickSplash     = option_get_bool  ("win", "quickSplash"    );
+
+  if (g_params.noScreensaver && g_params.autoScreensaver)
+  {
+    fprintf(stderr, "win:noScreensaver (-S) and win:autoScreensaver "
+        "can't be used simultaneously\n");
+    return false;
+  }
 
   switch(option_get_int("win", "rotate"))
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -538,6 +538,15 @@ int main_frameThread(void * unused)
       break;
     }
 
+    if (g_params.autoScreensaver && g_state.autoIdleInhibitState != frame->blockScreensaver)
+    {
+      if (frame->blockScreensaver)
+        g_state.ds->inhibitIdle();
+      else
+        g_state.ds->uninhibitIdle();
+      g_state.autoIdleInhibitState = frame->blockScreensaver;
+    }
+
     atomic_fetch_add_explicit(&g_state.frameCount, 1, memory_order_relaxed);
     lgSignalEvent(e_frame);
     lgmpClientMessageDone(queue);

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -92,6 +92,8 @@ struct AppState
 
   uint64_t resizeTimeout;
   bool     resizeDone;
+
+  bool     autoIdleInhibitState;
 };
 
 struct AppParams
@@ -121,6 +123,7 @@ struct AppParams
   bool              hideMouse;
   bool              ignoreQuit;
   bool              noScreensaver;
+  bool              autoScreensaver;
   bool              grabKeyboard;
   bool              grabKeyboardOnFocus;
   int               escapeKey;

--- a/common/include/common/KVMFR.h
+++ b/common/include/common/KVMFR.h
@@ -23,10 +23,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "types.h"
 
 #define KVMFR_MAGIC   "KVMFR---"
-#define KVMFR_VERSION 8
+#define KVMFR_VERSION 9
 
 #define LGMP_Q_POINTER     1
 #define LGMP_Q_FRAME       2
@@ -73,6 +74,7 @@ typedef struct KVMFRFrame
   uint32_t      pitch;             // the row pitch  (stride in bytes or the compressed frame size)
   uint32_t      offset;            // offset from the start of this header to the FrameBuffer header
   uint32_t      mouseScalePercent; // movement scale factor of the mouse (relates to DPI of display, 100 = no scale)
+  bool          blockScreensaver;  // whether the guest has requested to block screensavers
 }
 KVMFRFrame;
 

--- a/host/include/interface/platform.h
+++ b/host/include/interface/platform.h
@@ -38,3 +38,5 @@ void app_quit();
 // these must be implemented for each OS
 const char * os_getExecutable();
 const char * os_getDataPath();
+
+bool os_blockScreensaver();

--- a/host/platform/Linux/src/platform.c
+++ b/host/platform/Linux/src/platform.c
@@ -72,3 +72,8 @@ const char * os_getDataPath(void)
 {
   return app.dataPath;
 }
+
+bool os_blockScreensaver()
+{
+  return false;
+}

--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(platform_Windows
 	wtsapi32
 	psapi
 	shlwapi
+	powrprof
 )
 
 target_include_directories(platform_Windows

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -206,6 +206,7 @@ static int frameThread(void * opaque)
     fi->pitch             = frame.pitch;
     fi->offset            = pageSize - FrameBufferStructSize;
     fi->mouseScalePercent = app.iface->getMouseScale();
+    fi->blockScreensaver  = os_blockScreensaver();
     frameValid            = true;
 
     // put the framebuffer on the border of the next page


### PR DESCRIPTION
In this PR, the host application is modified to detect if any application on the guest called `SetThreadExecutionState(ES_DISPLAY_REQUIRED | ES_CONTINUOUS)` to disable the screensaver and report this information to the client.

This PR also adds a new flag `win:autoScreensaver`, which when set to yes, automatically disables the screensaver on the host machine when we detect that the screensaver is disabled in the guest, and re-enables it when it is no longer disabled.

The new flag `win:autoScreensaver` conflicts with the flag `win:noScreensaver` (`-S`) and cannot be specified at the same time.

