### PR TITLE
[client] imgui: use ES 3.0 and remove glew dependency

### DIFF
--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -25,9 +25,6 @@
 #include <EGL/egl.h>
 #include <GL/gl.h>
 
-// if GLEW is included, GLeglImageOES was not defined
-typedef void * GLeglImageOES;
-
 typedef EGLDisplay (*eglGetPlatformDisplayEXT_t)(EGLenum platform,
     void *native_display, const EGLint *attrib_list);
 typedef void (*eglSwapBuffersWithDamageKHR_t)(EGLDisplay dpy,

--- a/client/renderers/EGL/CMakeLists.txt
+++ b/client/renderers/EGL/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(renderer_EGL STATIC
 	${PROJECT_TOP}/repos/cimgui/imgui/backends/imgui_impl_opengl3.cpp
 )
 
-target_compile_definitions(renderer_EGL PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1)
+target_compile_definitions(renderer_EGL PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1 IMGUI_IMPL_OPENGL_ES3)
 
 target_link_libraries(renderer_EGL
 	${RENDERER_EGL_PKGCONFIG_LIBRARIES}
@@ -69,7 +69,6 @@ target_link_libraries(renderer_EGL
 	fonts
 
 	cimgui
-	GLEW
 )
 
 target_include_directories(renderer_EGL

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -30,7 +30,6 @@
 #include "util.h"
 #include "dynamic/fonts.h"
 
-#include <GL/glew.h>
 #include <EGL/egl.h>
 
 #include "cimgui.h"
@@ -925,14 +924,7 @@ bool egl_render_startup(void * opaque)
     return false;
   }
 
-  // glew is needed for imgui
-  if (!glewInit())
-  {
-    DEBUG_ERROR("GLEW failed to initialize");
-    return false;
-  }
-
-  if (!ImGui_ImplOpenGL3_Init("#version 100"))
+  if (!ImGui_ImplOpenGL3_Init("#version 300 es"))
   {
     DEBUG_ERROR("Failed to initialize ImGui");
     return false;

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -57,7 +57,6 @@ Required Dependencies
 -  fonts-freefont-ttf
 -  libegl-dev
 -  libgl-dev
--  libglew-dev
 -  libfontconfig1-dev
 -  libgmp-dev
 -  libspice-protocol-dev


### PR DESCRIPTION
If we specifically tell ImGui's OpenGL 3.x backend to target OpenGL ES 3.0,
then no extension loader is necessary.