### PR TITLE
[module] improvements after adding in-memory devices

### DIFF
--- a/module/test.c
+++ b/module/test.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
@@ -13,6 +14,8 @@
 
 int main(void)
 {
+  int page_size = getpagesize();
+
   int fd = open("/dev/kvmfr0", O_RDWR);
   if (fd < 0)
   {
@@ -23,6 +26,7 @@ int main(void)
   unsigned long size      = ioctl(fd, KVMFR_DMABUF_GETSIZE , 0);
   printf("Size: %lu MiB\n", size / 1024 / 1024);
 
+  // mmaping 0-offset dmabuf with 0 offset
   struct kvmfr_dmabuf_create create =
   {
     .flags  = KVMFR_DMABUF_FLAG_CLOEXEC,
@@ -37,14 +41,78 @@ int main(void)
   }
 
   void * mem = mmap(NULL, create.size, PROT_READ | PROT_WRITE, MAP_SHARED, dmaFd, 0);
-  if (!mem)
+  if (mem == MAP_FAILED)
   {
-    perror("mmap");
+    perror("mmap on dmabuf with no offset");
     return -1;
   }
-
   memset(mem, 0xAA, create.size);
+  strcpy(mem + page_size, "Hello, world!");
   munmap(mem, create.size);
+
+  // mmaping 0-offset dmabuf with 1 page offset
+  mem = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, dmaFd, page_size);
+  if (mem == MAP_FAILED)
+  {
+    perror("mmap on dmabuf with offset");
+    return -1;
+  }
+  printf("Read string: %s\n", (char *) mem);
+  munmap(mem, page_size);
+
+  close(dmaFd);
+
+  // mmaping page-offset dmabuf with 0 offset
+  create.offset = page_size;
+  create.size   = 2 * page_size;
+  dmaFd = ioctl(fd, KVMFR_DMABUF_CREATE, &create);
+  mem = mmap(NULL, create.size, PROT_READ | PROT_WRITE, MAP_SHARED, dmaFd, 0);
+  if (mem == MAP_FAILED)
+  {
+    perror("mmap on offset dmabuf with no offset");
+    return -1;
+  }
+  printf("Read string: %s\n", (char *) mem);
+  munmap(mem, create.size);
+
+  // mmaping page-offset dmabuf with 1 page offset
+  char *bytes = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, dmaFd, page_size);
+  if (bytes == MAP_FAILED)
+  {
+    perror("mmap on offset dmabuf with offset");
+    return -1;
+  }
+  for (int i = 0; i < page_size; i++)
+    if (bytes[i] != (char) 0xAA)
+      printf("Index: %d: 0x%02x\n", i, (unsigned) bytes[i]);
+  munmap(mem, page_size);
+
+  close(dmaFd);
+
+  // mmaping device with 0 offset
+  mem = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, page_size);
+  if (mem == MAP_FAILED)
+  {
+    perror("mmap on file with offset");
+    return -1;
+  }
+  printf("Read string: %s\n", (char *) mem);
+  munmap(mem, page_size);
+
+  // mmaping device with 0 offset
+  uint32_t *data = mmap(NULL, create.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (data == MAP_FAILED)
+  {
+    perror("mmap on file with no offset");
+    return -1;
+  }
+  for (size_t i = 0; i < create.size / sizeof(uint32_t); i++)
+  {
+    if (data[i] != 0xAAAAAAAA)
+      printf("Index %lu: 0x%08" PRIx32 "\n", i, data[i]);
+  }
+  munmap(data, create.size);
+
   close(fd);
   return 0;
 }

--- a/module/test.expected
+++ b/module/test.expected
@@ -1,0 +1,7 @@
+Read string: Hello, world!
+Read string: Hello, world!
+Read string: Hello, world!
+Index 1024: 0x6c6c6548
+Index 1025: 0x77202c6f
+Index 1026: 0x646c726f
+Index 1027: 0xaaaa0021


### PR DESCRIPTION
This PR contains some improvements `mmap` implementations in the kvmfr module after #455.

This PR:

* implements mmaping for PCI `kvmfr` devices (not going through the `dmabuf`)
* uses more optimal implementation of `mmap` for `dmabuf`, bypassing the need to fault in the pages one by one
* improves the test program to catch offset handling issues in the `mmap` implementations
* provides sample correct output for the test program