### PR TITLE
[client] imgui: track last rectangles for overlays

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -120,6 +120,7 @@ set(SOURCES
 	src/kb.c
 	src/egl_dynprocs.c
 	src/eglutil.c
+	src/overlay_utils.c
 
 	src/overlay/fps.c
 	src/overlay/graphs.c

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -80,6 +80,7 @@ void app_glSetSwapInterval(int interval);
 void app_glSwapBuffers(void);
 #endif
 
+#define MAX_OVERLAY_RECTS 10
 void app_registerOverlay(const struct LG_OverlayOps * ops, void * params);
 
 /**

--- a/client/include/overlay_utils.h
+++ b/client/include/overlay_utils.h
@@ -1,0 +1,28 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _H_LG_OVERLAY_UTILS_
+#define _H_LG_OVERLAY_UTILS_
+
+#include "common/types.h"
+
+void overlayGetImGuiRect(struct Rect * rect);
+
+#endif

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -1007,8 +1007,8 @@ bool egl_render(void * opaque, LG_RendererRotate rotate, const bool newFrame)
   hasOverlay |= egl_help_render(this->help, this->screenScaleX, this->screenScaleY);
   hasOverlay |= egl_damage_render(this->damage, newFrame ? desktopDamage : NULL);
 
-  struct Rect damage[KVMFR_MAX_DAMAGE_RECTS + 12];
-  int damageIdx = app_renderOverlay(damage, 10);
+  struct Rect damage[KVMFR_MAX_DAMAGE_RECTS + MAX_OVERLAY_RECTS + 2];
+  int damageIdx = app_renderOverlay(damage, MAX_OVERLAY_RECTS);
 
   switch (damageIdx)
   {

--- a/client/src/overlay/fps.c
+++ b/client/src/overlay/fps.c
@@ -20,6 +20,7 @@
 
 #include "interface/overlay.h"
 #include "cimgui.h"
+#include "overlay_utils.h"
 
 #include "../main.h"
 
@@ -54,13 +55,7 @@ static int fps_render(void * udata, bool interactive, struct Rect * windowRects,
       atomic_load_explicit(&g_state.fps, memory_order_relaxed),
       atomic_load_explicit(&g_state.ups, memory_order_relaxed));
 
-  ImVec2 size;
-  igGetWindowPos(&pos);
-  igGetWindowSize(&size);
-  windowRects[0].x = pos.x;
-  windowRects[0].y = pos.y;
-  windowRects[0].w = size.x;
-  windowRects[0].h = size.y;
+  overlayGetImGuiRect(windowRects);
   igEnd();
 
   return 1;

--- a/client/src/overlay/fps.c
+++ b/client/src/overlay/fps.c
@@ -54,12 +54,6 @@ static int fps_render(void * udata, bool interactive, struct Rect * windowRects,
       atomic_load_explicit(&g_state.fps, memory_order_relaxed),
       atomic_load_explicit(&g_state.ups, memory_order_relaxed));
 
-  if (maxRects == 0)
-  {
-    igEnd();
-    return -1;
-  }
-
   ImVec2 size;
   igGetWindowPos(&pos);
   igGetWindowSize(&size);

--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -25,6 +25,7 @@
 
 #include "ll.h"
 #include "common/debug.h"
+#include "overlay_utils.h"
 
 struct GraphState
 {
@@ -138,14 +139,7 @@ static int graphs_render(void * udata, bool interactive,
         sizeof(float));
   };
 
-  ImVec2 size;
-  igGetWindowPos(&pos);
-  igGetWindowSize(&size);
-  windowRects[0].x = pos.x;
-  windowRects[0].y = pos.y;
-  windowRects[0].w = size.x;
-  windowRects[0].h = size.y;
-
+  overlayGetImGuiRect(windowRects);
   igEnd();
   return 1;
 }

--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -138,12 +138,6 @@ static int graphs_render(void * udata, bool interactive,
         sizeof(float));
   };
 
-  if (maxRects == 0)
-  {
-    igEnd();
-    return -1;
-  }
-
   ImVec2 size;
   igGetWindowPos(&pos);
   igGetWindowSize(&size);

--- a/client/src/overlay_utils.c
+++ b/client/src/overlay_utils.c
@@ -1,0 +1,37 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "overlay_utils.h"
+
+#include "cimgui.h"
+
+void overlayGetImGuiRect(struct Rect * rect)
+{
+  ImVec2 size;
+  ImVec2 pos;
+
+  igGetWindowPos(&pos);
+  igGetWindowSize(&size);
+
+  rect->x = pos.x;
+  rect->y = pos.y;
+  rect->w = size.x;
+  rect->h = size.y;
+}


### PR DESCRIPTION
This is necessary in case overlays change size. When this happens, we must
damage the larger of the overlays' rectangles this frame and last frame.
This erases the overlay from where it is no longer appears.

In order to do this, we must keep track of the rectangles for every overlay
with no exception. We cannot short-circuit the generation of rectangles if
we run out of buffer space, and we must allocate space for MAX_OVERLAY_RECTS
rectangles for every frame. Otherwise, we will not know where to erase the
overlay if it disappears.