### PR TITLE
[client] wayland: do not leak cursor wl_buffer and wl_surface

### DIFF
--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -82,15 +82,23 @@ bool waylandCursorInit(void)
     return false;
   }
 
-  struct wl_buffer * cursorBuffer = createCursorBuffer();
-  if (cursorBuffer)
+  wlWm.cursorBuffer = createCursorBuffer();
+  if (wlWm.cursorBuffer)
   {
     wlWm.cursor = wl_compositor_create_surface(wlWm.compositor);
-    wl_surface_attach(wlWm.cursor, cursorBuffer, 0, 0);
+    wl_surface_attach(wlWm.cursor, wlWm.cursorBuffer, 0, 0);
     wl_surface_commit(wlWm.cursor);
   }
 
   return true;
+}
+
+void waylandCursorFree(void)
+{
+  if (wlWm.cursor)
+    wl_surface_destroy(wlWm.cursor);
+  if (wlWm.cursorBuffer)
+    wl_buffer_destroy(wlWm.cursorBuffer);
 }
 
 void waylandShowPointer(bool show)

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -121,6 +121,7 @@ static void waylandFree(void)
   waylandInputFree();
   waylandOutputFree();
   waylandRegistryFree();
+  waylandCursorFree();
   wl_display_disconnect(wlWm.display);
 }
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -110,6 +110,7 @@ struct WaylandDSState
 #endif
 
   struct wl_surface * cursor;
+  struct wl_buffer * cursorBuffer;
 
   struct wl_data_device_manager * dataDeviceManager;
 
@@ -188,6 +189,7 @@ void waylandCBRelease(void);
 
 // cursor module
 bool waylandCursorInit(void);
+void waylandCursorFree(void);
 void waylandShowPointer(bool show);
 
 // gl module


### PR DESCRIPTION
This PR frees the `wl_buffer` and `wl_surface` associated with the cursor so that the ASan output is cleaner.