### PR TITLE
[host] free capture interface on exit

### DIFF
--- a/host/src/app.c
+++ b/host/src/app.c
@@ -566,8 +566,6 @@ int app_main(int argc, char * argv[])
     DEBUG_ERROR("Failed to create the LGMP timer");
 
     iface->deinit();
-    iface->free();
-
     goto fail_timer;
   }
 
@@ -685,6 +683,7 @@ fail_capture:
   lgTimerDestroy(app.lgmpTimer);
 
 fail_timer:
+  iface->free();
   LG_LOCK_FREE(app.pointerLock);
 
 fail_lgmp:


### PR DESCRIPTION
This is needed for proper cleanup.

Freeing the capture interface also avoids a crash when using the NvFBC
backend. This is because we moved the mouse hook removal to nvfbc_free.
If nvfbc_free is not called before we start freeing LGMP memory, the
mouse hook would end up writing the cursor position into an invalid
memory address, causing an access violation.