### PR TITLE
[client] app: do not toggle capture if escapeKey is held

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -194,6 +194,7 @@ void app_handleKeyPress(int sc)
   if (sc == g_params.escapeKey && !g_state.escapeActive)
   {
     g_state.escapeActive = true;
+    g_state.escapeTime   = microtime();
     g_state.escapeAction = -1;
     app_showHelp(true);
     return;
@@ -233,7 +234,7 @@ void app_handleKeyRelease(int sc)
   {
     if (g_state.escapeAction == -1)
     {
-      if (g_params.useSpiceInput)
+      if (microtime() - g_state.escapeTime < 500000 && g_params.useSpiceInput)
         core_setGrab(!g_cursor.grab);
     }
     else

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -49,6 +49,7 @@ struct AppState
   bool                 ignoreInput;
   bool                 showFPS;
   bool                 escapeActive;
+  uint64_t             escapeTime;
   int                  escapeAction;
   KeybindHandle        bindings[KEY_MAX];
   const char *         keyDescription[KEY_MAX];


### PR DESCRIPTION
When users press escapeKey for a long time, they probably want to
see the help text instead of actually toggling capture. Therefore,
if the key is held down for more than 500 ms, we assume the user
wants to look at the help text and do not toggle capture mode.

500 ms seems to be a decent compromise, allowing slow presses, but
is not enough time for the user to have looked at the help text.