### PR TITLE
[client] egl: improve cursor damage logic

### DIFF
--- a/client/renderers/EGL/cursor.h
+++ b/client/renderers/EGL/cursor.h
@@ -47,6 +47,5 @@ void egl_cursor_set_size(EGL_Cursor * cursor, const float x, const float y);
 void egl_cursor_set_state(EGL_Cursor * cursor, const bool visible,
     const float x, const float y);
 
-struct CursorState egl_cursor_get_state(EGL_Cursor * cursor, int width, int height);
-
-void egl_cursor_render(EGL_Cursor * cursor, LG_RendererRotate rotate);
+struct CursorState egl_cursor_render(EGL_Cursor * cursor, LG_RendererRotate rotate,
+    int width, int height);


### PR DESCRIPTION
1. Use atomics and return exact cursor positions from egl_cursor_render
   to avoid race conditions between cursor render and update.
2. Instead of messing with lastCursorValid in various overlays, simply use
   the hasOverlay/hadOverlay logic for cursor damage. This simplifies the
   logic greatly.

As a result, I believe all cursor-related artifacts are fixed.

Note to reviewer: as atomic_init and atomic_store are implemented as macros,
it is currently not possible to pass structs as compound literals due to the
comma being interpreted as an argument separator by the preprocessor.