### PR TITLE
[common] option: Reformat help and support rST tables

### DIFF
--- a/common/include/common/option.h
+++ b/common/include/common/option.h
@@ -32,6 +32,13 @@ enum OptionType
   OPTION_TYPE_CUSTOM
 };
 
+enum doHelpMode
+{
+  DOHELP_MODE_NO = 0,
+  DOHELP_MODE_YES,
+  DOHELP_MODE_RST
+};
+
 struct Option;
 
 struct Option


### PR DESCRIPTION
Intersections of table lines have '+' added, and adds new command line flag --rst-help, which adds some extra formatting to the make it an rST compliant table for the in-line docs.

### Normal
[![image](https://user-images.githubusercontent.com/5211576/117191054-21ec9680-adae-11eb-86f1-789331f4e7bf.png)](https://gist.github.com/JJRcop/045ea8ded8dabe1157558f29643e01d3)

### rST compliant
[![image](https://user-images.githubusercontent.com/5211576/117191527-accd9100-adae-11eb-913a-3d46a84c87fa.png)](https://gist.github.com/JJRcop/d7a1598b8b08bd577c5824bd914c0970)