### PR TITLE
[host] service: fix adjustPriv return value

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -109,7 +109,7 @@ bool adjustPriv(const char * name, DWORD attributes)
   {
     doLog("failed to open the process\n");
     winerr();
-    return -1;
+    return false;
   }
 
   if (!LookupPrivilegeValueA(NULL, name, &luid))


### PR DESCRIPTION
When OpenProcessToken fails, the function returned -1, which would be true
when converted to bool. This is wrong, and it should be returning false.