### PR TITLE
[host] service: pass CREATE_UNICODE_ENVIRONMENT unconditionally

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -298,9 +298,7 @@ void Launch(void)
     goto fail_token;
   }
 
-  DWORD flags = CREATE_NEW_CONSOLE | HIGH_PRIORITY_CLASS;
-  if (!pEnvironment)
-    flags |= CREATE_UNICODE_ENVIRONMENT;
+  DWORD flags = DETACHED_PROCESS | HIGH_PRIORITY_CLASS | CREATE_UNICODE_ENVIRONMENT;
 
   PROCESS_INFORMATION pi = {0};
   STARTUPINFO si =


### PR DESCRIPTION
According to MSDN documentation for CreateEnvironmentBlock, "[i]f the
environment block is passed to CreateProcessAsUser, you must also
specify the CREATE_UNICODE_ENVIRONMENT flag."

Also pass DETACHED_PROCESS because the host is a GUI application and
doesn't use the console.