### PR TITLE
[host] avoid manual windres command

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -66,7 +66,10 @@ add_subdirectory("${PROJECT_TOP}/repos/LGMP/lgmp" "${CMAKE_BINARY_DIR}/lgmp"  )
 add_subdirectory(platform)
 
 if(WIN32)
-  add_executable(looking-glass-host WIN32 ${SOURCES})
+  add_executable(looking-glass-host WIN32
+    platform/Windows/resource.rc
+    ${SOURCES}
+  )
 else()
   add_executable(looking-glass-host ${SOURCES})
 endif()

--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(platform_Windows STATIC
 	src/mousehook.c
 	src/force_compose.c
 	src/delay.c
+	resource.rc
 )
 
 # allow use of functions for Windows Vista or later
@@ -18,15 +19,7 @@ add_definitions(-D _WIN32_WINNT=0x6000)
 
 add_subdirectory("capture")
 
-FIND_PROGRAM(WINDRES_EXECUTABLE NAMES "x86_64-w64-mingw32-windres" "windres.exe" DOC "windres executable")
-ADD_CUSTOM_COMMAND(TARGET platform_Windows POST_BUILD
-	WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-	COMMAND ${WINDRES_EXECUTABLE} -i resource.rc -o "${PROJECT_BINARY_DIR}/resource.o"
-	VERBATIM
-)
-
 target_link_libraries(platform_Windows
-	"${PROJECT_BINARY_DIR}/resource.o"
 	lg_common
 	capture
 


### PR DESCRIPTION
Not entirely sure what's up with the revert, but I'm assuming the issue was that by including the .rc.o in the platform .a, the linker wasn't picking it up? I think you'd need to use `--whole-archive` flag (or `OBJECT` library targets or something) to resolve it in that way, but a less intrusive change seems like just adding it directly as an object on the executable as I do so here.