### PR TITLE
[client] egl: use glGetError and codes for errors in gl* functions

### DIFF
--- a/client/renderers/EGL/egldebug.c
+++ b/client/renderers/EGL/egldebug.c
@@ -19,6 +19,7 @@
  */
 
 #include "egldebug.h"
+#include <GLES3/gl3.h>
 #include <EGL/egl.h>
 
 const char * egl_getErrorStr(void)
@@ -41,5 +42,19 @@ const char * egl_getErrorStr(void)
     case EGL_BAD_NATIVE_WINDOW  : return "EGL_BAD_NATIVE_WINDOW";
     case EGL_CONTEXT_LOST       : return "EGL_CONTEXT_LOST";
     default                     : return "UNKNOWN";
+  }
+}
+
+const char * gl_getErrorStr(void)
+{
+  switch (glGetError())
+  {
+    case GL_NO_ERROR                     : return "GL_NO_ERROR";
+    case GL_INVALID_ENUM                 : return "GL_INVALID_ENUM";
+    case GL_INVALID_VALUE                : return "GL_INVALID_VALUE";
+    case GL_INVALID_OPERATION            : return "GL_INVALID_OPERATION";
+    case GL_INVALID_FRAMEBUFFER_OPERATION: return "GL_INVALID_FRAMEBUFFER_OPERATION";
+    case GL_OUT_OF_MEMORY                : return "GL_OUT_OF_MEMORY";
+    default                              : return "UNKNOWN";
   }
 }

--- a/client/renderers/EGL/egldebug.h
+++ b/client/renderers/EGL/egldebug.h
@@ -21,9 +21,16 @@
 #include "common/debug.h"
 
 const char * egl_getErrorStr(void);
+const char * gl_getErrorStr(void);
 
 #define DEBUG_EGL_WARN(fmt, ...) \
   DEBUG_WARN(fmt " (%s)", ##__VA_ARGS__, egl_getErrorStr())
 
 #define DEBUG_EGL_ERROR(fmt, ...) \
   DEBUG_ERROR(fmt " (%s)", ##__VA_ARGS__, egl_getErrorStr())
+
+#define DEBUG_GL_WARN(fmt, ...) \
+  DEBUG_WARN(fmt " (%s)", ##__VA_ARGS__, gl_getErrorStr())
+
+#define DEBUG_GL_ERROR(fmt, ...) \
+  DEBUG_ERROR(fmt " (%s)", ##__VA_ARGS__, gl_getErrorStr())

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -156,7 +156,7 @@ static bool egl_texture_map(EGL_Texture * texture, uint8_t i)
 
   if (!texture->buf[i].map)
   {
-    DEBUG_EGL_ERROR("glMapBufferRange failed for %d of %lu bytes", i,
+    DEBUG_GL_ERROR("glMapBufferRange failed for %d of %lu bytes", i,
         texture->pboBufferSize);
   }
 
@@ -447,7 +447,7 @@ bool egl_texture_update_from_dma(EGL_Texture * texture, const FrameBuffer * fram
       void * new = realloc(texture->dmaImages, newCount * sizeof *texture->dmaImages);
       if (!new)
       {
-        DEBUG_EGL_ERROR("Failed to allocate memory");
+        DEBUG_ERROR("Failed to allocate memory");
         eglDestroyImage(texture->display, image);
         return false;
       }
@@ -487,7 +487,7 @@ bool egl_texture_update_from_dma(EGL_Texture * texture, const FrameBuffer * fram
 
     case GL_WAIT_FAILED:
     case GL_INVALID_VALUE:
-      DEBUG_EGL_ERROR("glClientWaitSync failed");
+      DEBUG_GL_ERROR("glClientWaitSync failed");
   }
 
   glDeleteSync(fence);
@@ -572,7 +572,7 @@ enum EGL_TexStatus egl_texture_bind(EGL_Texture * texture)
         case GL_INVALID_VALUE:
           glDeleteSync(texture->buf[b].sync);
           texture->buf[b].sync = 0;
-          DEBUG_EGL_ERROR("glClientWaitSync failed");
+          DEBUG_GL_ERROR("glClientWaitSync failed");
           return EGL_TEX_STATUS_ERROR;
       }
     }


### PR DESCRIPTION
We used to use DEBUG_EGL_ERROR for gl* functions, which just yields
EGL_SUCCESS even when there are errors.