### PR TITLE
[host] windows: declare high DPI support in manifest

### DIFF
--- a/host/platform/Windows/app.manifest
+++ b/host/platform/Windows/app.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <assemblyIdentity version="1.0.0.0" processorArchitecture="X86" name="HostFission.LookingGlass.Host" type="win32"/>
     <description>Looking Glass (host)</description>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
@@ -9,4 +9,10 @@
             </requestedPrivileges>
         </security>
     </trustInfo>
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+        </asmv3:windowsSettings>
+    </asmv3:application>
 </assembly>

--- a/host/platform/Windows/src/platform.c
+++ b/host/platform/Windows/src/platform.c
@@ -370,18 +370,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
   // setup a handler for ctrl+c
   SetConsoleCtrlHandler(CtrlHandler, TRUE);
 
-  // enable high DPI awareness
-  // this is required for DXGI 1.5 support to function and also capturing desktops with high DPI
-  DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);
-  #define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2  ((DPI_AWARENESS_CONTEXT)-4)
-  typedef BOOL (*User32_SetProcessDpiAwarenessContext)(DPI_AWARENESS_CONTEXT value);
-
-  HMODULE user32 = GetModuleHandle("user32.dll");
-  User32_SetProcessDpiAwarenessContext fn;
-  fn = (User32_SetProcessDpiAwarenessContext)GetProcAddress(user32, "SetProcessDpiAwarenessContext");
-  if (fn)
-    fn(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-
   // create a message window so that our message pump works
   WNDCLASSEX wx    = {};
   wx.cbSize        = sizeof(WNDCLASSEX);
@@ -405,6 +393,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
   app.messageWnd = CreateWindowEx(0, MAKEINTATOM(class), NULL, 0, 0, 0, 0, 0, NULL, NULL, hInstance, NULL);
 
   // this is needed so that unprivileged processes can send us this message
+  HMODULE user32 = GetModuleHandle("user32.dll");
   _ChangeWindowMessageFilterEx = (PChangeWindowMessageFilterEx)GetProcAddress(user32, "ChangeWindowMessageFilterEx");
   if (_ChangeWindowMessageFilterEx)
     _ChangeWindowMessageFilterEx(app.messageWnd, app.trayRestartMsg, MSGFLT_ALLOW, NULL);


### PR DESCRIPTION
This is the normal way of doing things, and it's easier and less sketchy
than GetProcAddress.