### PR TITLE
[client] ci: fix clang build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,11 @@ jobs:
       run: |
         mkdir client/build
         cd client/build
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_SDL=ON ..
+        cmake \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DCMAKE_LINKER:FILEPATH=/usr/bin/ld \
+          -DENABLE_SDL=ON \
+          ..
     - name: Build client
       run: |
         cd client/build


### PR DESCRIPTION
Our code to generate object files from shaders with the linker seems to
depend on GNU ld. More accurately, it works with lld, but we must specify
the correct object format via -m, which is very difficult to detect in a
satisfactory manner. Therefore we simply force use of GNU ld.