### PR TITLE
[client] ui: add input:helpMenuDelay option

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -397,7 +397,7 @@ void app_handleRenderEvent(const uint64_t timeUs)
   }
   else
   {
-    if (!g_state.escapeHelp && timeUs - g_state.escapeTime > 200000)
+    if (!g_state.escapeHelp && timeUs - g_state.escapeTime > g_params.helpMenuDelayUs)
     {
       g_state.escapeHelp = true;
       app_showHelp(true);

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -352,6 +352,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_BOOL,
     .value.x_bool   = false
   },
+  {
+    .module         = "input",
+    .name           = "helpMenuDelay",
+    .description    = "Show help menu after holding down the escape key for this many milliseconds",
+    .type           = OPTION_TYPE_INT,
+    .value.x_int    = 200
+  },
 
   // spice options
   {
@@ -546,6 +553,8 @@ bool config_load(int argc, char * argv[])
   g_params.mouseRedraw            = option_get_bool("input", "mouseRedraw"           );
   g_params.autoCapture            = option_get_bool("input", "autoCapture"           );
   g_params.captureInputOnly       = option_get_bool("input", "captureOnly"           );
+
+  g_params.helpMenuDelayUs = option_get_int("input", "helpMenuDelay") * (uint64_t) 1000;
 
   g_params.minimizeOnFocusLoss = option_get_bool("win", "minimizeOnFocusLoss");
 

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -137,6 +137,7 @@ struct AppParams
   bool              captureOnStart;
   bool              quickSplash;
   bool              alwaysShowCursor;
+  uint64_t          helpMenuDelayUs;
 
   unsigned int      cursorPollInterval;
   unsigned int      framePollInterval;


### PR DESCRIPTION
This option controls the time period (in ms) after which the help menu
appears when holding down the escape key. After this time period,
capture mode is no longer toggled.

This fixes #527.