### PR TITLE
[client] wayland: fix typo in warp usage

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -444,7 +444,7 @@ void waylandWarpPointer(int x, int y, bool exiting)
 
   INTERLOCKED_SECTION(wlWm.confineLock,
   {
-    if (!wlWm.lockedPointer)
+    if (wlWm.lockedPointer)
     {
       LG_UNLOCK(wlWm.confineLock);
       return;


### PR DESCRIPTION
The unwanted ! was introduced in 4b99bba200da004d134f38f5d8c2a74dead6e436.
This basically caused warp to never be used.