### PR TITLE
[host] windows: fix resource compilation dependencies

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -71,6 +71,9 @@ add_subdirectory("${PROJECT_TOP}/repos/LGMP/lgmp" "${CMAKE_BINARY_DIR}/lgmp"  )
 add_subdirectory(platform)
 
 if(WIN32)
+  set_source_files_properties(platform/Windows/resource.rc PROPERTIES
+    OBJECT_DEPENDS "${PROJECT_SOURCE_DIR}/platform/Windows/app.manifest;${PROJECT_TOP}/resources/icon.ico"
+  )
   add_executable(looking-glass-host WIN32
     platform/Windows/resource.rc
     ${SOURCES}


### PR DESCRIPTION
It used to be the case that when updating app.manifest, the resource file
it not automatically rebuilt. This made it a headache to update the manifest.
We set OBJECT_DEPENDS so that cmake knows to make the res file depend on
app.manifest and icon.ico.

This commit is based on PR #579 and should be rebased on it after it's merged.
