### PR TITLE
[host] nvfbc: do not crash when protected content is playing

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
@@ -253,6 +253,11 @@ CaptureResult NvFBCToSysCapture(
       handle->retry = 0;
       break;
 
+    case NVFBC_ERROR_PROTECTED_CONTENT:
+      DEBUG_WARN("Protected content is playing, can't capture");
+      Sleep(100);
+      return CAPTURE_RESULT_TIMEOUT;
+
     case NVFBC_ERROR_INVALID_PARAM:
       if (handle->retry < 2)
       {


### PR DESCRIPTION
We return a timeout, so that when protected content finishes playing, we
can immediately resume capture.

The fact we crash with an obscure message (`Unknown NVFBCRESULT failure 0xfffffffc`) was reported on Discord a while ago. I am unable to test this because I don't have any HDCP content.