### PR TITLE
[client] imgui: darken background when rendering overlays

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -671,6 +671,13 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
 
   igNewFrame();
 
+  if (g_state.overlayInput)
+  {
+    totalDamage = true;
+    ImDrawList_AddRectFilled(igGetBackgroundDrawListNil(), (ImVec2) { 0.0f , 0.0f },
+      g_state.io->DisplaySize, 0xCC000000, 0, 0);
+  }
+
   // render the overlays
   for (ll_reset(g_state.overlays);
       ll_walk(g_state.overlays, (void **)&overlay); )

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -137,15 +137,9 @@ static void bind_toggleOverlay(int sc, void * opaque)
 {
   g_state.overlayInput ^= true;
   if (g_state.overlayInput)
-  {
     g_state.io->ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
-    app_alert(LG_ALERT_INFO, "Overlay input enabled");
-  }
   else
-  {
     g_state.io->ConfigFlags |= ImGuiConfigFlags_NoMouse;
-    app_alert(LG_ALERT_INFO, "Overlay input disabled");
-  }
 }
 
 void keybind_register(void)

--- a/client/src/overlay/help.c
+++ b/client/src/overlay/help.c
@@ -39,7 +39,7 @@ static void help_free(void * udata)
 static int help_render(void * udata, bool interactive, struct Rect * windowRects,
     int maxRects)
 {
-  if (!g_state.escapeHelp)
+  if (!g_state.escapeHelp && !g_state.overlayInput)
     return 0;
 
   ImVec2 * screen = overlayGetScreenSize();


### PR DESCRIPTION
This replaces the alert that says whether the overlay is enabled or not.

Also, we now always display the help menu in overlay mode.