### PR TITLE
[client] wayland: gracefully downgrade to wl_output v2 

### DIFF
--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -56,6 +56,7 @@ struct WaylandOutput
   uint32_t name;
   int32_t scale;
   struct wl_output * output;
+  uint32_t version;
   struct wl_list link;
 };
 


### PR DESCRIPTION
We don't necessarily need `wl_output.release`, which is the only
addition in v3.

This allows Looking Glass to run on Ubuntu 20.04 without having to go
difficult lengths to acquire newer Wayland packages. Since 20.04 is an
LTS release, this seems worthwhile for the small amount of complexity
this introduces.

Fixes
https://forum.level1techs.com/t/latest-build-allow-inhibiting-shortcuts-dialog-ubuntu/168684/6.