### PR TITLE
[host] windows: avoid compiling .rc file twice

### DIFF
--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -11,7 +11,6 @@ add_library(platform_Windows STATIC
 	src/mousehook.c
 	src/force_compose.c
 	src/delay.c
-	resource.rc
 )
 
 # allow use of functions for Windows Vista or later


### PR DESCRIPTION
a4f5ce08b93c101ea797bef058d6f3a6f832a2f4 has a regression that caused
the .rc file to be compiled twice. We do not want the version that's
added into the .a file.