### PR TITLE
[doc] point IRC to Libera.Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ https://forum.level1techs.com/c/software/lookingglass/142
 
 ## IRC
 
-Join us in the #LookingGlass channel on the FreeNode network
+Join us in the #LookingGlass channel on the Libera.Chat network.
 
 ## Trello
 


### PR DESCRIPTION
Due to recent events involved with freenode, we decided to move the IRC
channel to Libera.Chat.