### PR TITLE
Add libdecor pseudo-shell for GNOME Wayland

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -41,6 +41,9 @@ add_feature_info(ENABLE_X11 ENABLE_X11 "X11 support.")
 option(ENABLE_WAYLAND "Build with Wayland support" ON)
 add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
 
+option(ENABLE_LIBDECOR "Build with libdecor support" OFF)
+add_feature_info(ENABLE_LIBDECOR ENABLE_LIBDECOR "libdecor support.")
+
 if (NOT ENABLE_SDL AND NOT ENABLE_X11 AND NOT ENABLE_WAYLAND)
   message(FATAL_ERROR "One of ENABLE_SDL, ENABLE_X11, or ENABLE_WAYLAND must be on")
 endif()

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(displayserver_Wayland STATIC
 	poll.c
 	state.c
 	registry.c
+	shell_xdg.c
 	wayland.c
 	window.c
 )

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -9,6 +9,20 @@ pkg_check_modules(DISPLAYSERVER_Wayland_PKGCONFIG REQUIRED
 #pkg_check_modules(DISPLAYSERVER_Wayland_OPT_PKGCONFIG
 #)
 
+set(displayserver_Wayland_SHELL_SRC "")
+
+if (ENABLE_LIBDECOR)
+	pkg_check_modules(DISPLAYSERVER_Wayland_LIBDECOR REQUIRED
+		libdecor-0.1
+	)
+	list(APPEND DISPLAYSERVER_Wayland_PKGCONFIG_LIBRARIES ${DISPLAYSERVER_Wayland_LIBDECOR_LIBRARIES})
+	list(APPEND DISPLAYSERVER_Wayland_PKGCONFIG_INCLUDE_DIRS ${DISPLAYSERVER_Wayland_LIBDECOR_INCLUDE_DIRS})
+	list(APPEND displayserver_Wayland_SHELL_SRC shell_libdecor.c)
+	add_definitions(-D ENABLE_LIBDECOR)
+else()
+	list(APPEND displayserver_Wayland_SHELL_SRC shell_xdg.c)
+endif()
+
 add_library(displayserver_Wayland STATIC
 	clipboard.c
 	cursor.c
@@ -19,9 +33,9 @@ add_library(displayserver_Wayland STATIC
 	poll.c
 	state.c
 	registry.c
-	shell_xdg.c
 	wayland.c
 	window.c
+	${displayserver_Wayland_SHELL_SRC}
 )
 
 target_link_libraries(displayserver_Wayland

--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -85,11 +85,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
     wlWm.needsResize = false;
   }
 
-  if (wlWm.resizeSerial)
-  {
-    xdg_surface_ack_configure(wlWm.xdgSurface, wlWm.resizeSerial);
-    wlWm.resizeSerial = 0;
-  }
+  waylandShellAckConfigureIfNeeded();
 }
 #endif
 

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -38,11 +38,13 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
     wlWm.shm = wl_registry_bind(wlWm.registry, name, &wl_shm_interface, 1);
   else if (!strcmp(interface, wl_compositor_interface.name) && version >= 3)
     wlWm.compositor = wl_registry_bind(wlWm.registry, name, &wl_compositor_interface, 3);
+#ifndef ENABLE_LIBDECOR
   else if (!strcmp(interface, xdg_wm_base_interface.name))
     wlWm.xdgWmBase = wl_registry_bind(wlWm.registry, name, &xdg_wm_base_interface, 1);
   else if (!strcmp(interface, zxdg_decoration_manager_v1_interface.name))
     wlWm.xdgDecorationManager = wl_registry_bind(wlWm.registry, name,
         &zxdg_decoration_manager_v1_interface, 1);
+#endif
   else if (!strcmp(interface, zwp_relative_pointer_manager_v1_interface.name))
     wlWm.relativePointerManager = wl_registry_bind(wlWm.registry, name,
         &zwp_relative_pointer_manager_v1_interface, 1);

--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -1,0 +1,129 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2021 Guanzhong Chen (quantum2048@gmail.com)
+Copyright (C) 2021 Tudor Brindus (contact@tbrindus.ca)
+https://looking-glass.io
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "wayland.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include <libdecor.h>
+#include <wayland-client.h>
+
+#include "app.h"
+#include "common/debug.h"
+
+struct libdecor_configuration {
+  uint32_t serial;
+
+  bool has_window_state;
+  enum libdecor_window_state window_state;
+
+  bool has_size;
+  int window_width;
+  int window_height;
+};
+
+static void libdecorHandleError(struct libdecor * context, enum libdecor_error error,
+    const char *message)
+{
+  DEBUG_ERROR("Got libdecor error (%d): %s", error, message);
+}
+
+static struct libdecor_interface libdecorListener = {
+  libdecorHandleError,
+};
+
+static void libdecorFrameConfigure(struct libdecor_frame * frame,
+    struct libdecor_configuration * configuration, void * opaque)
+{
+  int width, height;
+  if (libdecor_configuration_get_content_size(configuration, frame, &width, &height)) {
+    wlWm.width = width;
+    wlWm.height = height;
+  }
+
+  enum libdecor_window_state windowState;
+  if (libdecor_configuration_get_window_state(configuration, &windowState))
+    wlWm.fullscreen = windowState & LIBDECOR_WINDOW_STATE_FULLSCREEN;
+
+  struct libdecor_state * state = libdecor_state_new(wlWm.width, wlWm.height);
+  libdecor_frame_commit(frame, state, wlWm.configured ? NULL : configuration);
+  libdecor_state_free(state);
+
+  if (wlWm.configured)
+  {
+    wlWm.needsResize = true;
+    wlWm.resizeSerial = configuration->serial;
+  }
+  else
+    wlWm.configured = true;
+}
+
+static void libdecorFrameClose(struct libdecor_frame * frame, void * opaque)
+{
+  app_handleCloseEvent();
+}
+
+static void libdecorFrameCommit(void * opaque)
+{
+}
+
+static struct libdecor_frame_interface libdecorFrameListener = {
+  libdecorFrameConfigure,
+  libdecorFrameClose,
+  libdecorFrameCommit,
+};
+
+bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless)
+{
+  wlWm.libdecor = libdecor_new(wlWm.display, &libdecorListener);
+  wlWm.libdecorFrame = libdecor_decorate(wlWm.libdecor, wlWm.surface, &libdecorFrameListener, NULL);
+
+  libdecor_frame_set_app_id(wlWm.libdecorFrame, "looking-glass-client");
+  libdecor_frame_set_title(wlWm.libdecorFrame, title);
+  libdecor_frame_map(wlWm.libdecorFrame);
+
+  while (!wlWm.configured)
+    wl_display_roundtrip(wlWm.display);
+
+  return true;
+}
+
+void waylandShellAckConfigureIfNeeded(void)
+{
+  if (wlWm.resizeSerial)
+  {
+    xdg_surface_ack_configure(libdecor_frame_get_xdg_surface(wlWm.libdecorFrame), wlWm.resizeSerial);
+    wlWm.resizeSerial = 0;
+  }
+}
+
+void waylandSetFullscreen(bool fs)
+{
+  if (fs)
+    libdecor_frame_set_fullscreen(wlWm.libdecorFrame, NULL);
+  else
+    libdecor_frame_unset_fullscreen(wlWm.libdecorFrame);
+}
+
+bool waylandGetFullscreen(void)
+{
+  return wlWm.fullscreen;
+}

--- a/client/displayservers/Wayland/shell_xdg.c
+++ b/client/displayservers/Wayland/shell_xdg.c
@@ -1,0 +1,148 @@
+/*
+Looking Glass - KVM FrameRelay (KVMFR) Client
+Copyright (C) 2021 Guanzhong Chen (quantum2048@gmail.com)
+Copyright (C) 2021 Tudor Brindus (contact@tbrindus.ca)
+https://looking-glass.io
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include "wayland.h"
+
+#include <stdbool.h>
+#include <wayland-client.h>
+
+#include "app.h"
+#include "common/debug.h"
+
+// XDG WM base listeners.
+
+static void xdgWmBasePing(void * data, struct xdg_wm_base * xdgWmBase, uint32_t serial)
+{
+  xdg_wm_base_pong(xdgWmBase, serial);
+}
+
+static const struct xdg_wm_base_listener xdgWmBaseListener = {
+  .ping = xdgWmBasePing,
+};
+
+// XDG Surface listeners.
+
+static void xdgSurfaceConfigure(void * data, struct xdg_surface * xdgSurface,
+    uint32_t serial)
+{
+  if (wlWm.configured)
+  {
+    wlWm.needsResize  = true;
+    wlWm.resizeSerial = serial;
+  }
+  else
+  {
+    xdg_surface_ack_configure(xdgSurface, serial);
+    wlWm.configured = true;
+  }
+}
+
+static const struct xdg_surface_listener xdgSurfaceListener = {
+  .configure = xdgSurfaceConfigure,
+};
+
+// XDG Toplevel listeners.
+
+static void xdgToplevelConfigure(void * data, struct xdg_toplevel * xdgToplevel,
+    int32_t width, int32_t height, struct wl_array * states)
+{
+  wlWm.width = width;
+  wlWm.height = height;
+  wlWm.fullscreen = false;
+
+  enum xdg_toplevel_state * state;
+  wl_array_for_each(state, states)
+  {
+    if (*state == XDG_TOPLEVEL_STATE_FULLSCREEN)
+      wlWm.fullscreen = true;
+  }
+}
+
+static void xdgToplevelClose(void * data, struct xdg_toplevel * xdgToplevel)
+{
+  app_handleCloseEvent();
+}
+
+static const struct xdg_toplevel_listener xdgToplevelListener = {
+  .configure = xdgToplevelConfigure,
+  .close     = xdgToplevelClose,
+};
+
+bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless)
+{
+  if (!wlWm.xdgWmBase)
+  {
+    DEBUG_ERROR("Compositor missing xdg_wm_base, will not proceed");
+    return false;
+  }
+
+  xdg_wm_base_add_listener(wlWm.xdgWmBase, &xdgWmBaseListener, NULL);
+
+  wlWm.xdgSurface = xdg_wm_base_get_xdg_surface(wlWm.xdgWmBase, wlWm.surface);
+  xdg_surface_add_listener(wlWm.xdgSurface, &xdgSurfaceListener, NULL);
+
+  wlWm.xdgToplevel = xdg_surface_get_toplevel(wlWm.xdgSurface);
+  xdg_toplevel_add_listener(wlWm.xdgToplevel, &xdgToplevelListener, NULL);
+  xdg_toplevel_set_title(wlWm.xdgToplevel, title);
+  xdg_toplevel_set_app_id(wlWm.xdgToplevel, "looking-glass-client");
+
+  if (fullscreen)
+    xdg_toplevel_set_fullscreen(wlWm.xdgToplevel, NULL);
+
+  if (maximize)
+    xdg_toplevel_set_maximized(wlWm.xdgToplevel);
+
+  if (wlWm.xdgDecorationManager)
+  {
+    wlWm.xdgToplevelDecoration = zxdg_decoration_manager_v1_get_toplevel_decoration(
+        wlWm.xdgDecorationManager, wlWm.xdgToplevel);
+    if (wlWm.xdgToplevelDecoration)
+    {
+      zxdg_toplevel_decoration_v1_set_mode(wlWm.xdgToplevelDecoration,
+          borderless ?
+            ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE :
+            ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+    }
+  }
+
+  return true;
+}
+
+void waylandShellAckConfigureIfNeeded(void)
+{
+  if (wlWm.resizeSerial)
+  {
+    xdg_surface_ack_configure(wlWm.xdgSurface, wlWm.resizeSerial);
+    wlWm.resizeSerial = 0;
+  }
+}
+
+void waylandSetFullscreen(bool fs)
+{
+  if (fs)
+    xdg_toplevel_set_fullscreen(wlWm.xdgToplevel, NULL);
+  else
+    xdg_toplevel_unset_fullscreen(wlWm.xdgToplevel);
+}
+
+bool waylandGetFullscreen(void)
+{
+  return wlWm.fullscreen;
+}

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -68,6 +68,8 @@ static bool waylandInit(const LG_DSInitParams params)
   wlWm.warpSupport = option_get_bool("wayland", "warpSupport");
 
   wlWm.display = wl_display_connect(NULL);
+  wlWm.width = params.w;
+  wlWm.height = params.h;
 
   if (!waylandPollInit())
     return false;

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -96,11 +96,16 @@ struct WaylandDSState
   EGLSurface glSurface;
 #endif
 
+#ifdef ENABLE_LIBDECOR
+  struct libdecor * libdecor;
+  struct libdecor_frame * libdecorFrame;
+#else
   struct xdg_wm_base * xdgWmBase;
   struct xdg_surface * xdgSurface;
   struct xdg_toplevel * xdgToplevel;
   struct zxdg_decoration_manager_v1 * xdgDecorationManager;
   struct zxdg_toplevel_decoration_v1 * xdgToplevelDecoration;
+#endif
 
   struct wl_surface * cursor;
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -236,11 +236,15 @@ bool waylandPollUnregister(int fd);
 bool waylandRegistryInit(void);
 void waylandRegistryFree(void);
 
+// shell module
+bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless);
+void waylandShellAckConfigureIfNeeded(void);
+void waylandSetFullscreen(bool fs);
+bool waylandGetFullscreen(void);
+
 // window module
 bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless);
 void waylandWindowFree(void);
 void waylandWindowUpdateScale(void);
 void waylandSetWindowSize(int x, int y);
-void waylandSetFullscreen(bool fs);
-bool waylandGetFullscreen(void);
 bool waylandIsValidPointerPos(int x, int y);

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -70,6 +70,8 @@ struct WaylandDSState
 {
   bool pointerGrabbed;
   bool keyboardGrabbed;
+  bool pointerInSurface;
+  bool focusedOnSurface;
 
   struct wl_display * display;
   struct wl_surface * surface;


### PR DESCRIPTION
This PR adds support for using `libdecor` to implement client-side decorations, allowing window decorations (i.e. title bar) to be shown on GNOME Wayland. This only exists to work around the GNOME people's blind belief that server-side decorations don't exist, despite there being a standard protocol for it.

This feature is experimental and can be enabled with `-DENABLE_LIBDECOR=ON`. It is off by default due to extra dependencies (`libdecor`, `cairo`) and the fact that the code is much less tested. Various `libdecor` plugins installed on the system may also cause crashes. Only users running GNOME Wayland and wishes to see decorations should use this feature.