### PR TITLE
[host] windows: add version resource

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -46,6 +46,7 @@ get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 
 add_custom_command(
 	OUTPUT	${CMAKE_BINARY_DIR}/version.c
+    ${CMAKE_BINARY_DIR}/include/version.h
 		${CMAKE_BINARY_DIR}/_version.c
 	COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
 		${PROJECT_TOP}/version.cmake
@@ -72,7 +73,7 @@ add_subdirectory(platform)
 
 if(WIN32)
   set_source_files_properties(platform/Windows/resource.rc PROPERTIES
-    OBJECT_DEPENDS "${PROJECT_SOURCE_DIR}/platform/Windows/app.manifest;${PROJECT_TOP}/resources/icon.ico"
+    OBJECT_DEPENDS "${PROJECT_SOURCE_DIR}/platform/Windows/app.manifest;${PROJECT_TOP}/resources/icon.ico;${CMAKE_BINARY_DIR}/include/version.h"
   )
   add_executable(looking-glass-host WIN32
     platform/Windows/resource.rc

--- a/host/platform/Windows/resource.rc
+++ b/host/platform/Windows/resource.rc
@@ -1,4 +1,41 @@
 #include "winuser.h"
+#include "winver.h"
+#include "version.h"
 
 CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "app.manifest"
 IDI_APPLICATION ICON "../../../resources/icon.ico"
+
+#define STRINGIFY2(s) #s
+#define STRINGIFY(s) STRINGIFY2(s)
+#define COPYRIGHT_TEXT(year) (c) 2017-year The Looking Glass Developers
+#define COPYRIGHT_STR(year) STRINGIFY(COPYRIGHT_TEXT(year))
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     0,0,0,0
+PRODUCTVERSION  0,0,0,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "04090000"
+        BEGIN
+            VALUE "CompanyName",      "The Looking Glass Developers"
+            VALUE "FileDescription",  "Looking Glass (host)"
+            VALUE "FileVersion",      LG_VERSION_STR
+            VALUE "InternalName",     "looking-glass-host.exe"
+            VALUE "LegalCopyright",   COPYRIGHT_STR(LG_CURRENT_YEAR)
+            VALUE "OriginalFilename", "looking-glass-host.exe"
+            VALUE "ProductName",      "Looking Glass (host)"
+            VALUE "ProductVersion",   LG_VERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 0
+    END
+END

--- a/version.cmake
+++ b/version.cmake
@@ -16,6 +16,11 @@ endif()
 string(STRIP "${GIT_REV}" GIT_VERSION)
 set(BUILD_VERSION "const char * BUILD_VERSION = \"${GIT_VERSION}\";")
 
+string(TIMESTAMP YEAR "%Y")
+set(HEADER "\
+#define LG_VERSION_STR \"${GIT_VERSION}\"\n\
+#define LG_CURRENT_YEAR ${YEAR}\n")
+
 if(EXISTS "${CMAKE_BINARY_DIR}/version.c")
 	file(READ ${CMAKE_BINARY_DIR}/version.c BUILD_VERSION_)
 else()
@@ -25,4 +30,5 @@ endif()
 if (NOT "${BUILD_VERSION}" STREQUAL "${BUILD_VERSION_}")
 	file(WRITE ${CMAKE_BINARY_DIR}/version.c "${BUILD_VERSION}")
 	file(WRITE ${CMAKE_BINARY_DIR}/VERSION   "${GIT_VERSION}")
+	file(WRITE ${CMAKE_BINARY_DIR}/include/version.h "${HEADER}")
 endif()


### PR DESCRIPTION
This allows friendly names and versions to be displayed in task manager
and other applications.