### PR TITLE
[host] windows: log MsgWaitForMultipleObjects errors

### DIFF
--- a/host/platform/Windows/src/force_compose.c
+++ b/host/platform/Windows/src/force_compose.c
@@ -106,6 +106,7 @@ static DWORD WINAPI threadProc(LPVOID lParam)
         }
         break;
       default:
+        DEBUG_ERROR("MsgWaitForMultipleObjects failed: 0x%lx", GetLastError());
         goto exit;
     }
   }

--- a/host/platform/Windows/src/mousehook.c
+++ b/host/platform/Windows/src/mousehook.c
@@ -151,6 +151,7 @@ static DWORD WINAPI threadProc(LPVOID lParam) {
         }
         break;
       default:
+        DEBUG_ERROR("MsgWaitForMultipleObjects failed: 0x%lx", GetLastError());
         goto exit;
     }
   }


### PR DESCRIPTION
This function is sometimes flaky and may fail for no apparent reason,
see https://stackoverflow.com/q/3945003. This has also been experienced
during the development of #610.

This commit adds logging so we may see if it ever fails for no reason
and work out some way to fix it.