### PR TITLE
[client] wayland: lock confine-related code to avoid race

### DIFF
--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -141,6 +141,7 @@ struct WaylandDSState
   struct zwp_locked_pointer_v1 * lockedPointer;
   bool showPointer;
   uint32_t pointerEnterSerial;
+  LG_Lock confineLock;
 
   struct zwp_idle_inhibit_manager_v1 * idleInhibitManager;
   struct zwp_idle_inhibitor_v1 * idleInhibitor;


### PR DESCRIPTION
This should fix the occasional Wayland protocol errors that arise when
the UI thread and the cursor thread race.

Example of error that is fixed:

    zwp_pointer_constraints_v1@11: error 1: a pointer constraint with a wl_pointer of the same wl_seat is already on this surface