### PR TITLE
[client] egl: implement error reporting callback

### DIFF
--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -34,6 +34,11 @@ typedef void (*eglSwapBuffersWithDamageKHR_t)(EGLDisplay dpy,
     EGLSurface surface, const EGLint *rects, EGLint n_rects);
 typedef void (*glEGLImageTargetTexture2DOES_t)(GLenum target,
     GLeglImageOES image);
+typedef void (*DEBUGPROC_t)(GLenum source,
+    GLenum type, GLuint id, GLenum severity, GLsizei length,
+    const GLchar *message, const void *userParam);
+typedef void (*glDebugMessageCallback_t)(DEBUGPROC_t callback,
+    const void * userParam);
 
 struct EGLDynProcs
 {
@@ -42,6 +47,8 @@ struct EGLDynProcs
   eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageKHR;
   eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageEXT;
   glEGLImageTargetTexture2DOES_t glEGLImageTargetTexture2DOES;
+  glDebugMessageCallback_t       glDebugMessageCallback;
+  glDebugMessageCallback_t       glDebugMessageCallbackKHR;
 };
 
 extern struct EGLDynProcs g_egl_dynProcs;

--- a/client/src/egl_dynprocs.c
+++ b/client/src/egl_dynprocs.c
@@ -36,6 +36,10 @@ void egl_dynProcsInit(void)
     eglGetProcAddress("eglSwapBuffersWithDamageKHR");
   g_egl_dynProcs.eglSwapBuffersWithDamageEXT = (eglSwapBuffersWithDamageKHR_t)
     eglGetProcAddress("eglSwapBuffersWithDamageEXT");
+  g_egl_dynProcs.glDebugMessageCallback = (glDebugMessageCallback_t)
+    eglGetProcAddress("glDebugMessageCallback");
+  g_egl_dynProcs.glDebugMessageCallbackKHR = (glDebugMessageCallback_t)
+    eglGetProcAddress("glDebugMessageCallbackKHR");
 };
 
 #endif


### PR DESCRIPTION
This reports useful information from OpenGL on supported platforms, including errors, performance warnings, and other things.