### PR TITLE
[host] windows: use WM_CLOSE to signal window destruction

### DIFF
--- a/host/platform/Windows/src/platform.c
+++ b/host/platform/Windows/src/platform.c
@@ -257,7 +257,7 @@ static int appThread(void * opaque)
 {
   RegisterTrayIcon();
   int result = app_main(app.argc, app.argv);
-  DestroyWindow(app.messageWnd);
+  SendMessage(app.messageWnd, WM_CLOSE, 0, 0);
   return result;
 }
 


### PR DESCRIPTION
DestroyWindow can only be invoked on the thread that created the window.
All other threads must use WM_CLOSE or another message to signal tell the
window to destroy itself.