### PR TITLE
[client] renderers: treat -1 as full damage and 0 as no overlay

### DIFF
--- a/client/include/app.h
+++ b/client/include/app.h
@@ -85,8 +85,8 @@ void app_registerOverlay(const struct LG_OverlayOps * ops, void * params);
 /**
  * render the overlay
  * returns:
- *   -1 for no overlay
- *    0 for full output damage
+ *   -1 for full output damage
+ *    0 for no overlay
  *   >0 number of rects written into rects
  */
 int app_renderOverlay(struct Rect * rects, int maxRects);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -1010,22 +1010,20 @@ bool egl_render(void * opaque, LG_RendererRotate rotate, const bool newFrame)
   struct Rect damage[KVMFR_MAX_DAMAGE_RECTS + 12];
   int damageIdx = app_renderOverlay(damage, 10);
 
-  // if no overlay
-  if (damageIdx == -1)
+  switch (damageIdx)
   {
-    damageIdx = 0;
-  }
-  else
-  {
-    ImGui_ImplOpenGL3_NewFrame();
-    ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
-
-    for (int i = 0; i < damageIdx; ++i)
-      damage[i].y = this->height - damage[i].y - damage[i].h;
-
-    // if there were too many rects invalidate the entire window
-    if (damageIdx == 0)
+    case 0: // no overlay
+      break;
+    case -1: // full damage
       hasOverlay = true;
+      damageIdx = 0;
+      // fallthrough
+    default:
+      ImGui_ImplOpenGL3_NewFrame();
+      ImGui_ImplOpenGL3_RenderDrawData(igGetDrawData());
+
+      for (int i = 0; i < damageIdx; ++i)
+        damage[i].y = this->height - damage[i].y - damage[i].h;
   }
 
   if (!hasOverlay && !this->hadOverlay)

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -686,7 +686,7 @@ bool opengl_render(void * opaque, LG_RendererRotate rotate, const bool newFrame)
     break;
   }
 
-  if (app_renderOverlay(NULL, 0) > -1)
+  if (app_renderOverlay(NULL, 0) != 0)
   {
     ImGui_ImplOpenGL2_NewFrame();
     ImGui_ImplOpenGL2_RenderDrawData(igGetDrawData());

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -662,7 +662,7 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
     const int written =
       overlay->ops->render(overlay->udata, false, rects, maxRects);
 
-    if (!totalDamage)
+    if (totalDamage)
       continue;
 
     if (written == -1)


### PR DESCRIPTION
This makes everything consistent.