### PR TITLE
[client] wayland: fix full screen toggle in capture mode regression

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -439,7 +439,7 @@ void waylandUngrabKeyboard(void)
 
 void waylandWarpPointer(int x, int y, bool exiting)
 {
-  if (!wlWm.pointerInSurface)
+  if (!wlWm.pointerInSurface || wlWm.lockedPointer)
     return;
 
   INTERLOCKED_SECTION(wlWm.confineLock,


### PR DESCRIPTION
This was fixed in 9db3cd7b and accidentally broke again in 4b99bba2.