### PR TITLE
[client] wayland: offer all supported clipboard formats

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -180,6 +180,7 @@ static void keyboardLeaveHandler(void * data, struct wl_keyboard * keyboard,
     return;
 
   wlWm.focusedOnSurface = false;
+  waylandCBInvalidate();
   app_handleFocusEvent(false);
 }
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -177,13 +177,9 @@ struct WCBState
   struct wl_data_device * dataDevice;
   char lgMimetype[64];
 
-  enum LG_ClipboardData pendingType;
-  char * pendingMimetype;
-  bool isSelfCopy;
-
-  enum LG_ClipboardData stashedType;
-  uint8_t * stashedContents;
-  ssize_t stashedSize;
+  char * mimetypes[LG_CLIPBOARD_DATA_NONE];
+  struct wl_data_offer * offer;
+  struct wl_data_offer * dndOffer;
 
   bool haveRequest;
   LG_ClipboardData type;
@@ -199,6 +195,7 @@ bool waylandCBInit(void);
 void waylandCBRequest(LG_ClipboardData type);
 void waylandCBNotice(LG_ClipboardData type);
 void waylandCBRelease(void);
+void waylandCBInvalidate(void);
 
 // cursor module
 bool waylandCursorInit(void);


### PR DESCRIPTION
This commit restructures the Wayland clipboard handling for host->VM.

Before, we select one clipboard format and buffers the data for it, to
be presented to spice when needed.

Now, we simply offer all clipboard formats supported, and only when spice
asks for the data do we actually read the wl_data_offer. The wl_data_offer
is kept around until a new offer is presented, the offer invalidated, or
when we lose keyboard focus. This is in accordance with the specification
for wl_data_device::selection, which states that:

> The data_offer is valid until a new data_offer or NULL is received or
> until the client loses keyboard focus. The client must destroy the
> previous selection data_offer, if any, upon receiving this event.

We still buffer the entire clipboard data into memory because we have no
knowledge of the clipboard data size in advance and cannot do incremental
transfers.

Furthermore, if the user performs drag-and-drop on our window, we may have
need to handle multiple wl_data_offer objects at the same time. Therefore,
instead of storing state on the global wlCb object, we instead allocate
memory and store it as user_data on the wl_data_offer. As a result, we also
handle drag-and-drop so that we can free the memory.

Currently, this appears to work, but it's best that @Xyene review this.