### PR TITLE
[common] runningavg: avoid integer overflows

### DIFF
--- a/common/src/runningavg.c
+++ b/common/src/runningavg.c
@@ -26,7 +26,7 @@ struct RunningAvg
 {
   int       length, samples;
   int       pos;
-  int       value;
+  int64_t   value;
   int64_t   values[0];
 };
 


### PR DESCRIPTION
We receive values as int64_t, but when we compute the sum, we store it as
int. This doesn't make sense as we eventually cast it to double when
computing the average. We should instead store the sum as int64_t.