### PR TITLE
[client] cmake: build for nehalem when OPTIMIZE_FOR_NATIVE=NO

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -13,6 +13,8 @@ if(OPTIMIZE_FOR_NATIVE)
   if(COMPILER_SUPPORTS_MARCH_NATIVE)
     add_compile_options("-march=native")
   endif()
+else()
+  add_compile_options("-march=nehalem" "-mtune=generic")
 endif()
 
 option(ENABLE_OPENGL "Enable the OpenGL renderer"       ON)


### PR DESCRIPTION
We need SSE intrinsics like _mm_stream_load_si128 which is only available
on CPUs of nehalem or newer.