### PR TITLE
[client] wayland: allow EGL/OpenGL vsync to be set to on

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -103,17 +103,6 @@ struct Inst
   LG_FontObj        fontObj;
 };
 
-static bool egl_vsync_option_validator(struct Option * opt, const char ** error)
-{
-  if (opt->value.x_bool && getenv("WAYLAND_DISPLAY"))
-  {
-    DEBUG_WARN("Cannot disable vsync on Wayland, forcing egl:vsync=off");
-    opt->value.x_bool = false;
-  }
-
-  return true;
-}
-
 static struct Option egl_options[] =
 {
   {
@@ -122,7 +111,6 @@ static struct Option egl_options[] =
     .description  = "Enable vsync",
     .type         = OPTION_TYPE_BOOL,
     .value.x_bool = false,
-    .validator    = &egl_vsync_option_validator
   },
   {
     .module       = "egl",

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -48,17 +48,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #define FADE_TIME 1000000
 
-static bool opengl_vsync_option_validator(struct Option * opt, const char ** error)
-{
-  if (opt->value.x_bool && getenv("WAYLAND_DISPLAY"))
-  {
-    DEBUG_WARN("Cannot disable vsync on Wayland, forcing opengl:vsync=off");
-    opt->value.x_bool = false;
-  }
-
-  return true;
-}
-
 static struct Option opengl_options[] =
 {
   {
@@ -74,7 +63,6 @@ static struct Option opengl_options[] =
     .description  = "Enable vsync",
     .type         = OPTION_TYPE_BOOL,
     .value.x_bool = false,
-    .validator    = &opengl_vsync_option_validator
   },
   {
     .module       = "opengl",


### PR DESCRIPTION
This effectively reverts 4bceaf5.

Upstream ticket: https://gitlab.freedesktop.org/mesa/mesa/-/issues/4180

Commit 941c651 makes working around the hang in LG itself not as
annoying as before.

In the future, we can bypass this entire issue by implementing our own
swapchain and listening to frame callbacks ourselves.