### PR TITLE
[host] windows: use event to gracefully signal exit

### DIFF
--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(platform_Windows
 	psapi
 	shlwapi
 	powrprof
+	rpcrt4
 )
 
 target_include_directories(platform_Windows


### PR DESCRIPTION
This allows the process to be terminated without resorting to
TerminateProcess. With some fixes, this allows the notification icon to be
removed when the service is restarted.

Furthermore, instead of sending WM_DESTROY to fool the window into believing
it's being destroyed, we actually call DestroyWindow now.