### PR TITLE
[client] ci: correctly set CMAKE_BUILD_TYPE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         mkdir client/build
         cd client/build
-        cmake -DCMAKE_BUILD_TYPE={{ matrix.build_type }} -DENABLE_SDL=ON ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_SDL=ON ..
     - name: Build client
       run: |
         cd client/build


### PR DESCRIPTION
A $ sign is needed for GitHub Actions to interpolate the variable.