### PR TITLE
[doc] module: dkms example has explicit "."

### DIFF
--- a/doc/module.rst
+++ b/doc/module.rst
@@ -76,7 +76,7 @@ To install the module into DKMS, run
 
 .. code:: bash
 
-   dkms install .
+   dkms install "."
 
 .. _module_dkms_loading:
 


### PR DESCRIPTION
This works in dash (not just bash), so should be portable to most shells.
Will hopefully help users not misinterpret the period as a mistake.