### PR TITLE
[client] readme: remove mention of Wayland's lack of warp

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -41,11 +41,6 @@ and the client will fallback to using it.
 
     cmake ../ -DENABLE_WAYLAND=OFF
 
-At this time, X11 is the perferred and best supported interface. Wayland is not
-far behind, however it lacks some of the seamless interaction features that X11
-has due to the lack of cursor warp (programmatic movement of the local cusror) on
-Wayland.
-
 ---
 
 ## Usage Tips


### PR DESCRIPTION
We have an implementation of Wayland cursor warping now, so there is no
need for the section saying that Wayland lacks the feature.