### PR TITLE
[host] windows: correctly declare WINVER and _WIN32_WINNT

### DIFF
--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(platform_Windows STATIC
 )
 
 # allow use of functions for Windows Vista or later
-add_definitions(-D _WIN32_WINNT=0x6000)
+add_compile_definitions(WINVER=0x0600 _WIN32_WINNT=0x0600)
 
 add_subdirectory("capture")
 


### PR DESCRIPTION
We wanted to target Windows Vista, which is 0x0600 not 0x6000.
0x6000 is in fact larger than Windows 10 which is 0x0a00.