### PR TITLE
Add command line option to constrain the client's window dimensions

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -126,6 +126,7 @@ Command line arguments will override any options loaded from the config files.
 | win:keepAspect          | -r    | yes                    | Maintain the correct aspect ratio                                    |
 | win:forceAspect         |       | yes                    | Force the window to maintain the aspect ratio                        |
 | win:dontUpscale         |       | no                     | Never try to upscale the window                                      |
+| win:shrinkOnUpscale     |       | no                     | Limit the window dimensions when dontUpscale is enabled              |
 | win:borderless          | -d    | no                     | Borderless mode                                                      |
 | win:fullScreen          | -F    | no                     | Launch in fullscreen borderless mode                                 |
 | win:maximize            | -T    | no                     | Launch window maximized                                              |

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -163,6 +163,13 @@ static struct Option options[] =
   },
   {
     .module         = "win",
+    .name           = "shrinkOnUpscale",
+    .description    = "Limit the window dimensions when dontUpscale is enabled",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false,
+  },
+  {
+    .module         = "win",
     .name           = "borderless",
     .description    = "Borderless mode",
     .shortopt       = 'd',
@@ -493,6 +500,7 @@ bool config_load(int argc, char * argv[])
   g_params.keepAspect      = option_get_bool  ("win", "keepAspect"     );
   g_params.forceAspect     = option_get_bool  ("win", "forceAspect"    );
   g_params.dontUpscale     = option_get_bool  ("win", "dontUpscale"    );
+  g_params.shrinkOnUpscale = option_get_bool  ("win", "shrinkOnUpscale");
   g_params.borderless      = option_get_bool  ("win", "borderless"     );
   g_params.fullscreen      = option_get_bool  ("win", "fullScreen"     );
   g_params.maximize        = option_get_bool  ("win", "maximize"       );

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -238,6 +238,20 @@ void core_updatePositionInfo(void)
       g_state.dstRect.y = (g_state.windowH >> 1) - (g_state.dstRect.h >> 1);
     }
 
+    if (g_params.dontUpscale && g_params.shrinkOnUpscale)
+    {
+      if (g_state.windowW > srcW)
+      {
+        force = true;
+        g_state.dstRect.w = srcW;
+      }
+      if (g_state.windowH > srcH)
+      {
+        force = true;
+        g_state.dstRect.h = srcH;
+      }
+    }
+
     if (force && g_params.forceAspect)
     {
       g_state.resizeTimeout = microtime() + RESIZE_TIMEOUT;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -106,6 +106,7 @@ struct AppParams
   bool              keepAspect;
   bool              forceAspect;
   bool              dontUpscale;
+  bool              shrinkOnUpscale;
   bool              borderless;
   bool              fullscreen;
   bool              maximize;


### PR DESCRIPTION
Add command line option to constrain the client's window dimensions to the guest's resolution when `dontUpscale` is also enabled.

I really like `dontUpscale`, but it is annoying that resizing the window above the guest's resolution makes black bars show up around the image.

When this option is enabled, the window is limited to the guest's resolution so you never get the black bars.