### PR TITLE
[client] egl: properly use OpenGL ES

### DIFF
--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -23,7 +23,8 @@
 #ifdef ENABLE_EGL
 
 #include <EGL/egl.h>
-#include <GL/gl.h>
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
 
 typedef EGLDisplay (*eglGetPlatformDisplayEXT_t)(EGLenum platform,
     void *native_display, const EGLint *attrib_list);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -31,6 +31,7 @@
 #include "dynamic/fonts.h"
 
 #include <EGL/egl.h>
+#include <GLES3/gl32.h>
 
 #include "cimgui.h"
 #include "generator/output/cimgui_impl.h"
@@ -838,6 +839,18 @@ bool egl_render_startup(void * opaque)
   GLint esMaj, esMin;
   glGetIntegerv(GL_MAJOR_VERSION, &esMaj);
   glGetIntegerv(GL_MINOR_VERSION, &esMin);
+
+  if (!util_hasGLExt(gl_exts, "GL_EXT_buffer_storage"))
+  {
+    DEBUG_ERROR("GL_EXT_buffer_storage is needed to use EGL backend");
+    return false;
+  }
+
+  if (!util_hasGLExt(gl_exts, "GL_EXT_texture_format_BGRA8888"))
+  {
+    DEBUG_ERROR("GL_EXT_texture_format_BGRA8888 is needed to use EGL backend");
+    return false;
+  }
 
   if (g_egl_dynProcs.glEGLImageTargetTexture2DOES)
   {

--- a/client/renderers/EGL/egldebug.c
+++ b/client/renderers/EGL/egldebug.c
@@ -19,7 +19,6 @@
  */
 
 #include "egldebug.h"
-#include <GL/gl.h>
 #include <EGL/egl.h>
 
 const char * egl_getErrorStr(void)

--- a/client/renderers/EGL/model.h
+++ b/client/renderers/EGL/model.h
@@ -24,7 +24,7 @@
 #include "shader.h"
 #include "texture.h"
 
-#include <GL/gl.h>
+#include <GLES3/gl3.h>
 
 typedef struct EGL_Model EGL_Model;
 

--- a/client/renderers/EGL/shader.h
+++ b/client/renderers/EGL/shader.h
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <GL/gl.h>
+#include <GLES3/gl3.h>
 
 typedef struct EGL_Shader EGL_Shader;
 

--- a/client/renderers/EGL/splash.c
+++ b/client/renderers/EGL/splash.c
@@ -26,7 +26,7 @@
 #include "shader.h"
 #include "model.h"
 
-#include <GL/gl.h>
+#include <GLES3/gl3.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -150,8 +150,8 @@ static bool egl_texture_map(EGL_Texture * texture, uint8_t i)
     GL_MAP_WRITE_BIT             |
     GL_MAP_UNSYNCHRONIZED_BIT    |
     GL_MAP_INVALIDATE_BUFFER_BIT |
-    GL_MAP_PERSISTENT_BIT        |
-    GL_MAP_COHERENT_BIT
+    GL_MAP_PERSISTENT_BIT_EXT    |
+    GL_MAP_COHERENT_BIT_EXT
   );
 
   if (!texture->buf[i].map)
@@ -209,8 +209,8 @@ bool egl_texture_setup(EGL_Texture * texture, enum EGL_PixelFormat pixFmt, size_
   {
     case EGL_PF_BGRA:
       texture->bpp           = 4;
-      texture->format        = GL_BGRA;
-      texture->intFormat     = GL_BGRA;
+      texture->format        = GL_BGRA_EXT;
+      texture->intFormat     = GL_BGRA_EXT;
       texture->dataType      = GL_UNSIGNED_BYTE;
       texture->fourcc        = DRM_FORMAT_ARGB8888;
       texture->pboBufferSize = height * stride;
@@ -219,7 +219,7 @@ bool egl_texture_setup(EGL_Texture * texture, enum EGL_PixelFormat pixFmt, size_
     case EGL_PF_RGBA:
       texture->bpp           = 4;
       texture->format        = GL_RGBA;
-      texture->intFormat     = GL_BGRA;
+      texture->intFormat     = GL_RGBA;
       texture->dataType      = GL_UNSIGNED_BYTE;
       texture->fourcc        = DRM_FORMAT_ABGR8888;
       texture->pboBufferSize = height * stride;
@@ -300,13 +300,13 @@ bool egl_texture_setup(EGL_Texture * texture, enum EGL_PixelFormat pixFmt, size_
     texture->buf[i].hasPBO = true;
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, texture->buf[i].pbo);
-    glBufferStorage(
+    glBufferStorageEXT(
       GL_PIXEL_UNPACK_BUFFER,
       texture->pboBufferSize,
       NULL,
-      GL_MAP_WRITE_BIT      |
-      GL_MAP_PERSISTENT_BIT |
-      GL_MAP_COHERENT_BIT
+      GL_MAP_WRITE_BIT          |
+      GL_MAP_PERSISTENT_BIT_EXT |
+      GL_MAP_COHERENT_BIT_EXT
     );
 
     if (!egl_texture_map(texture, i))

--- a/client/renderers/EGL/texture.h
+++ b/client/renderers/EGL/texture.h
@@ -24,7 +24,6 @@
 #include "shader.h"
 #include "common/framebuffer.h"
 
-#include <GL/gl.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 


### PR DESCRIPTION
Instead of using the desktop <GL/gl.h>, we properly use the OpenGL ES 3.x
headers. Also, we now use GL_EXT_buffer_storage for MAP_PERSISTENT_BIT_EXT
and MAP_COHERENT_BIT_EXT as the core versions are only available in desktop
OpenGL 4.4. Similarly, we need GL_EXT_texture_format_BGRA8888 for GL_BGRA_EXT
as GL_BGRA is desktop-only.