### PR TITLE
[client] wayland: fail gracefully when interfaces are too old

### DIFF
--- a/client/displayservers/Wayland/clipboard.c
+++ b/client/displayservers/Wayland/clipboard.c
@@ -329,7 +329,7 @@ bool waylandCBInit(void)
 
   if (!wlWm.dataDeviceManager)
   {
-    DEBUG_ERROR("Missing wl_data_device_manager interface");
+    DEBUG_ERROR("Missing wl_data_device_manager interface (version 3+)");
     return false;
   }
 

--- a/client/displayservers/Wayland/output.c
+++ b/client/displayservers/Wayland/output.c
@@ -77,11 +77,17 @@ void waylandOutputFree(void)
   }
 }
 
-void waylandOutputBind(uint32_t name)
+void waylandOutputBind(uint32_t name, uint32_t version)
 {
   struct WaylandOutput * node = malloc(sizeof(struct WaylandOutput));
   if (!node)
     return;
+
+  if (version < 3)
+  {
+    DEBUG_WARN("wl_output version too old: expected 3, got %d", version);
+    return;
+  }
 
   node->name   = name;
   node->scale  = 0;

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -31,12 +31,12 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
     uint32_t name, const char * interface, uint32_t version)
 {
   if (!strcmp(interface, wl_output_interface.name))
-    waylandOutputBind(name);
+    waylandOutputBind(name, version);
   else if (!strcmp(interface, wl_seat_interface.name) && !wlWm.seat)
     wlWm.seat = wl_registry_bind(wlWm.registry, name, &wl_seat_interface, 1);
   else if (!strcmp(interface, wl_shm_interface.name))
     wlWm.shm = wl_registry_bind(wlWm.registry, name, &wl_shm_interface, 1);
-  else if (!strcmp(interface, wl_compositor_interface.name))
+  else if (!strcmp(interface, wl_compositor_interface.name) && version >= 4)
     wlWm.compositor = wl_registry_bind(wlWm.registry, name, &wl_compositor_interface, 4);
   else if (!strcmp(interface, xdg_wm_base_interface.name))
     wlWm.xdgWmBase = wl_registry_bind(wlWm.registry, name, &xdg_wm_base_interface, 1);
@@ -52,7 +52,7 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name))
     wlWm.keyboardInhibitManager = wl_registry_bind(wlWm.registry, name,
         &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
-  else if (!strcmp(interface, wl_data_device_manager_interface.name))
+  else if (!strcmp(interface, wl_data_device_manager_interface.name) && version >= 3)
     wlWm.dataDeviceManager = wl_registry_bind(wlWm.registry, name,
         &wl_data_device_manager_interface, 3);
   else if (!strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name))

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -221,7 +221,7 @@ void waylandWarpPointer(int x, int y, bool exiting);
 // output module
 bool waylandOutputInit(void);
 void waylandOutputFree(void);
-void waylandOutputBind(uint32_t name);
+void waylandOutputBind(uint32_t name, uint32_t version);
 void waylandOutputTryUnbind(uint32_t name);
 int32_t waylandOutputGetScale(struct wl_output * output);
 

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -139,7 +139,7 @@ bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool 
 
   if (!wlWm.compositor)
   {
-    DEBUG_ERROR("Compositor missing wl_compositor, will not proceed");
+    DEBUG_ERROR("Compositor missing wl_compositor (version 4+), will not proceed");
     return false;
   }
 


### PR DESCRIPTION
Before, we just attempt to bind, causing an obscure Wayland error.
This commit checks the interface versions and print better error
messages.