### PR TITLE
[client] cmake: correctly link static libbfd.a

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(looking-glass-client C)
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
 include(GNUInstallDirs)
 include(CheckCCompilerFlag)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0)
 project(lg_common LANGUAGES C)
 
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
+
 include_directories(
 	${PROJECT_SOURCE_DIR}/include
 )

--- a/common/cmake/FindBFD.cmake
+++ b/common/cmake/FindBFD.cmake
@@ -1,0 +1,40 @@
+# Try to find the BFD librairies
+# BFD_FOUND - system has BFD lib
+# BFD_INCLUDE_DIR - the BFD include directory
+# BFD_LIBRARIES - Libraries needed to use BFD
+
+if (BFD_INCLUDE_DIR AND BFD_LIBRARIES)
+  # Already in cache, be silent
+  set(BFD_FIND_QUIETLY TRUE)
+endif (BFD_INCLUDE_DIR AND BFD_LIBRARIES)
+
+find_path(BFD_INCLUDE_DIR NAMES bfd.h)
+find_library(BFD_LIBRARIES NAMES bfd)
+
+include(FindPackageHandleStandardArgs)
+
+if (";${BFD_LIBRARIES};" MATCHES "bfd.a;")
+  MESSAGE(STATUS "Linking against static bfd")
+
+  find_library(BFD_LIBIBERTY_LIBRARIES NAMES libiberty.a)
+  find_package_handle_standard_args(BFD_LIBIBERTY DEFAULT_MSG BFD_LIBIBERTY_LIBRARIES)
+
+  find_library(BFD_LIBZ_LIBRARIES NAMES libz.a)
+  find_package_handle_standard_args(BFD_LIBZ DEFAULT_MSG BFD_LIBZ_LIBRARIES)
+
+  if (NOT ${BFD_LIBIBERTY_FOUND})
+    message(FATAL_ERROR "Using static libbfd.a, but libiberty.a not available")
+  elseif (NOT ${BFD_LIBZ_FOUND})
+    message(FATAL_ERROR "Using static libbfd.a, but libz.a not available")
+  else()
+    list(APPEND BFD_LIBRARIES ${BFD_LIBIBERTY_LIBRARIES} ${BFD_LIBZ_LIBRARIES})
+  endif()
+endif()
+
+MESSAGE(STATUS "BFD libs: " "${BFD_LIBRARIES}")
+
+find_package_handle_standard_args(BFD DEFAULT_MSG BFD_LIBRARIES BFD_INCLUDE_DIR)
+
+MESSAGE(STATUS "BFD libs: " "${BFD_LIBRARIES}")
+
+mark_as_advanced(BFD_INCLUDE_DIR BFD_LIBRARIES)

--- a/common/src/platform/linux/CMakeLists.txt
+++ b/common/src/platform/linux/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(lg_common_platform_code STATIC
 )
 
 if(ENABLE_BACKTRACE)
-  target_link_libraries(lg_common_platform_code bfd)
+  find_package(BFD)
+  target_link_libraries(lg_common_platform_code ${BFD_LIBRARIES})
 endif()
 
 target_link_libraries(lg_common_platform_code


### PR DESCRIPTION
When linking against libbfd.so, just passing libbfd.so to the compiler is
sufficient. When linking against the static version libbfd.a, however,
we must additionally link against libiberty.a and libz.a.

This commit adds a CMake helper to find the correct libraries that need
to be passed to link against libbfd correctly.