### PR TITLE
[common] windows: declare WINVER and _WIN32_WINNT

### DIFF
--- a/common/src/platform/windows/CMakeLists.txt
+++ b/common/src/platform/windows/CMakeLists.txt
@@ -5,6 +5,9 @@ include_directories(
         ${PROJECT_TOP}/vendor/ivshmem
 )
 
+# allow use of functions for Windows 7 or later
+add_compile_definitions(WINVER=0x0601 _WIN32_WINNT=0x0601)
+
 add_library(lg_common_platform_code STATIC
     debug.c
     crash.c


### PR DESCRIPTION
This is done for consistency with the Windows-specific portions of the host.