### PR TITLE
[client] wayland: invalidate window on configure

### DIFF
--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -69,6 +69,7 @@ static void libdecorFrameConfigure(struct libdecor_frame * frame,
   {
     wlWm.needsResize = true;
     wlWm.resizeSerial = configuration->serial;
+    app_invalidateWindow();
   }
   else
     wlWm.configured = true;

--- a/client/displayservers/Wayland/shell_xdg.c
+++ b/client/displayservers/Wayland/shell_xdg.c
@@ -46,6 +46,7 @@ static void xdgSurfaceConfigure(void * data, struct xdg_surface * xdgSurface,
   {
     wlWm.needsResize  = true;
     wlWm.resizeSerial = serial;
+    app_invalidateWindow();
   }
   else
   {


### PR DESCRIPTION
This avoids sending potentially meaningless damage values after a surface
configuration event.