### PR TITLE
[client] wayland: handle output scale changes

### DIFF
--- a/client/displayservers/Wayland/output.c
+++ b/client/displayservers/Wayland/output.c
@@ -49,6 +49,7 @@ static void outputScaleHandler(void * opaque, struct wl_output * output, int32_t
 {
   struct WaylandOutput * node = opaque;
   node->scale = scale;
+  waylandWindowUpdateScale();
 }
 
 static const struct wl_output_listener outputListener = {

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -89,6 +89,7 @@ static bool waylandProbe(void)
 static bool waylandInit(const LG_DSInitParams params)
 {
   memset(&wlWm, 0, sizeof(wlWm));
+  wl_list_init(&wlWm.surfaceOutputs);
 
   wlWm.warpSupport = option_get_bool("wayland", "warpSupport");
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -238,6 +238,7 @@ void waylandRegistryFree(void);
 // window module
 bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless);
 void waylandWindowFree(void);
+void waylandWindowUpdateScale(void);
 void waylandSetWindowSize(int x, int y);
 void waylandSetFullscreen(bool fs);
 bool waylandGetFullscreen(void);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -41,7 +41,7 @@ static const struct xdg_wm_base_listener xdgWmBaseListener = {
 
 // Surface-handling listeners.
 
-static void surfaceUpdateScale(void)
+void waylandWindowUpdateScale(void)
 {
   int32_t maxScale = 0;
   struct SurfaceOutput * node;
@@ -65,7 +65,7 @@ static void wlSurfaceEnterHandler(void * data, struct wl_surface * surface, stru
   struct SurfaceOutput * node = malloc(sizeof(struct SurfaceOutput));
   node->output = output;
   wl_list_insert(&wlWm.surfaceOutputs, &node->link);
-  surfaceUpdateScale();
+  waylandWindowUpdateScale();
 }
 
 static void wlSurfaceLeaveHandler(void * data, struct wl_surface * surface, struct wl_output * output)
@@ -77,7 +77,7 @@ static void wlSurfaceLeaveHandler(void * data, struct wl_surface * surface, stru
       wl_list_remove(&node->link);
       break;
     }
-  surfaceUpdateScale();
+  waylandWindowUpdateScale();
 }
 
 static const struct wl_surface_listener wlSurfaceListener = {
@@ -158,7 +158,6 @@ bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool 
     return false;
   }
 
-  wl_list_init(&wlWm.surfaceOutputs);
   wl_surface_add_listener(wlWm.surface, &wlSurfaceListener, NULL);
 
   wlWm.xdgSurface = xdg_wm_base_get_xdg_surface(wlWm.xdgWmBase, wlWm.surface);


### PR DESCRIPTION
If the scale factor of an wl_output changes while the client is running,
the maximum scale factor is not updated. This may result in incorrect
scaling.

Therefore, when the scale factor is changed, we should generate a
resize event.