### PR TITLE
Find and use correct valuators for mouse axes

### DIFF
--- a/client/displayservers/X11/x11.h
+++ b/client/displayservers/X11/x11.h
@@ -38,6 +38,8 @@ struct X11DSState
 
   int pointerDev;
   int keyboardDev;
+  int xValuator;
+  int yValuator;
 
   bool pointerGrabbed;
   bool keyboardGrabbed;


### PR DESCRIPTION
... instead of the first two valuators present in the event.  The Xorg
evdev driver can send events with only one valuator set if the mouse only
moved along one axis.