### PR TITLE
[host] windows: do not complain about failed timer destruction at exit

### DIFF
--- a/common/src/platform/windows/time.c
+++ b/common/src/platform/windows/time.c
@@ -65,7 +65,7 @@ void lgTimerDestroy(LGTimer * timer)
 {
   if (timer->running)
   {
-    if (!KillTimer(MessageHWND, timer->handle))
+    if (MessageHWND && !KillTimer(MessageHWND, timer->handle))
       DEBUG_ERROR("failed to destroy the timer");
   }
 

--- a/host/platform/Windows/src/platform.c
+++ b/host/platform/Windows/src/platform.c
@@ -205,6 +205,7 @@ LRESULT CALLBACK DummyWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
   {
     case WM_DESTROY:
       Shell_NotifyIcon(NIM_DELETE, &app.iconData);
+      MessageHWND = NULL;
       PostQuitMessage(0);
       break;
 


### PR DESCRIPTION
When our window is destroyed, our timers are also destroyed. This causes our
attempt at destruction to fail. Instead, set MessageHWND to NULL in the
WM_DESTROY handler and don't try destroying the timers if the window is gone.