### PR TITLE
[client] ds: make SDL display server optional

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -32,11 +32,18 @@ add_feature_info(ENABLE_ASAN ENABLE_ASAN "AddressSanitizer support.")
 option(ENABLE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
 add_feature_info(ENABLE_UBSAN ENABLE_UBSAN "UndefinedBehaviorSanitizer support.")
 
+option(ENABLE_SDL "Build with SDL support" OFF)
+add_feature_info(ENABLE_SDL ENABLE_SDL "SDL support.")
+
 option(ENABLE_X11 "Build with X11 support" ON)
 add_feature_info(ENABLE_X11 ENABLE_X11 "X11 support.")
 
 option(ENABLE_WAYLAND "Build with Wayland support" ON)
 add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
+
+if (NOT ENABLE_SDL AND NOT ENABLE_X11 AND NOT ENABLE_WAYLAND)
+  message(FATAL_ERROR "One of ENABLE_SDL, ENABLE_X11, or ENABLE_WAYLAND must be on")
+endif()
 
 add_compile_options(
   "-Wall"
@@ -73,11 +80,6 @@ if(ENABLE_UBSAN)
   set(EXE_FLAGS "${EXE_FLAGS} -fsanitize=undefined")
 endif()
 
-find_package(PkgConfig)
-pkg_check_modules(PKGCONFIG REQUIRED
-	sdl2
-)
-
 find_package(GMP)
 
 add_definitions(-D ATOMIC_LOCKING)
@@ -94,12 +96,10 @@ add_custom_command(
 include_directories(
 	${PROJECT_SOURCE_DIR}/include
 	${CMAKE_BINARY_DIR}/include
-	${PKGCONFIG_INCLUDE_DIRS} ${PKGCONFIG_OPT_INCLUDE_DIRS}
 	${GMP_INCLUDE_DIR}
 )
 
 link_libraries(
-	${PKGCONFIG_LIBRARIES} ${PKGCONFIG_OPT_LIBRARIES}
 	${GMP_LIBRARIES}
 	${CMAKE_DL_LIBS}
 	rt
@@ -130,7 +130,6 @@ add_subdirectory(renderers)
 add_subdirectory(fonts)
 
 add_executable(looking-glass-client ${SOURCES})
-target_compile_options(looking-glass-client PUBLIC ${PKGCONFIG_CFLAGS_OTHER} ${PKGCONFIG_OPT_CFLAGS_OTHER})
 target_link_libraries(looking-glass-client
 	${EXE_FLAGS}
 	lg_common

--- a/client/README.md
+++ b/client/README.md
@@ -36,8 +36,7 @@ Should this all go well you should be left with the file `looking-glass-client`
 ### Removing Wayland or X11 support
 
 Wayland and/or X11 support can be disabled with the compile options
-`ENABLE_WAYLAND` and `ENABLE_X11`, if both are specified only `SDL2` will remain
-and the client will fallback to using it.
+`ENABLE_WAYLAND=NO` and `ENABLE_X11=NO`. It is an error to disable both backends.
 
     cmake ../ -DENABLE_WAYLAND=OFF
 

--- a/client/displayservers/CMakeLists.txt
+++ b/client/displayservers/CMakeLists.txt
@@ -28,7 +28,9 @@ if (ENABLE_X11)
 endif()
 
 # SDL must be last as it's the fallback implemntation
-add_displayserver(SDL)
+if (ENABLE_SDL)
+  add_displayserver(SDL)
+endif()
 
 list(REMOVE_AT DISPLAYSERVERS      0)
 list(REMOVE_AT DISPLAYSERVERS_LINK 0)

--- a/client/displayservers/SDL/CMakeLists.txt
+++ b/client/displayservers/SDL/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(displayserver_SDL LANGUAGES C)
 
-#find_package(PkgConfig)
-#pkg_check_modules(DISPLAYSERVER_SDL_PKGCONFIG REQUIRED
-#	#sdl2
-#)
+find_package(PkgConfig)
+pkg_check_modules(DISPLAYSERVER_SDL_PKGCONFIG REQUIRED
+	sdl2
+)
 
 add_library(displayserver_SDL STATIC
 	sdl.c


### PR DESCRIPTION
This PR also moves the SDL dependencies into the SDL backend so that `-DENABLE_SDL=NO` builds do not link against SDL.

Mentions of SDL are deleted from `README.md` as it's deprecated, defaults to off, and not encouraged. As such, `-DENABLE_SDL=ON` is not mentioned in the README, but we can still tell people to use it if needed.