### PR TITLE
[client] wayland: implement asychronous clipboard read/writes

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -19,6 +19,7 @@ set(COMMON_SOURCES
   src/option.c
   src/framebuffer.c
   src/KVMFR.c
+  src/countedbuffer.c
 )
 
 add_library(lg_common STATIC ${COMMON_SOURCES})

--- a/common/include/common/countedbuffer.h
+++ b/common/include/common/countedbuffer.h
@@ -1,0 +1,30 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2021 Guanzhong Chen <quantum2048@gmail.com>
+https://looking-glass.hostfission.com
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include <stddef.h>
+
+struct CountedBuffer {
+  _Atomic(size_t) refs;
+  size_t size;
+  char data[];
+};
+
+struct CountedBuffer * countedBufferNew(size_t size);
+void countedBufferAddRef(struct CountedBuffer * buffer);
+void countedBufferRelease(struct CountedBuffer ** buffer);

--- a/common/include/common/locking.h
+++ b/common/include/common/locking.h
@@ -36,9 +36,9 @@ typedef atomic_flag LG_Lock;
 #define INTERLOCKED_INC(x) atomic_fetch_add((x), 1)
 #define INTERLOCKED_DEC(x) atomic_fetch_sub((x), 1)
 
-#define INTERLOCKED_SECTION(lock, x) \
+#define INTERLOCKED_SECTION(lock, ...) \
   LG_LOCK(lock) \
-  x \
+  __VA_ARGS__ \
   LG_UNLOCK(lock)
 
 #endif

--- a/common/src/countedbuffer.c
+++ b/common/src/countedbuffer.c
@@ -1,0 +1,47 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2021 Guanzhong Chen <quantum2048@gmail.com>
+https://looking-glass.hostfission.com
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "common/countedbuffer.h"
+#include <stdlib.h>
+#include <stdatomic.h>
+
+struct CountedBuffer * countedBufferNew(size_t size)
+{
+  struct CountedBuffer * buffer = malloc(sizeof(struct CountedBuffer) + size);
+  if (!buffer)
+    return NULL;
+
+  atomic_init(&buffer->refs, 1);
+  buffer->size = size;
+  return buffer;
+}
+
+void countedBufferAddRef(struct CountedBuffer * buffer)
+{
+  atomic_fetch_add(&buffer->refs, 1);
+}
+
+void countedBufferRelease(struct CountedBuffer ** buffer)
+{
+  if (atomic_fetch_sub(&(*buffer)->refs, 1) == 1)
+  {
+    free(*buffer);
+    *buffer = NULL;
+  }
+}


### PR DESCRIPTION
This PR implements asynchronous clipboard reads/writes.

To achieve this, it converts `waylandWait` to use `epoll(7)` and enables the registration and deregistration of additional file descriptors to wait for in the event loop. This machinery would be used for clipboard reads/writes.

With asynchronous operations came more opportunity for race conditions:
* A new clipboard offer may be received while we are handling the current one. We handle this by cancelling the current read and attempting to read the new clipboard offer.
* Multiple Wayland clients may request clipboard data, so we support multiple simultaneous outgoing transfers.
* Our clipboard data source may be cancelled while there are ongoing transfers. We continue those transfers until they are finished.

Since we need to continue clipboard transfers after the data source has been cancelled, we need to reference count the clipboard data. An reference counted buffer type has been introduced into the common library, in the `common/include/common/refcount.h` header. Once all references to the clipboard data has been removed, the data is freed.

This PR should be reviewed by @Xyene, who is the foremost expert on Wayland clipboard handling in the world.