### PR TITLE
[client] wayland: require wl_compositor v3 instead of v4

### DIFF
--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -36,8 +36,8 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
     wlWm.seat = wl_registry_bind(wlWm.registry, name, &wl_seat_interface, 1);
   else if (!strcmp(interface, wl_shm_interface.name))
     wlWm.shm = wl_registry_bind(wlWm.registry, name, &wl_shm_interface, 1);
-  else if (!strcmp(interface, wl_compositor_interface.name) && version >= 4)
-    wlWm.compositor = wl_registry_bind(wlWm.registry, name, &wl_compositor_interface, 4);
+  else if (!strcmp(interface, wl_compositor_interface.name) && version >= 3)
+    wlWm.compositor = wl_registry_bind(wlWm.registry, name, &wl_compositor_interface, 3);
   else if (!strcmp(interface, xdg_wm_base_interface.name))
     wlWm.xdgWmBase = wl_registry_bind(wlWm.registry, name, &xdg_wm_base_interface, 1);
   else if (!strcmp(interface, zxdg_decoration_manager_v1_interface.name))

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -139,7 +139,7 @@ bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool 
 
   if (!wlWm.compositor)
   {
-    DEBUG_ERROR("Compositor missing wl_compositor (version 4+), will not proceed");
+    DEBUG_ERROR("Compositor missing wl_compositor (version 3+), will not proceed");
     return false;
   }
 


### PR DESCRIPTION
The only addition to v4 was `wl_surface_damage_buffer`, which we do not
use.

This change should allow running on more compositors (even though v4 is
already old -- 5 years now).

Ref
https://gitlab.freedesktop.org/wayland/wayland/-/commit/3384f69ecf043d62a4e036c0353c2daa01d7c4d0.