### PR TITLE
[client] wayland: synchronize host cursor position with guest

### DIFF
--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -106,7 +106,3 @@ void waylandShowPointer(bool show)
   wlWm.showPointer = show;
   wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, show ? wlWm.cursor : NULL, 0, 0);
 }
-
-void waylandGuestPointerUpdated(double x, double y, int localX, int localY)
-{
-}

--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -413,3 +413,11 @@ void waylandRealignPointer(void)
   if (!wlWm.warpSupport)
     app_resyncMouseBasic();
 }
+
+void waylandGuestPointerUpdated(double x, double y, int localX, int localY)
+{
+  if (!wlWm.warpSupport || !wlWm.pointerInSurface)
+    return;
+
+  waylandWarpPointer(localX, localY, false);
+}

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -190,7 +190,6 @@ void waylandCBRelease(void);
 // cursor module
 bool waylandCursorInit(void);
 void waylandCursorFree(void);
-void waylandGuestPointerUpdated(double x, double y, int localX, int localY);
 void waylandShowPointer(bool show);
 
 // gl module
@@ -228,6 +227,7 @@ void waylandUngrabKeyboard(void);
 void waylandUngrabPointer(void);
 void waylandRealignPointer(void);
 void waylandWarpPointer(int x, int y, bool exiting);
+void waylandGuestPointerUpdated(double x, double y, int localX, int localY);
 
 // output module
 bool waylandOutputInit(void);


### PR DESCRIPTION
This mirrors the x11 implementation, allowing the pointer to move
correctly into overlapping windows.