### PR TITLE
[client] cimgui: build as static library

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -124,6 +124,9 @@ set(SOURCES
 	src/egl_dynprocs.c
 )
 
+# Force cimgui to build as a static library.
+set(IMGUI_STATIC "yes" CACHE STRING "Build as a static library")
+
 add_subdirectory("${PROJECT_TOP}/common"          "${CMAKE_BINARY_DIR}/common"   )
 add_subdirectory("${PROJECT_TOP}/repos/LGMP/lgmp" "${CMAKE_BINARY_DIR}/LGMP"     )
 add_subdirectory("${PROJECT_TOP}/repos/PureSpice" "${CMAKE_BINARY_DIR}/PureSpice")


### PR DESCRIPTION
This doesn't fix build issues with clang, but still helps to not need to depend on a shared library when we are building it with the client.