### PR TITLE
[client] egl: use eglSwapBuffersWithDamageKHR for cursor-only updates

### DIFF
--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -254,7 +254,7 @@ static EGLNativeWindowType sdlGetEGLNativeWindow(void)
   }
 }
 
-static void sdlEGLSwapBuffers(EGLDisplay display, EGLSurface surface)
+static void sdlEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count)
 {
   eglSwapBuffers(display, surface);
 }

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -37,7 +37,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, wl_shm_interface.name))
     wlWm.shm = wl_registry_bind(wlWm.registry, name, &wl_shm_interface, 1);
   else if (!strcmp(interface, wl_compositor_interface.name) && version >= 3)
-    wlWm.compositor = wl_registry_bind(wlWm.registry, name, &wl_compositor_interface, 3);
+    wlWm.compositor = wl_registry_bind(wlWm.registry, name,
+        // we only need v3 to run, but v4 can use eglSwapBuffersWithDamageKHR
+        &wl_compositor_interface, version > 4 ? 4 : version);
 #ifndef ENABLE_LIBDECOR
   else if (!strcmp(interface, xdg_wm_base_interface.name))
     wlWm.xdgWmBase = wl_registry_bind(wlWm.registry, name, &xdg_wm_base_interface, 1);

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -29,6 +29,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 # include <EGL/eglext.h>
 #endif
 
+#include "egl_dynprocs.h"
 #include "common/locking.h"
 #include "common/countedbuffer.h"
 #include "interface/displayserver.h"
@@ -66,6 +67,13 @@ struct SurfaceOutput
   struct wl_list link;
 };
 
+enum EGLSwapWithDamageState {
+  SWAP_WITH_DAMAGE_UNKNOWN,
+  SWAP_WITH_DAMAGE_UNSUPPORTED,
+  SWAP_WITH_DAMAGE_KHR,
+  SWAP_WITH_DAMAGE_EXT,
+};
+
 struct WaylandDSState
 {
   bool pointerGrabbed;
@@ -88,8 +96,12 @@ struct WaylandDSState
   bool warpSupport;
   double cursorX, cursorY;
 
-#ifdef ENABLE_EGL
+#if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
   struct wl_egl_window * eglWindow;
+  bool eglSwapWithDamageInit;
+  eglSwapBuffersWithDamageKHR_t eglSwapWithDamage;
+  EGLint * eglDamageRects;
+  int eglDamageRectCount;
 #endif
 
 #ifdef ENABLE_OPENGL
@@ -197,7 +209,7 @@ void waylandShowPointer(bool show);
 #if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
 bool waylandEGLInit(int w, int h);
 EGLDisplay waylandGetEGLDisplay(void);
-void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface);
+void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count);
 #endif
 
 #ifdef ENABLE_EGL

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -114,5 +114,3 @@ bool waylandIsValidPointerPos(int x, int y)
 {
   return x >= 0 && x < wlWm.width && y >= 0 && y < wlWm.height;
 }
-
-

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -930,7 +930,7 @@ static EGLNativeWindowType x11GetEGLNativeWindow(void)
   return (EGLNativeWindowType)x11.window;
 }
 
-static void x11EGLSwapBuffers(EGLDisplay display, EGLSurface surface)
+static void x11EGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count)
 {
   eglSwapBuffers(display, surface);
 }

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -66,7 +66,7 @@ bool app_getProp(LG_DSProperty prop, void * ret);
 #ifdef ENABLE_EGL
 EGLDisplay app_getEGLDisplay(void);
 EGLNativeWindowType app_getEGLNativeWindow(void);
-void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface);
+void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count);
 #endif
 
 #ifdef ENABLE_OPENGL

--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -17,6 +17,8 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifndef _H_LG_EGL_DYNPROCS_
+#define _H_LG_EGL_DYNPROCS_
 #ifdef ENABLE_EGL
 
 #include <EGL/egl.h>
@@ -24,6 +26,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 typedef EGLDisplay (*eglGetPlatformDisplayEXT_t)(EGLenum platform,
     void *native_display, const EGLint *attrib_list);
+typedef void (*eglSwapBuffersWithDamageKHR_t)(EGLDisplay dpy,
+    EGLSurface surface, const EGLint *rects, EGLint n_rects);
 typedef void (*glEGLImageTargetTexture2DOES_t)(GLenum target,
     GLeglImageOES image);
 
@@ -31,6 +35,8 @@ struct EGLDynProcs
 {
   eglGetPlatformDisplayEXT_t     eglGetPlatformDisplay;
   eglGetPlatformDisplayEXT_t     eglGetPlatformDisplayEXT;
+  eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageKHR;
+  eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageEXT;
   glEGLImageTargetTexture2DOES_t glEGLImageTargetTexture2DOES;
 };
 
@@ -41,3 +47,5 @@ void egl_dynProcsInit(void);
 #else
   #define egl_dynProcsInit(...)
 #endif
+
+#endif // _H_LG_EGL_DYNPROCS_

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -22,6 +22,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <stdbool.h>
 #include <EGL/egl.h>
+#include "common/types.h"
 
 typedef enum LG_ClipboardData
 {
@@ -115,7 +116,7 @@ struct LG_DisplayServerOps
   /* EGL support */
   EGLDisplay (*getEGLDisplay)(void);
   EGLNativeWindowType (*getEGLNativeWindow)(void);
-  void (*eglSwapBuffers)(EGLDisplay display, EGLSurface surface);
+  void (*eglSwapBuffers)(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count);
 #endif
 
 #ifdef ENABLE_OPENGL

--- a/client/renderers/EGL/cursor.c
+++ b/client/renderers/EGL/cursor.c
@@ -215,6 +215,16 @@ void egl_cursor_set_state(EGL_Cursor * cursor, const bool visible, const float x
   cursor->y       = y;
 }
 
+struct CursorState egl_cursor_get_state(EGL_Cursor * cursor, int width, int height) {
+  return (struct CursorState) {
+    .visible = cursor->visible,
+    .rect.x = (cursor->x * width + width) / 2,
+    .rect.y = (-cursor->y * height + height) / 2 - cursor->h * height,
+    .rect.w = cursor->w * width + 2,
+    .rect.h = cursor->h * height + 2,
+  };
+}
+
 void egl_cursor_render(EGL_Cursor * cursor, LG_RendererRotate rotate)
 {
   if (!cursor->visible)

--- a/client/renderers/EGL/cursor.h
+++ b/client/renderers/EGL/cursor.h
@@ -25,6 +25,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 typedef struct EGL_Cursor EGL_Cursor;
 
+struct CursorState {
+  bool visible;
+  struct Rect rect;
+};
+
 bool egl_cursor_init(EGL_Cursor ** cursor);
 void egl_cursor_free(EGL_Cursor ** cursor);
 
@@ -40,5 +45,7 @@ void egl_cursor_set_size(EGL_Cursor * cursor, const float x, const float y);
 
 void egl_cursor_set_state(EGL_Cursor * cursor, const bool visible,
     const float x, const float y);
+
+struct CursorState egl_cursor_get_state(EGL_Cursor * cursor, int width, int height);
 
 void egl_cursor_render(EGL_Cursor * cursor, LG_RendererRotate rotate);

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -448,9 +448,9 @@ EGLNativeWindowType app_getEGLNativeWindow(void)
   return g_state.ds->getEGLNativeWindow();
 }
 
-void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface)
+void app_eglSwapBuffers(EGLDisplay display, EGLSurface surface, const struct Rect * damage, int count)
 {
-  g_state.ds->eglSwapBuffers(display, surface);
+  g_state.ds->eglSwapBuffers(display, surface, damage, count);
 }
 #endif
 

--- a/client/src/egl_dynprocs.c
+++ b/client/src/egl_dynprocs.c
@@ -31,6 +31,10 @@ void egl_dynProcsInit(void)
     eglGetProcAddress("eglGetPlatformDisplayEXT");
   g_egl_dynProcs.glEGLImageTargetTexture2DOES = (glEGLImageTargetTexture2DOES_t)
     eglGetProcAddress("glEGLImageTargetTexture2DOES");
+  g_egl_dynProcs.eglSwapBuffersWithDamageKHR = (eglSwapBuffersWithDamageKHR_t)
+    eglGetProcAddress("eglSwapBuffersWithDamageKHR");
+  g_egl_dynProcs.eglSwapBuffersWithDamageEXT = (eglSwapBuffersWithDamageKHR_t)
+    eglGetProcAddress("eglSwapBuffersWithDamageEXT");
 };
 
 #endif


### PR DESCRIPTION
Instead of damaging the entire surface when rendering a cursor move,
we can use the EGL_KHR_swap_buffers_with_damage extension to only
damage the part of the window covered by the cursor. This should
reduce the cursor movement latency on Wayland.

This should probably be tested by some Wayland users first before merging.
