### PR TITLE
[client] imgui: make graph y-axis configurable

### DIFF
--- a/client/displayservers/Wayland/presentation.c
+++ b/client/displayservers/Wayland/presentation.c
@@ -86,7 +86,7 @@ bool waylandPresentationInit(void)
   if (wlWm.presentation)
   {
     wlWm.photonTimings = ringbuffer_new(256, sizeof(float));
-    wlWm.photonGraph   = app_registerGraph("PHOTON", wlWm.photonTimings);
+    wlWm.photonGraph   = app_registerGraph("PHOTON", wlWm.photonTimings, 0.0f, 30.0f);
     wp_presentation_add_listener(wlWm.presentation, &presentationListener, NULL);
   }
   return true;

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -98,7 +98,7 @@ void app_freeOverlays(void);
 struct OverlayGraph;
 typedef struct OverlayGraph * GraphHandle;
 
-GraphHandle app_registerGraph(const char * name, RingBuffer buffer);
+GraphHandle app_registerGraph(const char * name, RingBuffer buffer, float min, float max);
 void app_unregisterGraph(GraphHandle handle);
 
 void app_clipboardRelease(void);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -214,7 +214,7 @@ bool egl_create(void ** opaque, const LG_RendererParams params, bool * needsOpen
   atomic_init(&this->desktopDamage, NULL);
 
   this->importTimings = ringbuffer_new(256, sizeof(float));
-  this->importGraph   = app_registerGraph("IMPORT", this->importTimings);
+  this->importGraph   = app_registerGraph("IMPORT", this->importTimings, 0.0f, 5.0f);
 
   *needsOpenGL = false;
   return true;

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -565,9 +565,9 @@ void app_releaseAllKeybinds(void)
     }
 }
 
-GraphHandle app_registerGraph(const char * name, RingBuffer buffer)
+GraphHandle app_registerGraph(const char * name, RingBuffer buffer, float min, float max)
 {
-  return overlayGraph_register(name, buffer);
+  return overlayGraph_register(name, buffer, min, max);
 }
 
 void app_unregisterGraph(GraphHandle handle)

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -793,8 +793,8 @@ static int lg_run(void)
   // initialize metrics ringbuffers
   g_state.renderTimings = ringbuffer_new(256, sizeof(float));
   g_state.frameTimings  = ringbuffer_new(256, sizeof(float));
-  overlayGraph_register("RENDER", g_state.renderTimings);
-  overlayGraph_register("UPLOAD", g_state.frameTimings );
+  overlayGraph_register("RENDER", g_state.renderTimings, 0.0f, 50.0f);
+  overlayGraph_register("UPLOAD", g_state.frameTimings , 0.0f, 50.0f);
 
   // search for the best displayserver ops to use
   for(int i = 0; i < LG_DISPLAYSERVER_COUNT; ++i)

--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -39,6 +39,8 @@ struct OverlayGraph
   const char * name;
   RingBuffer   buffer;
   bool         enabled;
+  float        min;
+  float        max;
 };
 
 static bool graphs_init(void ** udata, void * params)
@@ -135,8 +137,8 @@ static int graphs_render(void * udata, bool interactive,
         ringbuffer_getLength(graph->buffer),
         ringbuffer_getStart (graph->buffer),
         title,
-        0.0f,
-        50.0f,
+        graph->min,
+        graph->max,
         size,
         sizeof(float));
   };
@@ -154,12 +156,14 @@ struct LG_OverlayOps LGOverlayGraphs =
   .render         = graphs_render
 };
 
-GraphHandle overlayGraph_register(const char * name, RingBuffer buffer)
+GraphHandle overlayGraph_register(const char * name, RingBuffer buffer, float min, float max)
 {
   struct OverlayGraph * graph = malloc(sizeof(struct OverlayGraph));
   graph->name    = name;
   graph->buffer  = buffer;
   graph->enabled = true;
+  graph->min     = min;
+  graph->max     = max;
   ll_push(gs.graphs, graph);
   return graph;
 }

--- a/client/src/overlays.h
+++ b/client/src/overlays.h
@@ -28,7 +28,7 @@ extern struct LG_OverlayOps LGOverlayFPS;
 extern struct LG_OverlayOps LGOverlayGraphs;
 extern struct LG_OverlayOps LGOverlayHelp;
 
-GraphHandle overlayGraph_register(const char * name, RingBuffer buffer);
+GraphHandle overlayGraph_register(const char * name, RingBuffer buffer, float min, float max);
 void overlayGraph_unregister();
 
 #endif


### PR DESCRIPTION
The default of [0, 50] makes sense for FPS/UPS graphs, but does not for
things like the import graph. The latter should not take more than 5 ms
for sure.

This commit allows the min/max y-axis value to be specified when registering
the graph.