### PR TITLE
[host] windows/delay: cast to LONGLONG instead of int

### DIFF
--- a/host/platform/Windows/src/delay.c
+++ b/host/platform/Windows/src/delay.c
@@ -41,6 +41,6 @@ void delayInit(void)
 
 void delayExecution(float ms)
 {
-  LARGE_INTEGER interval = { .QuadPart = -1 * (int)(ms * 10000.0f) };
+  LARGE_INTEGER interval = { .QuadPart = -1 * (LONGLONG)(ms * 10000.0f) };
   NtDelayExecution(FALSE, &interval);
 }


### PR DESCRIPTION
The type of the QuadPart member of the LARGE_INTEGER union is actually
LONGLONG, so we should cast to LONGLONG instead of int.
This avoids truncation should (ms * 10000.0f) exceed 2^31-1.