### PR TITLE
[host] service: disable handle inheritance when spawning host

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -284,7 +284,7 @@ void Launch(void)
       NULL,
       NULL,
       NULL,
-      TRUE,
+      FALSE,
       flags,
       NULL,
       os_getDataPath(),


### PR DESCRIPTION
We don't actually have any handles that should be inherited, so specifying
TRUE for bInheritHandles to CreateProcessAsUserA is pointless.

Furthermore, according to MSDN, "[y]ou cannot inherit handles across
sessions," and we are spawning the host in a different session, so this
is even more pointless.