### PR TITLE
[client] ci: run all build combinations to completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ jobs:
   client:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - {cc: gcc, cxx: g++}


### PR DESCRIPTION
This is desirable because certain uncommon configurations like libdecor or
clang may break, and this shouldn't stop us from seeing if unrelated changes
pass.