### PR TITLE
[client] ds: implement Wayland warp support

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -195,4 +195,10 @@ Command line arguments will override any options loaded from the config files.
 | opengl:preventBuffer |       | yes   | Prevent the driver from buffering frames    |
 | opengl:amdPinnedMem  |       | yes   | Use GL_AMD_pinned_memory if it is available |
 |------------------------------------------------------------------------------------|
+
+|-------------------------------------------------------------|
+| Long                | Short | Value | Description           |
+|-------------------------------------------------------------|
+| wayland:warpSupport |       | yes   | Enable cursor warping |
+|-------------------------------------------------------------|
 ```

--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -53,6 +53,10 @@ static struct SDLDSState sdl;
 /* forwards */
 static int sdlEventFilter(void * userdata, SDL_Event * event);
 
+static void sdlSetup(void)
+{
+}
+
 static bool sdlProbe(void)
 {
   return true;
@@ -504,6 +508,7 @@ static bool sdlGetFullscreen(void)
 
 struct LG_DisplayServerOps LGDS_SDL =
 {
+  .setup               = sdlSetup,
   .probe               = sdlProbe,
   .earlyInit           = sdlEarlyInit,
   .init                = sdlInit,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -1015,7 +1015,7 @@ static bool waylandGetProp(LG_DSProperty prop, void * ret)
 {
   if (prop == LG_DS_WARP_SUPPORT)
   {
-    *(bool*)ret = false;
+    *(enum LG_DSWarpSupport*)ret = LG_DS_WARP_NONE;
     return true;
   }
 

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -118,6 +118,10 @@ static void x11SetFullscreen(bool fs);
 static int  x11EventThread(void * unused);
 static void x11GenericEvent(XGenericEventCookie *cookie);
 
+static void x11Setup(void)
+{
+}
+
 static bool x11Probe(void)
 {
   return getenv("DISPLAY") != NULL;
@@ -1490,6 +1494,7 @@ static void x11CBRequest(LG_ClipboardData type)
 
 struct LG_DisplayServerOps LGDS_X11 =
 {
+  .setup              = x11Setup,
   .probe              = x11Probe,
   .earlyInit          = x11EarlyInit,
   .init               = x11Init,

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -84,6 +84,9 @@ typedef struct LG_DSGLContext
 
 struct LG_DisplayServerOps
 {
+  /* called before options are parsed, useful for registering options */
+  void (*setup)(void);
+
   /* return true if the selected ds is valid for the current platform */
   bool (*probe)(void);
 
@@ -175,6 +178,7 @@ struct LG_DisplayServerOps
 #endif
 
 #define ASSERT_LG_DS_VALID(x) \
+  assert((x)->setup              ); \
   assert((x)->probe              ); \
   assert((x)->earlyInit          ); \
   assert((x)->init               ); \

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -53,6 +53,13 @@ typedef enum LG_DSProperty
 }
 LG_DSProperty;
 
+enum LG_DSWarpSupport
+{
+  LG_DS_WARP_NONE,
+  LG_DS_WARP_SURFACE,
+  LG_DS_WARP_SCREEN,
+};
+
 typedef struct LG_DSInitParams
 {
   const char * title;

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1032,6 +1032,9 @@ int main(int argc, char * argv[])
   for(unsigned int i = 0; i < LG_RENDERER_COUNT; ++i)
     LG_Renderers[i]->setup();
 
+  for(unsigned int i = 0; i < LG_DISPLAYSERVER_COUNT; ++i)
+    LG_DisplayServers[i]->setup();
+
   if (!config_load(argc, argv))
     return -1;
 


### PR DESCRIPTION
As it turns out, pointer confines can be used to warp cursors on the same surface on Wayland. This PR implements warps with this.

This may not necessarily work for all compositors. As such, the old cursor routines are still kept, and used when `wayland:warpSupport=no`.

This code is currently only tested to work on sway. Interested users should test this branch on Mutter and KWin and report findings.