### PR TITLE
[common] windebug: remove custom-rolled Windows 8 detector

### DIFF
--- a/common/include/common/windebug.h
+++ b/common/include/common/windebug.h
@@ -33,8 +33,6 @@ void DebugWinError(const char * file, const unsigned int line, const char * func
 
 #define DEBUG_WINERROR(x, y) DebugWinError(STRIPPATH(__FILE__), __LINE__, __FUNCTION__, x, y)
 
-bool IsWindows8();
-
 #ifdef __cplusplus
 }
 #endif

--- a/common/src/platform/windows/windebug.c
+++ b/common/src/platform/windows/windebug.c
@@ -41,27 +41,3 @@ void DebugWinError(const char * file, const unsigned int line, const char * func
   fprintf(stderr, "%12" PRId64 " [E] %20s:%-4u | %-30s | %s: 0x%08x (%s)\n", microtime(), file, line, function, desc, (int)status, buffer);
   LocalFree(buffer);
 }
-
-/* credit for this function to: https://stackoverflow.com/questions/17399302/how-can-i-detect-windows-8-1-in-a-desktop-application */
-inline static BOOL CompareWindowsVersion(DWORD dwMajorVersion, DWORD dwMinorVersion)
-{
-  OSVERSIONINFOEX ver;
-  DWORDLONG dwlConditionMask = 0;
-
-  ZeroMemory(&ver, sizeof(OSVERSIONINFOEX));
-  ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-  ver.dwMajorVersion = dwMajorVersion;
-  ver.dwMinorVersion = dwMinorVersion;
-
-  VER_SET_CONDITION(dwlConditionMask, VER_MAJORVERSION, VER_EQUAL);
-  VER_SET_CONDITION(dwlConditionMask, VER_MINORVERSION, VER_EQUAL);
-
-  return VerifyVersionInfo(&ver, VER_MAJORVERSION | VER_MINORVERSION, dwlConditionMask);
-}
-
-bool IsWindows8(void)
-{
-  return
-    (CompareWindowsVersion(6, 3) == TRUE) ||
-    (CompareWindowsVersion(6, 2) == TRUE);
-}

--- a/host/platform/Windows/app.manifest
+++ b/host/platform/Windows/app.manifest
@@ -2,6 +2,20 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
     <assemblyIdentity version="1.0.0.0" processorArchitecture="X86" name="HostFission.LookingGlass.Host" type="win32"/>
     <description>Looking Glass (host)</description>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        </application>
+    </compatibility>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>
             <requestedPrivileges>

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -35,6 +35,7 @@
 #include <dxgi.h>
 #include <d3d11.h>
 #include <d3dcommon.h>
+#include <versionhelpers.h>
 
 #include "dxgi_extra.h"
 
@@ -340,15 +341,15 @@ static bool dxgi_init(void)
 
   const D3D_FEATURE_LEVEL * featureLevels;
   unsigned int featureLevelCount;
-  if (IsWindows8())
+  if (IsWindows10OrGreater())
   {
-    featureLevels     = win8;
-    featureLevelCount = sizeof(win8) / sizeof(D3D_FEATURE_LEVEL);
+    featureLevels     = win10;
+    featureLevelCount = ARRAY_LENGTH(win10);
   }
   else
   {
-    featureLevels     = win10;
-    featureLevelCount = sizeof(win10) / sizeof(D3D_FEATURE_LEVEL);
+    featureLevels     = win8;
+    featureLevelCount = ARRAY_LENGTH(win8);
   }
 
   IDXGIAdapter * tmp;


### PR DESCRIPTION
Just declare Windows 10 in manifest and use `<versionhelpers.h>` from Windows SDK.

DXGI is changed to use `<versionhelpers.h>`. At the same time, also changed logic so that Windows versions before 8 is not treated as 10, and switched to using `ARRAY_LENGTH` helper.