### PR TITLE
[obs] install into plugin dir

### DIFF
--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -32,6 +32,23 @@ add_compile_options(
 set(EXE_FLAGS "-Wl,--gc-sections")
 set(CMAKE_C_STANDARD 11)
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set(OBS_PLUGIN_DIR 64bit)
+else()
+	set(OBS_PLUGIN_DIR 32bit)
+endif()
+
+if(USER_INSTALL)
+	if(DEFINED ENV{XDG_CONFIG_HOME})
+		set(OBS_PLUGIN_PREFIX $ENV{XDG_CONFIG_HOME})
+	else()
+		set(OBS_PLUGIN_PREFIX $ENV{HOME}/.config)
+	endif()
+	set(OBS_PLUGIN_PREFIX ${OBS_PLUGIN_PREFIX}/obs-studio/plugins)
+else()
+	set(OBS_PLUGIN_PREFIX ${CMAKE_INSTALL_DATADIR}/obs/obs-plugins)
+endif()
+
 add_definitions(-D ATOMIC_LOCKING)
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 
@@ -67,6 +84,10 @@ target_link_libraries(looking-glass-obs
 	${EXE_FLAGS}
 	lg_common
 	lgmp
+)
+
+install(TARGETS looking-glass-obs
+	LIBRARY DESTINATION ${OBS_PLUGIN_PREFIX}/${CMAKE_PROJECT_NAME}/bin/${OBS_PLUGIN_DIR}
 )
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)


### PR DESCRIPTION
`/usr/share/obs/blahblah` is where obs expects to find the dylib, so put it there!