### PR TITLE
[doc] index: Nuke trello and add ethereum address

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -157,8 +157,9 @@ The log file for the host application is located at::
 
    %ProgramData%\Looking Glass (host)\looking-glass-host.txt
 
-You can also find out where the file is by right clicking on the tray
-icon and selecting "Log File Location".
+You can also open the log file by right clicking on the Looking Glass
+system tray icon, then clicking *Open Log File*. This opens the log
+file in Notepad.
 
 The log file for the looking glass service is located at::
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,7 +31,6 @@ More information:
 * `Forum <https://forum.level1techs.com/c/software/lookingglass/142>`_
 * `Community wiki <https://looking-glass.io/wiki/>`_
 * IRC - #LookingGlass on `libera.chat <https://libera.chat/>`_
-* `Trello <https://trello.com/b/tI1Xbwsg/looking-glass>`_
 
 Donate:
 
@@ -40,3 +39,4 @@ Donate:
 * `Patreon <https://www.patreon.com/gnif>`_
 * `PayPal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ESQ72XUPGKXRY>`_
 * BTC - 14ZFcYjsKPiVreHqcaekvHGL846u3ZuT13
+* ETH - 0x6f8aEe454384122bF9ed28f025FBCe2Bce98db85


### PR DESCRIPTION
The LG Trello is unmaintained, and we have to fund those rare NFTs somehow.