### PR TITLE
[client] wayland: switch to using locked pointer when possible

### DIFF
--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -117,7 +117,7 @@ struct WaylandDSState
   struct zwp_relative_pointer_manager_v1 * relativePointerManager;
   struct zwp_pointer_constraints_v1 * pointerConstraints;
   struct zwp_relative_pointer_v1 * relativePointer;
-  struct zwp_confined_pointer_v1 * confinedPointer;
+  struct zwp_locked_pointer_v1 * lockedPointer;
   bool showPointer;
   uint32_t pointerEnterSerial;
 


### PR DESCRIPTION
Instead of using the confined pointer to do cursor capture, we instead
use locked pointers. We do not need the additional functionality that
confined pointer provides, and this also avoids compositor bugs that may
exist due to the more complicated implementation.

We still use confined pointers to do warp the pointer position.