### PR TITLE
[client] wayland: avoid protocol error when warping in capture mode

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -422,7 +422,7 @@ void waylandUngrabKeyboard(void)
 
 void waylandWarpPointer(int x, int y, bool exiting)
 {
-  if (!wlWm.pointerInSurface)
+  if (!wlWm.pointerInSurface || wlWm.lockedPointer)
     return;
 
   if (x < 0) x = 0;


### PR DESCRIPTION
When using locked pointer (i.e. capture mode), it doesn't make sense to
warp the cursor, so we disable it. This fixes #540.