### PR TITLE
[client] opengl: don't include <GL/glx.h>

### DIFF
--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -27,7 +27,6 @@
 #include <math.h>
 
 #include <GL/gl.h>
-#include <GL/glx.h>
 
 #include "cimgui.h"
 #include "generator/output/cimgui_impl.h"


### PR DESCRIPTION
The OpenGL renderer backend should not depend on any particular
implementation of OpenGL, as it's used by both X11 and Wayland.