### PR TITLE
[obs] fix oob cursor writes

### DIFF
--- a/obs/lg.c
+++ b/obs/lg.c
@@ -259,7 +259,7 @@ static void * pointerThread(void * data)
 
         case CURSOR_TYPE_MONOCHROME:
         {
-          dataSize = cursor->height * sizeof(uint32_t);
+          dataSize = cursor->height * cursor->width * sizeof(uint32_t);
           allocCursorData(this, dataSize);
 
           const int hheight = cursor->height / 2;


### PR DESCRIPTION
Allocate enough memory for the cursor data!

I think the alpha mask is still messed up for monochrome cursors but at least it doesn't segfault now.