### PR TITLE
[client] imgui: use improved high DPI rendering

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SOURCES
 	src/egl_dynprocs.c
 	src/eglutil.c
 	src/overlay_utils.c
+	src/overlay_utils.cpp
 
 	src/overlay/fps.c
 	src/overlay/graphs.c

--- a/client/include/util.h
+++ b/client/include/util.h
@@ -46,7 +46,6 @@ static inline double util_clamp(double x, double min, double max)
   return x;
 }
 
-#define DEFAULT_FONT_NAME "DejaVu Sans Mono"
 char * util_getUIFont(const char * fontName);
 
 #endif

--- a/client/include/util.h
+++ b/client/include/util.h
@@ -46,4 +46,7 @@ static inline double util_clamp(double x, double min, double max)
   return x;
 }
 
+#define DEFAULT_FONT_NAME "DejaVu Sans Mono"
+char * util_getUIFont(const char * fontName);
+
 #endif

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -504,6 +504,10 @@ void egl_on_resize(void * opaque, const int width, const int height, const doubl
   damage->count = 0;
   free(atomic_exchange(&this->desktopDamage, damage));
 
+  // this is needed to refresh the font atlas texture
+  ImGui_ImplOpenGL3_Shutdown();
+  ImGui_ImplOpenGL3_NewFrame();
+
   egl_damage_resize(this->damage, this->translateX, this->translateY, this->scaleX, this->scaleY);
 }
 

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -354,6 +354,10 @@ void opengl_on_resize(void * opaque, const int width, const int height, const do
       1.0f
     );
   }
+
+  // this is needed to refresh the font atlas texture
+  ImGui_ImplOpenGL2_Shutdown();
+  ImGui_ImplOpenGL2_NewFrame();
 }
 
 bool opengl_on_mouse_shape(void * opaque, const LG_RendererCursor cursor,

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -677,6 +677,14 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
     const int written =
       overlay->ops->render(overlay->udata, false, buffer, MAX_OVERLAY_RECTS);
 
+    for (int i = 0; i < written; ++i)
+    {
+      buffer[i].x *= g_state.windowScale;
+      buffer[i].y *= g_state.windowScale;
+      buffer[i].w *= g_state.windowScale;
+      buffer[i].h *= g_state.windowScale;
+    }
+
     // It is an error to run out of rectangles, because we will not be able to
     // correctly calculate the damage of the next frame.
     assert(written >= 0);

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -677,14 +677,6 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
     const int written =
       overlay->ops->render(overlay->udata, false, buffer, MAX_OVERLAY_RECTS);
 
-    for (int i = 0; i < written; ++i)
-    {
-      buffer[i].x *= g_state.windowScale;
-      buffer[i].y *= g_state.windowScale;
-      buffer[i].w *= g_state.windowScale;
-      buffer[i].h *= g_state.windowScale;
-    }
-
     // It is an error to run out of rectangles, because we will not be able to
     // correctly calculate the damage of the next frame.
     assert(written >= 0);

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -262,6 +262,20 @@ static struct Option options[] =
     .validator      = optRotateValidate,
     .value.x_int    = 0,
   },
+  {
+    .module         = "win",
+    .name           = "uiFont",
+    .description    = "The font to use when rendering on-screen UI",
+    .type           = OPTION_TYPE_STRING,
+    .value.x_string = "DejaVu Sans Mono",
+  },
+  {
+    .module         = "win",
+    .name           = "uiSize",
+    .description    = "The font size to use when rendering on-screen UI",
+    .type           = OPTION_TYPE_INT,
+    .value.x_int    = 14
+  },
 
   // input options
   {
@@ -526,6 +540,8 @@ bool config_load(int argc, char * argv[])
   g_params.autoScreensaver = option_get_bool  ("win", "autoScreensaver");
   g_params.showAlerts      = option_get_bool  ("win", "alerts"         );
   g_params.quickSplash     = option_get_bool  ("win", "quickSplash"    );
+  g_params.uiFont          = option_get_string("win"  , "uiFont"            );
+  g_params.uiSize          = option_get_int   ("win"  , "uiSize"            );
 
   if (g_params.noScreensaver && g_params.autoScreensaver)
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -179,12 +179,14 @@ static int renderThread(void * unused)
     int resize = atomic_load(&g_state.lgrResize);
     if (resize)
     {
-      const ImVec2 displaySize =
-      {
+      g_state.io->DisplaySize = (ImVec2) {
         .x = g_state.windowW,
         .y = g_state.windowH
       };
-      g_state.io->DisplaySize = displaySize;
+      g_state.io->DisplayFramebufferScale = (ImVec2) {
+        .x = g_state.windowScale,
+        .y = g_state.windowScale,
+      };
 
       if (g_state.lgr)
         g_state.lgr->on_resize(g_state.lgrData, g_state.windowW, g_state.windowH,

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -191,7 +191,7 @@ static int renderThread(void * unused)
 
       ImFontAtlas_Clear(g_state.io->Fonts);
       ImFontAtlas_AddFontFromFileTTF(g_state.io->Fonts, g_state.fontName,
-        14 * g_state.windowScale, NULL, NULL);
+        g_params.uiSize * g_state.windowScale, NULL, NULL);
       ImFontAtlas_Build(g_state.io->Fonts);
 
       if (g_state.lgr)
@@ -770,7 +770,7 @@ static int lg_run(void)
       &text_w, &text_h, NULL);
 
   g_state.windowScale = 1.0;
-  g_state.fontName    = util_getUIFont(DEFAULT_FONT_NAME);
+  g_state.fontName    = util_getUIFont(g_params.uiFont);
   DEBUG_INFO("Using font: %s", g_state.fontName);
 
   g_state.overlays = ll_new();

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -154,6 +154,8 @@ struct AppParams
   bool              quickSplash;
   bool              alwaysShowCursor;
   uint64_t          helpMenuDelayUs;
+  const char *      uiFont;
+  int               uiSize;
 
   unsigned int      cursorPollInterval;
   unsigned int      framePollInterval;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -47,8 +47,10 @@ struct AppState
 {
   enum RunState state;
 
-  ImGuiIO   * io;
-  struct ll * overlays;
+  ImGuiIO    * io;
+  ImGuiStyle * style;
+  struct ll  * overlays;
+  char       * fontName;
 
   struct LG_DisplayServerOps * ds;
   bool                         dsInitialized;

--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -93,6 +93,8 @@ static int graphs_render(void * udata, bool interactive,
   if (!g_state.showTiming)
     return 0;
 
+  float fontSize = igGetFontSize();
+
   ImVec2 pos = {0.0f, 0.0f};
   igSetNextWindowBgAlpha(0.4f);
   igSetNextWindowPos(pos, 0, pos);
@@ -121,7 +123,7 @@ static int graphs_render(void * udata, bool interactive,
     }
 
     char  title[64];
-    const ImVec2 size = {400.0f, 100.0f};
+    const ImVec2 size = {28.0f * fontSize, 7.0f * fontSize};
 
     snprintf(title, sizeof(title),
         "%s: min:%4.2f max:%4.2f avg:%4.2f/%4.2fHz",

--- a/client/src/overlay_utils.cpp
+++ b/client/src/overlay_utils.cpp
@@ -18,20 +18,11 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
-#ifndef _H_LG_OVERLAY_UTILS_
-#define _H_LG_OVERLAY_UTILS_
+#include "overlay_utils.h"
 
-#include "common/types.h"
+#include "imgui.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void overlayGetImGuiRect(struct Rect * rect);
-void imGuiResetStyle(void);
-
-#ifdef __cplusplus
+void imGuiResetStyle(void)
+{
+  ImGui::GetStyle() = ImGuiStyle();
 }
-#endif
-
-#endif


### PR DESCRIPTION
This implementation makes imgui render at a higher resolution, avoiding scaling resulting blurriness.

This is dependent on #645.