### PR TITLE
[host] nvfbc: fix null dereference in mouse hook handler

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -91,7 +91,8 @@ static void on_mouseMove(int x, int y)
   this->hasMousePosition = true;
   this->mouseX           = x;
   this->mouseY           = y;
-  lgSignalEvent(this->cursorEvents[0]);
+  if (this->cursorEvents[0])
+    lgSignalEvent(this->cursorEvents[0]);
 }
 
 static const char * nvfbc_getName(void)


### PR DESCRIPTION
Since we now let the mouse hook linger until the process is killed, the
cursor event that the hook signals may now be null, as the capture could
have stopped. If the hook fires during this time, a crash occurs.