### PR TITLE
[client] egl: remove dependency on SDL

### DIFF
--- a/client/renderers/EGL/desktop.h
+++ b/client/renderers/EGL/desktop.h
@@ -20,7 +20,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #pragma once
 
 #include <stdbool.h>
-#include <SDL2/SDL_egl.h>
 
 #include "interface/renderer.h"
 

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -29,10 +29,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <EGL/egl.h>
 
-#if defined(SDL_VIDEO_DRIVER_WAYLAND)
-#include <wayland-egl.h>
-#endif
-
 #include <assert.h>
 #include <string.h>
 

--- a/client/renderers/EGL/egldebug.c
+++ b/client/renderers/EGL/egldebug.c
@@ -18,8 +18,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 #include "egldebug.h"
-#include <SDL2/SDL_egl.h>
 #include <GL/gl.h>
+#include <EGL/egl.h>
 
 const char * egl_getErrorStr(void)
 {
@@ -28,18 +28,18 @@ const char * egl_getErrorStr(void)
     case EGL_SUCCESS            : return "EGL_SUCCESS";
     case EGL_NOT_INITIALIZED    : return "EGL_NOT_INITIALIZED";
     case EGL_BAD_ACCESS         : return "EGL_BAD_ACCESS";
-		case EGL_BAD_ALLOC          : return "EGL_BAD_ALLOC";
-		case EGL_BAD_ATTRIBUTE      : return "EGL_BAD_ATTRIBUTE";
-		case EGL_BAD_CONTEXT        : return "EGL_BAD_CONTEXT";
-		case EGL_BAD_CONFIG         : return "EGL_BAD_CONFIG";
-		case EGL_BAD_CURRENT_SURFACE: return "EGL_BAD_CURRENT_SURFACE";
-		case EGL_BAD_DISPLAY        : return "EGL_BAD_DISPLAY";
-		case EGL_BAD_SURFACE        : return "EGL_BAD_SURFACE";
-		case EGL_BAD_MATCH          : return "EGL_BAD_MATCH";
-		case EGL_BAD_PARAMETER      : return "EGL_BAD_PARAMETER";
-		case EGL_BAD_NATIVE_PIXMAP  : return "EGL_BAD_NATIVE_PIXMAP";
-		case EGL_BAD_NATIVE_WINDOW  : return "EGL_BAD_NATIVE_WINDOW";
-		case EGL_CONTEXT_LOST       : return "EGL_CONTEXT_LOST";
-		default                     : return "UNKNOWN";
-	}
+    case EGL_BAD_ALLOC          : return "EGL_BAD_ALLOC";
+    case EGL_BAD_ATTRIBUTE      : return "EGL_BAD_ATTRIBUTE";
+    case EGL_BAD_CONTEXT        : return "EGL_BAD_CONTEXT";
+    case EGL_BAD_CONFIG         : return "EGL_BAD_CONFIG";
+    case EGL_BAD_CURRENT_SURFACE: return "EGL_BAD_CURRENT_SURFACE";
+    case EGL_BAD_DISPLAY        : return "EGL_BAD_DISPLAY";
+    case EGL_BAD_SURFACE        : return "EGL_BAD_SURFACE";
+    case EGL_BAD_MATCH          : return "EGL_BAD_MATCH";
+    case EGL_BAD_PARAMETER      : return "EGL_BAD_PARAMETER";
+    case EGL_BAD_NATIVE_PIXMAP  : return "EGL_BAD_NATIVE_PIXMAP";
+    case EGL_BAD_NATIVE_WINDOW  : return "EGL_BAD_NATIVE_WINDOW";
+    case EGL_CONTEXT_LOST       : return "EGL_CONTEXT_LOST";
+    default                     : return "UNKNOWN";
+  }
 }

--- a/client/renderers/EGL/model.c
+++ b/client/renderers/EGL/model.c
@@ -29,8 +29,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdio.h>
 #include <assert.h>
 
-#include <SDL2/SDL_egl.h>
-
 struct EGL_Model
 {
   bool        rebuild;

--- a/client/renderers/EGL/shader.c
+++ b/client/renderers/EGL/shader.c
@@ -25,8 +25,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <string.h>
 #include <stdio.h>
 
-#include <SDL2/SDL_egl.h>
-
 struct EGL_Shader
 {
   bool   hasShader;

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -39,8 +39,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define DRM_FORMAT_BGRA1010102   fourcc_code('B', 'A', '3', '0')
 #define DRM_FORMAT_ABGR16161616F fourcc_code('A', 'B', '4', 'H')
 
-#include <SDL2/SDL_egl.h>
-
 /* this must be a multiple of 2 */
 #define BUFFER_COUNT 4
 

--- a/client/renderers/EGL/texture.h
+++ b/client/renderers/EGL/texture.h
@@ -23,8 +23,9 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "shader.h"
 #include "common/framebuffer.h"
 
-#include <SDL2/SDL_egl.h>
 #include <GL/gl.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 
 typedef struct EGL_Texture EGL_Texture;
 


### PR DESCRIPTION
After this PR, EGL functions are now accessed through <EGL/egl.h>
instead of through <SDL2/SDL_egl.h>, removing a pointless dependency
on SDL.