### PR TITLE
[host] allow user to select capture backend

### DIFF
--- a/host/include/interface/capture.h
+++ b/host/include/interface/capture.h
@@ -89,6 +89,7 @@ typedef void (*CapturePostPointerBuffer)(CapturePointer pointer);
 
 typedef struct CaptureInterface
 {
+  const char     *shortName;
   const char *  (*getName        )();
   void          (*initOptions    )();
 

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -235,6 +235,7 @@ static CaptureResult xcb_getFrame(FrameBuffer * frame)
 
 struct CaptureInterface Capture_XCB =
 {
+  .shortName       = "XCB",
   .getName         = xcb_getName,
   .create          = xcb_create,
   .init            = xcb_init,

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -1023,6 +1023,7 @@ static CaptureResult dxgi_releaseFrame(void)
 
 struct CaptureInterface Capture_DXGI =
 {
+  .shortName       = "DXGI",
   .getName         = dxgi_getName,
   .initOptions     = dxgi_initOptions,
   .create          = dxgi_create,

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -427,6 +427,7 @@ static int pointerThread(void * unused)
 
 struct CaptureInterface Capture_NVFBC =
 {
+  .shortName       = "NvFBC",
   .getName         = nvfbc_getName,
   .initOptions     = nvfbc_initOptions,
 


### PR DESCRIPTION
This commit introduces a new option, app:capture, which can be set to
either DXGI or NvFBC to force the host application to use that backend.

This is very useful for testing DXGI on Quadro cards, which would default
to running with NvFBC.