### PR TITLE
[client] libdecor: fix gcc compile warnings-turned-errors

### DIFF
--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -46,10 +46,6 @@ static void libdecorHandleError(struct libdecor * context, enum libdecor_error e
   DEBUG_ERROR("Got libdecor error (%d): %s", error, message);
 }
 
-static struct libdecor_interface libdecorListener = {
-  libdecorHandleError,
-};
-
 static void libdecorFrameConfigure(struct libdecor_frame * frame,
     struct libdecor_configuration * configuration, void * opaque)
 {
@@ -81,15 +77,22 @@ static void libdecorFrameClose(struct libdecor_frame * frame, void * opaque)
   app_handleCloseEvent();
 }
 
-static void libdecorFrameCommit(void * opaque)
+static void libdecorFrameCommit(struct libdecor_frame * frame, void * opaque)
 {
 }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+static struct libdecor_interface libdecorListener = {
+  libdecorHandleError,
+};
 
 static struct libdecor_frame_interface libdecorFrameListener = {
   libdecorFrameConfigure,
   libdecorFrameClose,
   libdecorFrameCommit,
 };
+#pragma GCC diagnostic pop
 
 bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless)
 {


### PR DESCRIPTION
This commit fixes the -Wmissing-field-initializers warning, which can only
be disabled with a pragma. GCC wants us to Initialize libdecor reserved
fields, which requires knowing how many reserved fields there are.
This is an implementation detail, and so we can only disable the warning.

This also fixes -Wincompatible-pointer-types, which is an actual bug.