### PR TITLE
[host] windows: re-implement open log safely

### DIFF
--- a/host/platform/Windows/src/platform.h
+++ b/host/platform/Windows/src/platform.h
@@ -17,7 +17,26 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include <stdbool.h>
 #include <windows.h>
+
+/*
+ * Windows 10 provides this API via kernel32.dll as well as advapi32.dll and
+ * mingw opts for linking against the kernel32.dll version which is fine
+ * provided you don't intend to run this on earlier versions of windows. As such
+ * we need to lookup this method at runtime. */
+typedef WINBOOL WINAPI (*CreateProcessAsUserA_t)(HANDLE hToken,
+    LPCSTR lpApplicationName,
+    LPSTR lpCommandLine,
+    LPSECURITY_ATTRIBUTES lpProcessAttributes,
+    LPSECURITY_ATTRIBUTES lpThreadAttributes,
+    WINBOOL bInheritHandles,
+    DWORD dwCreationFlags,
+    LPVOID lpEnvironment,
+    LPCSTR lpCurrentDirectory,
+    LPSTARTUPINFOA lpStartupInfo,
+    LPPROCESS_INFORMATION lpProcessInformation);
+extern CreateProcessAsUserA_t f_CreateProcessAsUserA;
 
 #define WM_CALL_FUNCTION (WM_USER+1)
 #define WM_TRAYICON      (WM_USER+2)
@@ -30,5 +49,6 @@ struct MSG_CALL_FUNCTION
   LPARAM       lParam;
 };
 
+bool windowsSetupAPI(void);
 const char *getSystemLogDirectory(void);
 LRESULT sendAppMessage(UINT Msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Instead of doing ShellExecute from the service, we instead get the token
of the currently logged in user, and do CreateProcessAsUserA to run
notepad with that token. This should be safe.