### PR TITLE
Add high DPI support for Wayland

### DIFF
--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -381,6 +381,7 @@ static int sdlEventFilter(void * userdata, SDL_Event * event)
           app_handleResizeEvent(
               event->window.data1,
               event->window.data2,
+              1,
               border);
           break;
         }

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(displayserver_Wayland STATIC
 	gl.c
 	idle.c
 	input.c
+	output.c
 	poll.c
 	state.c
 	registry.c

--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -71,16 +71,22 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
 {
   eglSwapBuffers(display, surface);
 
-  if (wlWm.resizeSerial)
+  if (wlWm.needsResize)
   {
-    wl_egl_window_resize(wlWm.eglWindow, wlWm.width, wlWm.height, 0, 0);
+    wl_egl_window_resize(wlWm.eglWindow, wlWm.width * wlWm.scale, wlWm.height * wlWm.scale, 0, 0);
+    wl_surface_set_buffer_scale(wlWm.surface, wlWm.scale);
 
     struct wl_region * region = wl_compositor_create_region(wlWm.compositor);
     wl_region_add(region, 0, 0, wlWm.width, wlWm.height);
     wl_surface_set_opaque_region(wlWm.surface, region);
     wl_region_destroy(region);
 
-    app_handleResizeEvent(wlWm.width, wlWm.height, 1, (struct Border) {0, 0, 0, 0});
+    app_handleResizeEvent(wlWm.width, wlWm.height, wlWm.scale, (struct Border) {0, 0, 0, 0});
+    wlWm.needsResize = false;
+  }
+
+  if (wlWm.resizeSerial)
+  {
     xdg_surface_ack_configure(wlWm.xdgSurface, wlWm.resizeSerial);
     wlWm.resizeSerial = 0;
   }

--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -80,7 +80,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
     wl_surface_set_opaque_region(wlWm.surface, region);
     wl_region_destroy(region);
 
-    app_handleResizeEvent(wlWm.width, wlWm.height, (struct Border) {0, 0, 0, 0});
+    app_handleResizeEvent(wlWm.width, wlWm.height, 1, (struct Border) {0, 0, 0, 0});
     xdg_surface_ack_configure(wlWm.xdgSurface, wlWm.resizeSerial);
     wlWm.resizeSerial = 0;
   }

--- a/client/displayservers/Wayland/output.c
+++ b/client/displayservers/Wayland/output.c
@@ -1,0 +1,126 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2021 Guanzhong Chen (quantum2048@gmail.com)
+Copyright (C) 2021 Tudor Brindus (contact@tbrindus.ca)
+https://looking-glass.io
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "wayland.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include <wayland-client.h>
+
+#include "common/debug.h"
+
+static void outputGeometryHandler(void * data, struct wl_output * output, int32_t x, int32_t y,
+    int32_t physical_width, int32_t physical_height, int32_t subpixel, const char * make,
+    const char * model, int32_t output_transform)
+{
+  // Do nothing.
+}
+
+static void outputModeHandler(void * data, struct wl_output * wl_output, uint32_t flags,
+    int32_t width, int32_t height, int32_t refresh)
+{
+  // Do nothing.
+}
+
+static void outputDoneHandler(void * data, struct wl_output * output)
+{
+  // Do nothing.
+}
+
+static void outputScaleHandler(void * opaque, struct wl_output * output, int32_t scale)
+{
+  struct WaylandOutput * node = opaque;
+  node->scale = scale;
+}
+
+static const struct wl_output_listener outputListener = {
+  .geometry = outputGeometryHandler,
+  .mode = outputModeHandler,
+  .done = outputDoneHandler,
+  .scale = outputScaleHandler,
+};
+
+bool waylandOutputInit(void)
+{
+  wl_list_init(&wlWm.outputs);
+  return true;
+}
+
+void waylandOutputFree(void)
+{
+  struct WaylandOutput * node;
+  struct WaylandOutput * temp;
+  wl_list_for_each_safe(node, temp, &wlWm.outputs, link)
+  {
+    wl_output_release(node->output);
+    wl_list_remove(&node->link);
+    free(node);
+  }
+}
+
+void waylandOutputBind(uint32_t name)
+{
+  struct WaylandOutput * node = malloc(sizeof(struct WaylandOutput));
+  if (!node)
+    return;
+
+  node->name   = name;
+  node->scale  = 0;
+  node->output = wl_registry_bind(wlWm.registry, name,
+      &wl_output_interface, 3);
+
+  if (!node->output)
+  {
+    DEBUG_ERROR("Failed to bind to wl_output %u\n", name);
+    free(node);
+    return;
+  }
+
+  wl_output_add_listener(node->output, &outputListener, node);
+  wl_list_insert(&wlWm.outputs, &node->link);
+}
+
+void waylandOutputTryUnbind(uint32_t name)
+{
+  struct WaylandOutput * node;
+
+  wl_list_for_each(node, &wlWm.outputs, link)
+  {
+    if (node->name == name)
+    {
+      wl_output_release(node->output);
+      wl_list_remove(&node->link);
+      free(node);
+      break;
+    }
+  }
+}
+
+int32_t waylandOutputGetScale(struct wl_output * output)
+{
+  struct WaylandOutput * node;
+
+  wl_list_for_each(node, &wlWm.outputs, link)
+    if (node->output == output)
+      return node->scale;
+  return 0;
+}
+

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -30,7 +30,9 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 static void registryGlobalHandler(void * data, struct wl_registry * registry,
     uint32_t name, const char * interface, uint32_t version)
 {
-  if (!strcmp(interface, wl_seat_interface.name) && !wlWm.seat)
+  if (!strcmp(interface, wl_output_interface.name))
+    waylandOutputBind(name);
+  else if (!strcmp(interface, wl_seat_interface.name) && !wlWm.seat)
     wlWm.seat = wl_registry_bind(wlWm.registry, name, &wl_seat_interface, 1);
   else if (!strcmp(interface, wl_shm_interface.name))
     wlWm.shm = wl_registry_bind(wlWm.registry, name, &wl_shm_interface, 1);
@@ -61,7 +63,7 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
 static void registryGlobalRemoveHandler(void * data,
     struct wl_registry * registry, uint32_t name)
 {
-  // Do nothing.
+  waylandOutputTryUnbind(name);
 }
 
 static const struct wl_registry_listener registryListener = {

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -97,6 +97,9 @@ static bool waylandInit(const LG_DSInitParams params)
   if (!waylandPollInit())
     return false;
 
+  if (!waylandOutputInit())
+    return false;
+
   if (!waylandRegistryInit())
     return false;
 
@@ -139,6 +142,7 @@ static void waylandFree(void)
   waylandIdleFree();
   waylandWindowFree();
   waylandInputFree();
+  waylandOutputFree();
   waylandRegistryFree();
   wl_display_disconnect(wlWm.display);
 }

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -51,6 +51,14 @@ struct WaylandPoll
   struct wl_list link;
 };
 
+struct WaylandOutput
+{
+  uint32_t name;
+  int32_t scale;
+  struct wl_output * output;
+  struct wl_list link;
+};
+
 struct WaylandDSState
 {
   bool pointerGrabbed;
@@ -107,6 +115,8 @@ struct WaylandDSState
 
   struct zwp_idle_inhibit_manager_v1 * idleInhibitManager;
   struct zwp_idle_inhibitor_v1 * idleInhibitor;
+
+  struct wl_list outputs; // WaylandOutput::link
 
   struct wl_list poll; // WaylandPoll::link
   struct wl_list pollFree; // WaylandPoll::link
@@ -199,6 +209,13 @@ void waylandUngrabKeyboard(void);
 void waylandUngrabPointer(void);
 void waylandRealignPointer(void);
 void waylandWarpPointer(int x, int y, bool exiting);
+
+// output module
+bool waylandOutputInit(void);
+void waylandOutputFree(void);
+void waylandOutputBind(uint32_t name);
+void waylandOutputTryUnbind(uint32_t name);
+int32_t waylandOutputGetScale(struct wl_output * output);
 
 // poll module
 bool waylandPollInit(void);

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -59,6 +59,12 @@ struct WaylandOutput
   struct wl_list link;
 };
 
+struct SurfaceOutput
+{
+  struct wl_output * output;
+  struct wl_list link;
+};
+
 struct WaylandDSState
 {
   bool pointerGrabbed;
@@ -71,7 +77,8 @@ struct WaylandDSState
   struct wl_shm * shm;
   struct wl_compositor * compositor;
 
-  int32_t width, height;
+  int32_t width, height, scale;
+  bool needsResize;
   bool fullscreen;
   uint32_t resizeSerial;
   bool configured;
@@ -117,6 +124,7 @@ struct WaylandDSState
   struct zwp_idle_inhibitor_v1 * idleInhibitor;
 
   struct wl_list outputs; // WaylandOutput::link
+  struct wl_list surfaceOutputs; // SurfaceOutput::link
 
   struct wl_list poll; // WaylandPoll::link
   struct wl_list pollFree; // WaylandPoll::link

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -569,10 +569,10 @@ static int x11EventThread(void * unused)
         if (x11.fullscreen)
         {
           struct Border border = {0};
-          app_handleResizeEvent(x11.rect.w, x11.rect.h, border);
+          app_handleResizeEvent(x11.rect.w, x11.rect.h, 1, border);
         }
         else
-          app_handleResizeEvent(x11.rect.w, x11.rect.h, x11.border);
+          app_handleResizeEvent(x11.rect.w, x11.rect.h, 1, x11.border);
         break;
       }
 
@@ -648,7 +648,7 @@ static int x11EventThread(void * unused)
             x11.border.right  = cardinal[1];
             x11.border.top    = cardinal[2];
             x11.border.bottom = cardinal[3];
-            app_handleResizeEvent(x11.rect.w, x11.rect.h, x11.border);
+            app_handleResizeEvent(x11.rect.w, x11.rect.h, 1, x11.border);
           }
 
           XFree(data);

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -39,7 +39,7 @@ bool app_isRunning(void);
 bool app_inputEnabled(void);
 void app_updateCursorPos(double x, double y);
 void app_updateWindowPos(int x, int y);
-void app_handleResizeEvent(int w, int h, const struct Border border);
+void app_handleResizeEvent(int w, int h, double scale, const struct Border border);
 
 void app_handleMouseRelative(double normx, double normy,
     double rawx, double rawy);

--- a/client/include/interface/renderer.h
+++ b/client/include/interface/renderer.h
@@ -109,7 +109,7 @@ typedef bool         (* LG_RendererInitialize   )(void * opaque);
 typedef void         (* LG_RendererDeInitialize )(void * opaque);
 typedef bool         (* LG_RendererSupports     )(void * opaque, LG_RendererSupport support);
 typedef void         (* LG_RendererOnRestart    )(void * opaque);
-typedef void         (* LG_RendererOnResize     )(void * opaque, const int width, const int height, const LG_RendererRect destRect, LG_RendererRotate rotate);
+typedef void         (* LG_RendererOnResize     )(void * opaque, const int width, const int height, const double scale, const LG_RendererRect destRect, LG_RendererRotate rotate);
 typedef bool         (* LG_RendererOnMouseShape )(void * opaque, const LG_RendererCursor cursor, const int width, const int height, const int pitch, const uint8_t * data);
 typedef bool         (* LG_RendererOnMouseEvent )(void * opaque, const bool visible , const int x, const int y);
 typedef bool         (* LG_RendererOnFrameFormat)(void * opaque, const LG_RendererFormat format, bool useDMA);

--- a/client/renderers/EGL/alert.c
+++ b/client/renderers/EGL/alert.c
@@ -164,6 +164,13 @@ void egl_alert_set_text (EGL_Alert * alert, const char * str)
   LG_UNLOCK(alert->lock);
 }
 
+void egl_alert_set_font(EGL_Alert * alert, LG_Font * fontObj)
+{
+  LG_LOCK(alert->lock);
+  alert->fontObj = fontObj;
+  LG_UNLOCK(alert->lock);
+}
+
 void egl_alert_render(EGL_Alert * alert, const float scaleX, const float scaleY)
 {
   if (alert->update)

--- a/client/renderers/EGL/alert.h
+++ b/client/renderers/EGL/alert.h
@@ -30,4 +30,5 @@ void egl_alert_free(EGL_Alert ** alert);
 
 void egl_alert_set_color(EGL_Alert * alert, const uint32_t color);
 void egl_alert_set_text (EGL_Alert * alert, const char * str);
+void egl_alert_set_font (EGL_Alert * alert, LG_Font * fontObj);
 void egl_alert_render   (EGL_Alert * alert, const float scaleX, const float scaleY);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -379,7 +379,7 @@ static void egl_update_scale_type(struct Inst * this)
     this->scaleType = EGL_DESKTOP_UPSCALE;
 }
 
-void egl_on_resize(void * opaque, const int width, const int height,
+void egl_on_resize(void * opaque, const int width, const int height, const double scale,
     const LG_RendererRect destRect, LG_RendererRotate rotate)
 {
   struct Inst * this = (struct Inst *)opaque;

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -384,30 +384,33 @@ void egl_on_resize(void * opaque, const int width, const int height, const doubl
 {
   struct Inst * this = (struct Inst *)opaque;
 
-  this->width  = width;
-  this->height = height;
+  this->width  = width * scale;
+  this->height = height * scale;
   this->rotate = rotate;
 
-  memcpy(&this->destRect, &destRect, sizeof(LG_RendererRect));
+  this->destRect.x = destRect.x * scale;
+  this->destRect.y = destRect.y * scale;
+  this->destRect.w = destRect.w * scale;
+  this->destRect.h = destRect.h * scale;
 
-  glViewport(0, 0, width, height);
+  glViewport(0, 0, this->width, this->height);
 
   if (destRect.valid)
   {
-    this->translateX     = 1.0f - (((destRect.w / 2) + destRect.x) * 2) / (float)width;
-    this->translateY     = 1.0f - (((destRect.h / 2) + destRect.y) * 2) / (float)height;
-    this->scaleX         = (float)destRect.w / (float)width;
-    this->scaleY         = (float)destRect.h / (float)height;
-    this->viewportWidth  = destRect.w;
-    this->viewportHeight = destRect.h;
+    this->translateX     = 1.0f - (((this->destRect.w / 2) + this->destRect.x) * 2) / (float)this->width;
+    this->translateY     = 1.0f - (((this->destRect.h / 2) + this->destRect.y) * 2) / (float)this->height;
+    this->scaleX         = (float)this->destRect.w / (float)this->width;
+    this->scaleY         = (float)this->destRect.h / (float)this->height;
+    this->viewportWidth  = this->destRect.w;
+    this->viewportHeight = this->destRect.h;
   }
 
   egl_update_scale_type(this);
   egl_calc_mouse_size(this);
 
   this->splashRatio  = (float)width / (float)height;
-  this->screenScaleX = 1.0f / width;
-  this->screenScaleY = 1.0f / height;
+  this->screenScaleX = 1.0f / this->width;
+  this->screenScaleY = 1.0f / this->height;
 
   egl_calc_mouse_state(this);
 }

--- a/client/renderers/EGL/fps.c
+++ b/client/renderers/EGL/fps.c
@@ -138,6 +138,11 @@ void egl_fps_set_display(EGL_FPS * fps, bool display)
   fps->display = display;
 }
 
+void egl_fps_set_font(EGL_FPS * fps, LG_Font * fontObj)
+{
+  fps->fontObj = fontObj;
+}
+
 void egl_fps_update(EGL_FPS * fps, const float avgFPS, const float renderFPS)
 {
   if (!fps->display)

--- a/client/renderers/EGL/fps.h
+++ b/client/renderers/EGL/fps.h
@@ -29,5 +29,6 @@ bool egl_fps_init(EGL_FPS ** fps, const LG_Font * font, LG_FontObj fontObj);
 void egl_fps_free(EGL_FPS ** fps);
 
 void egl_fps_set_display(EGL_FPS * fps, bool display);
+void egl_fps_set_font   (EGL_FPS * fps, LG_Font * fontObj);
 void egl_fps_update(EGL_FPS * fps, const float avgUPS, const float avgFPS);
 void egl_fps_render(EGL_FPS * fps, const float scaleX, const float scaleY);

--- a/client/renderers/EGL/help.c
+++ b/client/renderers/EGL/help.c
@@ -154,6 +154,11 @@ void egl_help_set_text(EGL_Help * help, const char * help_text)
   }
 }
 
+void egl_help_set_font(EGL_Help * help, LG_FontObj fontObj)
+{
+  help->fontObj = fontObj;
+}
+
 void egl_help_render(EGL_Help * help, const float scaleX, const float scaleY)
 {
   LG_FontBitmap * bmp = atomic_exchange(&help->bmp, NULL);

--- a/client/renderers/EGL/help.h
+++ b/client/renderers/EGL/help.h
@@ -29,4 +29,5 @@ bool egl_help_init(EGL_Help ** help, const LG_Font * font, LG_FontObj fontObj);
 void egl_help_free(EGL_Help ** help);
 
 void egl_help_set_text(EGL_Help * help, const char * help_text);
+void egl_help_set_font(EGL_Help * help, LG_FontObj fontObj);
 void egl_help_render(EGL_Help * help, const float scaleX, const float scaleY);

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -303,11 +303,17 @@ void opengl_on_resize(void * opaque, const int width, const int height, const do
 {
   struct Inst * this = (struct Inst *)opaque;
 
-  this->window.x = width;
-  this->window.y = height;
+  this->window.x = width * scale;
+  this->window.y = height * scale;
 
   if (destRect.valid)
-    memcpy(&this->destRect, &destRect, sizeof(LG_RendererRect));
+  {
+    this->destRect.valid = true;
+    this->destRect.x = destRect.x * scale;
+    this->destRect.y = destRect.y * scale;
+    this->destRect.w = destRect.w * scale;
+    this->destRect.h = destRect.h * scale;
+  }
 
   // setup the projection matrix
   glViewport(0, 0, this->window.x, this->window.y);

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -111,6 +111,7 @@ struct Inst
   LG_DSGLContext    glContext;
 
   SDL_Point         window;
+  float             uiScale;
   bool              frameUpdate;
 
   const LG_Font   * font;
@@ -305,6 +306,7 @@ void opengl_on_resize(void * opaque, const int width, const int height, const do
 
   this->window.x = width * scale;
   this->window.y = height * scale;
+  this->uiScale  = (float) scale;
 
   if (destRect.valid)
   {
@@ -661,6 +663,7 @@ bool opengl_render(void * opaque, LG_RendererRotate rotate)
     glPushMatrix();
       glLoadIdentity();
       glTranslatef(this->window.x / 2, this->window.y / 2, 0.0f);
+      glScalef(this->uiScale, this->uiScale, 1.0f);
       glCallList(this->alertList);
     glPopMatrix();
     break;
@@ -703,9 +706,6 @@ void opengl_update_fps(void * opaque, const float avgUPS, const float avgFPS)
   this->fpsTexture  = true;
 
   glNewList(this->fpsList, GL_COMPILE);
-    glPushMatrix();
-    glLoadIdentity();
-
     glEnable(GL_BLEND);
     glDisable(GL_TEXTURE_2D);
     glColor4f(0.0f, 0.0f, 1.0f, 0.5f);
@@ -727,8 +727,6 @@ void opengl_update_fps(void * opaque, const float avgUPS, const float avgFPS)
     glEnd();
     glBindTexture(GL_TEXTURE_2D, 0);
     glDisable(GL_BLEND);
-
-    glPopMatrix();
   glEndList();
 }
 

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -298,7 +298,7 @@ void opengl_on_restart(void * opaque)
   this->waiting = true;
 }
 
-void opengl_on_resize(void * opaque, const int width, const int height,
+void opengl_on_resize(void * opaque, const int width, const int height, const double scale,
     const LG_RendererRect destRect, LG_RendererRotate rotate)
 {
   struct Inst * this = (struct Inst *)opaque;

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -349,18 +349,19 @@ void app_updateWindowPos(int x, int y)
   g_state.windowPos.y = y;
 }
 
-void app_handleResizeEvent(int w, int h, const struct Border border)
+void app_handleResizeEvent(int w, int h, double scale, const struct Border border)
 {
   memcpy(&g_state.border, &border, sizeof(border));
 
   /* don't do anything else if the window dimensions have not changed */
-  if (g_state.windowW == w && g_state.windowH == h)
+  if (g_state.windowW == w && g_state.windowH == h && g_state.windowScale == scale)
     return;
 
-  g_state.windowW  = w;
-  g_state.windowH  = h;
-  g_state.windowCX = w / 2;
-  g_state.windowCY = h / 2;
+  g_state.windowW     = w;
+  g_state.windowH     = h;
+  g_state.windowCX    = w / 2;
+  g_state.windowCY    = h / 2;
+  g_state.windowScale = scale;
   core_updatePositionInfo();
 
   if (core_inputEnabled())

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -126,7 +126,7 @@ static int renderThread(void * unused)
     {
       if (g_state.lgr)
         g_state.lgr->on_resize(g_state.lgrData, g_state.windowW, g_state.windowH,
-            g_state.dstRect, g_params.winRotate);
+            g_state.windowScale, g_state.dstRect, g_params.winRotate);
       atomic_compare_exchange_weak(&g_state.lgrResize, &resize, 0);
     }
 

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -58,6 +58,7 @@ struct AppState
   struct Point         windowPos;
   int                  windowW, windowH;
   int                  windowCX, windowCY;
+  double               windowScale;
   LG_RendererRotate    rotate;
   bool                 focused;
   struct Border        border;


### PR DESCRIPTION
This PR adds the support for high DPI with UI scaling.

Currently, only the Wayland display server passes a UI scale factor. All other display servers pass 1 for scale. Both the EGL and OpenGL renderers can render the UI at high resolution, but only the EGL backend scales the alerts, FPS meter, and help overlay by rendering it at high DPI.

Limitations: the desktop does not look very good when upscaled with `LG_SCALE_NEAREST` (currently hardcoded). We might want to add a setting to switch between the different filters.