### PR TITLE
[common] framebuffer: fix copy when source and dest pitch differs

### DIFF
--- a/common/src/framebuffer.c
+++ b/common/src/framebuffer.c
@@ -99,7 +99,7 @@ bool framebuffer_read(const FrameBuffer * frame, void * restrict dst,
         return false;
 
       memcpy(d, frame->data + rp, dstpitch);
-      rp += linewidth;
+      rp += pitch;
       d  += dstpitch;
     }
   }


### PR DESCRIPTION
We used to increment the source buffer index by width * bpp, not by pitch.
This is incorrect and the root cause behind #670.

This is a regression that appeared in 196050bd2381f4d7dbf6149c3347932951a47ebf.
This PR fixes #670.