### PR TITLE
[client] egl: use new util_hasGLExt helper to check extensions

### DIFF
--- a/client/displayservers/SDL/sdl.c
+++ b/client/displayservers/SDL/sdl.c
@@ -35,6 +35,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "egl_dynprocs.h"
 #include "common/types.h"
 #include "common/debug.h"
+#include "util.h"
 
 struct SDLDSState
 {
@@ -199,14 +200,14 @@ static EGLDisplay sdlGetEGLDisplay(void)
 
   const char *early_exts = eglQueryString(NULL, EGL_EXTENSIONS);
 
-  if (strstr(early_exts, "EGL_KHR_platform_base") != NULL &&
+  if (util_hasGLExt(early_exts, "EGL_KHR_platform_base") &&
       g_egl_dynProcs.eglGetPlatformDisplay)
   {
     DEBUG_INFO("Using eglGetPlatformDisplay");
     return g_egl_dynProcs.eglGetPlatformDisplay(platform, native, NULL);
   }
 
-  if (strstr(early_exts, "EGL_EXT_platform_base") != NULL &&
+  if (util_hasGLExt(early_exts, "EGL_EXT_platform_base") &&
       g_egl_dynProcs.eglGetPlatformDisplayEXT)
   {
     DEBUG_INFO("Using eglGetPlatformDisplayEXT");

--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -28,6 +28,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "app.h"
 #include "common/debug.h"
+#include "util.h"
 
 #if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
 #include "egl_dynprocs.h"
@@ -49,14 +50,14 @@ EGLDisplay waylandGetEGLDisplay(void)
 
   const char *early_exts = eglQueryString(NULL, EGL_EXTENSIONS);
 
-  if (strstr(early_exts, "EGL_KHR_platform_wayland") != NULL &&
+  if (util_hasGLExt(early_exts, "EGL_KHR_platform_wayland") &&
       g_egl_dynProcs.eglGetPlatformDisplay)
   {
     DEBUG_INFO("Using eglGetPlatformDisplay");
     return g_egl_dynProcs.eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, native, NULL);
   }
 
-  if (strstr(early_exts, "EGL_EXT_platform_wayland") != NULL &&
+  if (util_hasGLExt(early_exts, "EGL_EXT_platform_wayland") &&
       g_egl_dynProcs.eglGetPlatformDisplayEXT)
   {
     DEBUG_INFO("Using eglGetPlatformDisplayEXT");

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -42,6 +42,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "app.h"
 #include "common/debug.h"
 #include "common/time.h"
+#include "util.h"
 
 #define _NET_WM_STATE_REMOVE 0
 #define _NET_WM_STATE_ADD    1
@@ -901,14 +902,14 @@ static EGLDisplay x11GetEGLDisplay(void)
   EGLDisplay ret;
   const char *early_exts = eglQueryString(NULL, EGL_EXTENSIONS);
 
-  if (strstr(early_exts, "EGL_KHR_platform_base") != NULL &&
+  if (util_hasGLExt(early_exts, "EGL_KHR_platform_base") &&
       g_egl_dynProcs.eglGetPlatformDisplay)
   {
     DEBUG_INFO("Using eglGetPlatformDisplay");
     ret = g_egl_dynProcs.eglGetPlatformDisplay(EGL_PLATFORM_X11_KHR,
         x11.display, NULL);
   }
-  else if (strstr(early_exts, "EGL_EXT_platform_base") != NULL &&
+  else if (util_hasGLExt(early_exts, "EGL_EXT_platform_base") &&
       g_egl_dynProcs.eglGetPlatformDisplayEXT)
   {
     DEBUG_INFO("Using eglGetPlatformDisplayEXT");

--- a/client/include/util.h
+++ b/client/include/util.h
@@ -32,6 +32,7 @@ void util_cursorToInt(double ex, double ey, int *x, int *y);
 bool util_guestCurToLocal(struct DoublePoint *local);
 void util_localCurToGuest(struct DoublePoint *guest);
 void util_rotatePoint(struct DoublePoint *point);
+bool util_hasGLExt(const char * exts, const char * ext);
 
 static inline double util_clamp(double x, double min, double max)
 {

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -698,7 +698,7 @@ bool egl_render_startup(void * opaque)
 
   if (g_egl_dynProcs.glEGLImageTargetTexture2DOES)
   {
-    if (strstr(client_exts, "EGL_EXT_image_dma_buf_import") != NULL)
+    if (util_hasGLExt(client_exts, "EGL_EXT_image_dma_buf_import"))
     {
       /*
        * As of version 455.45.01 NVidia started advertising support for this

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -21,9 +21,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "main.h"
 
 #include "common/debug.h"
+#include "common/stringutils.h"
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <assert.h>
 #include <math.h>
 
@@ -206,4 +208,9 @@ void util_rotatePoint(struct DoublePoint *point)
       point->y =  temp;
       break;
   }
+}
+
+bool util_hasGLExt(const char * exts, const char * ext)
+{
+  return str_containsValue(exts, ' ', ext);
 }

--- a/common/include/common/stringutils.h
+++ b/common/include/common/stringutils.h
@@ -20,6 +20,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #ifndef _H_LG_COMMON_STRINGUTILS
 #define _H_LG_COMMON_STRINGUTILS
 
+#include <stdbool.h>
+
 // vsprintf but with buffer allocation
 int valloc_sprintf(char ** str, const char * format, va_list ap)
   __attribute__ ((format (printf, 2, 0)));
@@ -27,5 +29,8 @@ int valloc_sprintf(char ** str, const char * format, va_list ap)
 // sprintf but with buffer allocation
 int alloc_sprintf(char ** str, const char * format, ...)
   __attribute__ ((format (printf, 2, 3)));
+
+// Find value in a list separated by delimiter.
+bool str_containsValue(const char * list, char delimiter, const char * value);
 
 #endif

--- a/common/src/stringutils.c
+++ b/common/src/stringutils.c
@@ -17,9 +17,13 @@ this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
+
+#include "common/stringutils.h"
 
 int valloc_sprintf(char ** str, const char * format, va_list ap)
 {
@@ -63,4 +67,24 @@ int alloc_sprintf(char ** str, const char * format, ...)
   int ret = valloc_sprintf(str, format, ap);
   va_end(ap);
   return ret;
+}
+
+bool str_containsValue(const char * list, char delimiter, const char * value)
+{
+  size_t len = strlen(value);
+  const char span[] = {delimiter, '\0'};
+
+  while (*list)
+  {
+    if (*list == delimiter)
+    {
+      ++list;
+      continue;
+    }
+    size_t n = strcspn(list, span);
+    if (n == len && strncmp(value, list, n) == 0)
+      return true;
+    list += n;
+  }
+  return false;
 }


### PR DESCRIPTION
We previously used strstr, which can be prone to false positives when
the name of one extension is a substring of another extension.

This commit creates the helper function util_hasGLExt, which asserts
that the substring found in extension list is bounded by either spaces
or the beginning/end of the string.