### PR TITLE
[client] ci: do not install libglew-dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           libsdl2-dev libsdl2-ttf-dev \
           libspice-protocol-dev nettle-dev \
           libx11-dev libxss-dev libxi-dev \
-          libglew-dev \
           wayland-protocols
     - name: Configure client
       env:


### PR DESCRIPTION
We removed the GLEW dependency, so we shouldn't be installing it.