### PR TITLE
[host] service: retry a few times when host fails to restart

### DIFF
--- a/host/include/interface/platform.h
+++ b/host/include/interface/platform.h
@@ -29,6 +29,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define LG_HOST_EXIT_KILLED  0x30
 // exit code for failed to start
 #define LG_HOST_EXIT_FAILED  0x40
+// exit code for failed to start, and no amount of restarting could help
+#define LG_HOST_EXIT_FATAL   0x50
 
 int  app_main(int argc, char * argv[]);
 bool app_init();

--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -717,6 +717,10 @@ VOID WINAPI SvcMain(DWORD dwArgc, LPTSTR *lpszArgv)
               break;
             }
 
+            case LG_HOST_EXIT_FATAL:
+              doLog("Host application failed to start with fatal error; will not restart\n");
+              goto stopped;
+
             default:
               doLog("Host application failed due to unknown error; restarting\n");
               break;

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -440,7 +440,7 @@ int app_main(int argc, char * argv[])
   {
     option_free();
     DEBUG_ERROR("Failed to get the application's data path");
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
   }
 
   const size_t len = strlen(dataPath) + sizeof(CONFIG_FILE) + 1;
@@ -457,18 +457,18 @@ int app_main(int argc, char * argv[])
   {
     option_free();
     DEBUG_ERROR("Failure to parse the command line");
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
   }
 
   if (!option_validate())
   {
     option_free();
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
   }
 
   // perform platform specific initialization
   if (!app_init())
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
 
   DEBUG_INFO("Looking Glass Host (%s)", BUILD_VERSION);
 
@@ -476,13 +476,13 @@ int app_main(int argc, char * argv[])
   if (!ivshmemInit(&shmDev))
   {
     DEBUG_ERROR("Failed to find the IVSHMEM device");
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
   }
 
   if (!ivshmemOpen(&shmDev))
   {
     DEBUG_ERROR("Failed to open the IVSHMEM device");
-    return LG_HOST_EXIT_FAILED;
+    return LG_HOST_EXIT_FATAL;
   }
 
   int exitcode  = 0;
@@ -502,21 +502,21 @@ int app_main(int argc, char * argv[])
           sizeof(udata), (uint8_t *)&udata)) != LGMP_OK)
   {
     DEBUG_ERROR("lgmpHostInit Failed: %s", lgmpStatusString(status));
-    exitcode = LG_HOST_EXIT_FAILED;
+    exitcode = LG_HOST_EXIT_FATAL;
     goto fail_ivshmem;
   }
 
   if ((status = lgmpHostQueueNew(app.lgmp, FRAME_QUEUE_CONFIG, &app.frameQueue)) != LGMP_OK)
   {
     DEBUG_ERROR("lgmpHostQueueCreate Failed (Frame): %s", lgmpStatusString(status));
-    exitcode = LG_HOST_EXIT_FAILED;
+    exitcode = LG_HOST_EXIT_FATAL;
     goto fail_lgmp;
   }
 
   if ((status = lgmpHostQueueNew(app.lgmp, POINTER_QUEUE_CONFIG, &app.pointerQueue)) != LGMP_OK)
   {
     DEBUG_ERROR("lgmpHostQueueNew Failed (Pointer): %s", lgmpStatusString(status));
-    exitcode = LG_HOST_EXIT_FAILED;
+    exitcode = LG_HOST_EXIT_FATAL;
     goto fail_lgmp;
   }
 
@@ -525,7 +525,7 @@ int app_main(int argc, char * argv[])
     if ((status = lgmpHostMemAlloc(app.lgmp, MAX_POINTER_SIZE, &app.pointerMemory[i])) != LGMP_OK)
     {
       DEBUG_ERROR("lgmpHostMemAlloc Failed (Pointer): %s", lgmpStatusString(status));
-      exitcode = LG_HOST_EXIT_FAILED;
+      exitcode = LG_HOST_EXIT_FATAL;
       goto fail_lgmp;
     }
     memset(lgmpHostMemPtr(app.pointerMemory[i]), 0, MAX_POINTER_SIZE);
@@ -535,7 +535,7 @@ int app_main(int argc, char * argv[])
   if ((status = lgmpHostMemAlloc(app.lgmp, MAX_POINTER_SIZE, &app.pointerShape)) != LGMP_OK)
   {
     DEBUG_ERROR("lgmpHostMemAlloc Failed (Pointer Shape): %s", lgmpStatusString(status));
-    exitcode = LG_HOST_EXIT_FAILED;
+    exitcode = LG_HOST_EXIT_FATAL;
     goto fail_lgmp;
   }
 
@@ -550,7 +550,7 @@ int app_main(int argc, char * argv[])
     if ((status = lgmpHostMemAllocAligned(app.lgmp, app.maxFrameSize, sz, &app.frameMemory[i])) != LGMP_OK)
     {
       DEBUG_ERROR("lgmpHostMemAlloc Failed (Frame): %s", lgmpStatusString(status));
-      exitcode = LG_HOST_EXIT_FAILED;
+      exitcode = LG_HOST_EXIT_FATAL;
       goto fail_lgmp;
     }
   }


### PR DESCRIPTION
Certain users of Radeon cards have observed that the host fails to start
at boot, with D3D11CreateDevice failing with HSTATUS 0x887a0004, which
translates to "The specified device interface or feature level is not
supported on this system."

This failure results in a LG_HOST_EXIT_FAILED exit code, which the service
does not attempt to restart. The user has to manually restart the service
for the host application to work.

These users reported that the host application started fine on
B2. This strongly suggests that the fix to enable capturing the login
screen made the host application start too early during the boot process,
and the graphics driver did not have time to initialize fully.

This PR allows the service to retry a few times on LG_HOST_EXIT_FAILED,
with exponential backoff, before giving up. This should cover this bug
and other similar bugs related to the early initialization which I do not
have logs for.

A preview version of the host is attached: [looking-glass-host-setup.zip](https://github.com/gnif/LookingGlass/files/6161931/looking-glass-host-setup.zip)

