### PR TITLE
[host] windows: fix graceful exit

### DIFF
--- a/host/platform/Windows/src/mousehook.c
+++ b/host/platform/Windows/src/mousehook.c
@@ -166,7 +166,7 @@ void mouseHook_install(MouseHookFn callback)
 {
   if (!mouseHook.event)
   {
-    mouseHook.event = CreateEventA(NULL, FALSE, FALSE, NULL);
+    mouseHook.event = CreateEventA(NULL, TRUE, FALSE, NULL);
     if (!mouseHook.event)
     {
       DEBUG_WINERROR("Failed to create mouse hook uninstall event",
@@ -201,6 +201,7 @@ void mouseHook_remove(void)
   SetEvent(mouseHook.event);
   WaitForSingleObject(mouseHook.thread      , INFINITE);
   WaitForSingleObject(mouseHook.updateThread, INFINITE);
+  ResetEvent(mouseHook.event);
   CloseHandle(mouseHook.thread);
   CloseHandle(mouseHook.updateThread);
 }

--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -683,6 +683,7 @@ VOID WINAPI SvcMain(DWORD dwArgc, LPTSTR *lpszArgv)
     {
       case WAIT_OBJECT_0:
         service.running = false;
+        doLog("Host application exited gracefully\n");
         break;
       case WAIT_TIMEOUT:
         doLog("Host application failed to exit in 1 second\n");

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -787,6 +787,7 @@ fail_lgmp:
 fail_ivshmem:
   ivshmemClose(&shmDev);
   ivshmemFree(&shmDev);
+  DEBUG_INFO("Host application exited");
   return exitcode;
 }
 


### PR DESCRIPTION
We were using an auto-reset event to signal the mousehook exit. This was
fine when there was only one thread, but with the addition of the update
thread, only one thread is signaled, causing the wait to last forever.

The fix is switching to a manual reset event and call ResetEvent after
the threads have exited.