### PR TITLE
[client] wayland: use consistent naming in poll module

### DIFF
--- a/client/displayservers/Wayland/clipboard.c
+++ b/client/displayservers/Wayland/clipboard.c
@@ -202,7 +202,7 @@ static void dataDeviceHandleDataOffer(void * data,
 
 static void clipboardReadCancel(struct ClipboardRead * data, bool freeBuf)
 {
-  waylandEpollUnregister(data->fd);
+  waylandPollUnregister(data->fd);
   close(data->fd);
   wl_data_offer_destroy(data->offer);
   if (freeBuf)
@@ -307,7 +307,7 @@ static void dataDeviceHandleSelection(void * opaque,
     return;
   }
 
-  if (!waylandEpollRegister(data->fd, clipboardReadCallback, data, EPOLLIN))
+  if (!waylandPollRegister(data->fd, clipboardReadCallback, data, EPOLLIN))
   {
     DEBUG_ERROR("Failed to register clipboard read into epoll: %s", strerror(errno));
     close(data->fd);
@@ -404,7 +404,7 @@ static void clipboardWriteCallback(uint32_t events, void * opaque)
     return;
 
 error:
-  waylandEpollUnregister(data->fd);
+  waylandPollUnregister(data->fd);
   close(data->fd);
   countedBufferRelease(&data->buffer);
   free(data);
@@ -432,7 +432,7 @@ static void dataSourceHandleSend(void * data, struct wl_data_source * source,
     data->pos    = 0;
     data->buffer = transfer->data;
     countedBufferAddRef(transfer->data);
-    waylandEpollRegister(fd, clipboardWriteCallback, data, EPOLLOUT);
+    waylandPollRegister(fd, clipboardWriteCallback, data, EPOLLOUT);
     return;
   }
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -229,8 +229,8 @@ int32_t waylandOutputGetScale(struct wl_output * output);
 // poll module
 bool waylandPollInit(void);
 void waylandWait(unsigned int time);
-bool waylandEpollRegister(int fd, WaylandPollCallback callback, void * opaque, uint32_t events);
-bool waylandEpollUnregister(int fd);
+bool waylandPollRegister(int fd, WaylandPollCallback callback, void * opaque, uint32_t events);
+bool waylandPollUnregister(int fd);
 
 // registry module
 bool waylandRegistryInit(void);


### PR DESCRIPTION
Some of the functions were named WaylandEpoll*, which is inconsistent.
This commit changed them to be WaylandPoll*.