### PR TITLE
[common] crash/linux: generate core dump when handling SIGSEGV

### DIFF
--- a/common/src/platform/linux/crash.c
+++ b/common/src/platform/linux/crash.c
@@ -215,7 +215,7 @@ static void crit_err_hdlr(int sig_num, siginfo_t * info, void * ucontext)
   DEBUG_ERROR("signal %d (%s), address is %p", sig_num, strsignal(sig_num), info->si_addr);
   printBacktrace();
   cleanupCrashHandler();
-  exit(EXIT_FAILURE);
+  abort();
 }
 
 bool installCrashHandler(const char * exe)


### PR DESCRIPTION
Calling abort() instead of exit() will generate a core dump, allowing gdb
to be used when the client crashes. This is desirable for the following
reasons:

1. gdb can be used to inspect the call stack with far more detail than the
   our quick stack trace code, and also allows the access to the heap.
2. Our SIGSEGV handler is unable to use debug symbols for shared libraries,
   making it impossible to debug bugs involving drivers and similar.