### PR TITLE
cmake install targets

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -143,6 +143,8 @@ target_link_libraries(looking-glass-client
 	fonts
 )
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/looking-glass-client DESTINATION bin/ COMPONENT binary)
+install(TARGETS looking-glass-client
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	COMPONENT binary)
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "compiler flag
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
+include(GNUInstallDirs)
 include(CheckCCompilerFlag)
 include(FeatureSummary)
 
@@ -81,6 +82,8 @@ else()
   set_target_properties(looking-glass-host PROPERTIES LINK_FLAGS "-Wl,--gc-sections -z noexecstack")
 endif()
 
-install(PROGRAMS ${CMAKE_BINARY_DIR}/looking-glass-host DESTINATION bin/ COMPONENT binary)
+install(TARGETS looking-glass-host
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	COMPONENT binary)
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)


### PR DESCRIPTION
Just a small change that uses `TARGETS` install mode and `CMAKE_INSTALL_BINDIR` to put things in the right place.