### PR TITLE
[client] ds: build SDL backend in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         mkdir client/build
         cd client/build
-        cmake -DCMAKE_BUILD_TYPE={{ matrix.build_type }} ..
+        cmake -DCMAKE_BUILD_TYPE={{ matrix.build_type }} -DENABLE_SDL=ON ..
     - name: Build client
       run: |
         cd client/build


### PR DESCRIPTION
SDL was made optional, and defaulted to off, in c34fe10. However, we
should still make sure it continues building.