### PR TITLE
[client] ds: avoid util_cursorToInt when warping pointer

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -459,10 +459,10 @@ void waylandRealignPointer(void)
     app_resyncMouseBasic();
 }
 
-void waylandGuestPointerUpdated(double x, double y, int localX, int localY)
+void waylandGuestPointerUpdated(double x, double y, double localX, double localY)
 {
   if (!wlWm.warpSupport || !wlWm.pointerInSurface || wlWm.lockedPointer)
     return;
 
-  waylandWarpPointer(localX, localY, false);
+  waylandWarpPointer((int) localX, (int) localY, false);
 }

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -230,7 +230,7 @@ void waylandCapturePointer(void);
 void waylandUncapturePointer(void);
 void waylandRealignPointer(void);
 void waylandWarpPointer(int x, int y, bool exiting);
-void waylandGuestPointerUpdated(double x, double y, int localX, int localY);
+void waylandGuestPointerUpdated(double x, double y, double localX, double localY);
 
 // output module
 bool waylandOutputInit(void);

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -963,7 +963,7 @@ static void x11GLSwapBuffers(void)
 }
 #endif
 
-static void x11GuestPointerUpdated(double x, double y, int localX, int localY)
+static void x11GuestPointerUpdated(double x, double y, double localX, double localY)
 {
   if (app_isCaptureMode() || !x11.entered)
     return;

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -129,7 +129,7 @@ struct LG_DisplayServerOps
 #endif
 
   /* dm specific cursor implementations */
-  void (*guestPointerUpdated)(double x, double y, int localX, int localY);
+  void (*guestPointerUpdated)(double x, double y, double localX, double localY);
   void (*showPointer)(bool show);
   void (*grabKeyboard)();
   void (*ungrabKeyboard)();

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -318,13 +318,13 @@ void core_stopFrameThread(void)
 
 void core_handleGuestMouseUpdate(void)
 {
-  int x, y;
   struct DoublePoint localPos;
   util_guestCurToLocal(&localPos);
-  localPos.x = util_clamp(localPos.x, 0.0, g_state.dstRect.w);
-  localPos.y = util_clamp(localPos.y, 0.0, g_state.dstRect.h);
-  util_cursorToInt(localPos.x, localPos.y, &x, &y);
-  g_state.ds->guestPointerUpdated(g_cursor.guest.x, g_cursor.guest.y, x, y);
+  g_state.ds->guestPointerUpdated(
+    g_cursor.guest.x, g_cursor.guest.y,
+    util_clamp(localPos.x, 0.0, g_state.dstRect.w),
+    util_clamp(localPos.y, 0.0, g_state.dstRect.h)
+  );
 }
 
 void core_handleMouseGrabbed(double ex, double ey)


### PR DESCRIPTION
Using util_cursorToInt messes with the error tracking for normal movements,
and is not necessary since we are computing an absolute position on the
client window.