### PR TITLE
[client] ds/imgui: use display server to display various imgui cursors

### DIFF
--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -4,6 +4,7 @@ project(displayserver_Wayland LANGUAGES C)
 find_package(PkgConfig)
 pkg_check_modules(DISPLAYSERVER_Wayland REQUIRED IMPORTED_TARGET
 	wayland-client
+	wayland-cursor
 )
 
 set(DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES "")

--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -101,8 +101,8 @@ void waylandCursorFree(void)
     wl_buffer_destroy(wlWm.cursorBuffer);
 }
 
-void waylandShowPointer(bool show)
+void waylandSetPointer(LG_DSPointer pointer)
 {
-  wlWm.showPointer = show;
-  wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, show ? wlWm.cursor : NULL, 0, 0);
+  wlWm.showPointer = pointer != LG_POINTER_NONE;
+  wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, wlWm.showPointer ? wlWm.cursor : NULL, 0, 0);
 }

--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -38,7 +38,7 @@ static const uint32_t cursorBitmap[] = {
   0x000000, 0x000000, 0x000000, 0x000000,
 };
 
-static struct wl_buffer * createCursorBuffer(void)
+static struct wl_buffer * createSquareCursorBuffer(void)
 {
   int fd = memfd_create("lg-cursor", 0);
   if (fd < 0)
@@ -74,6 +74,58 @@ fail:
   return result;
 }
 
+static bool loadThemedCursor(const char * name, struct wl_surface ** surface,
+    struct Point * hotspot)
+{
+  struct wl_cursor * cursor = wl_cursor_theme_get_cursor(wlWm.cursorTheme, name);
+  if (!cursor)
+    return false;
+
+  struct wl_buffer * buffer = wl_cursor_image_get_buffer(cursor->images[0]);
+  if (!buffer)
+    return false;
+
+  *surface = wl_compositor_create_surface(wlWm.compositor);
+  if (!*surface)
+    return NULL;
+
+  wl_surface_attach(*surface, buffer, 0, 0);
+  wl_surface_commit(*surface);
+
+  *hotspot = (struct Point) {
+    .x = cursor->images[0]->hotspot_x,
+    .y = cursor->images[0]->hotspot_y,
+  };
+  return true;
+}
+
+static const char ** nameLists[LG_POINTER_COUNT] = {
+  [LG_POINTER_ARROW      ] = (const char *[]) { "left_ptr", "arrow", NULL },
+  [LG_POINTER_INPUT      ] = (const char *[]) { "text", "xterm", "ibeam", NULL },
+  [LG_POINTER_MOVE       ] = (const char *[]) {
+    "move", "4498f0e0c1937ffe01fd06f973665830", "9081237383d90e509aa00f00170e968f", NULL
+  },
+  [LG_POINTER_RESIZE_NS  ] = (const char *[]) {
+    "sb_v_double_arrow", "size_ver", "v_double_arrow",
+    "2870a09082c103050810ffdffffe0204", "00008160000006810000408080010102", NULL
+  },
+  [LG_POINTER_RESIZE_EW  ] = (const char *[]) {
+    "sb_h_double_arrow", "size_hor", "h_double_arrow",
+    "14fef782d02440884392942c11205230", "028006030e0e7ebffc7f7070c0600140", NULL
+  },
+  [LG_POINTER_RESIZE_NESW] = (const char *[]) {
+    "fd_double_arrow", "size_bdiag", "fcf1c3c7cd4491d801f1e1c78f100000", NULL
+  },
+  [LG_POINTER_RESIZE_NWSE] = (const char *[]) {
+    "bd_double_arrow", "size_fdiag", "c7088f0f3e6c8088236ef8e1e3e70000", NULL
+  },
+  [LG_POINTER_HAND       ] = (const char *[]) {
+    "hand", "pointing_hand", "hand1", "hand2", "pointer",
+    "e29285e634086352946a0e7090d73106", "9d800788f1b08800ae810202380a0822", NULL
+  },
+  [LG_POINTER_NOT_ALLOWED] = (const char *[]) { "crossed_circle", "not-allowed", NULL },
+};
+
 bool waylandCursorInit(void)
 {
   if (!wlWm.compositor)
@@ -82,27 +134,39 @@ bool waylandCursorInit(void)
     return false;
   }
 
-  wlWm.cursorBuffer = createCursorBuffer();
-  if (wlWm.cursorBuffer)
+  wlWm.cursorSquareBuffer = createSquareCursorBuffer();
+  if (wlWm.cursorSquareBuffer)
   {
-    wlWm.cursor = wl_compositor_create_surface(wlWm.compositor);
-    wl_surface_attach(wlWm.cursor, wlWm.cursorBuffer, 0, 0);
-    wl_surface_commit(wlWm.cursor);
+    wlWm.cursors[LG_POINTER_SQUARE] = wl_compositor_create_surface(wlWm.compositor);
+    wl_surface_attach(wlWm.cursors[LG_POINTER_SQUARE], wlWm.cursorSquareBuffer, 0, 0);
+    wl_surface_commit(wlWm.cursors[LG_POINTER_SQUARE]);
   }
+
+  wlWm.cursorTheme = wl_cursor_theme_load(NULL, 24, wlWm.shm);
+  if (wlWm.cursorTheme)
+    for (LG_DSPointer pointer = LG_POINTER_ARROW; pointer < LG_POINTER_COUNT; ++pointer)
+      for (const char ** names = nameLists[pointer]; *names; ++names)
+        if (loadThemedCursor(*names, wlWm.cursors + pointer, wlWm.cursorHot + pointer))
+          break;
 
   return true;
 }
 
 void waylandCursorFree(void)
 {
-  if (wlWm.cursor)
-    wl_surface_destroy(wlWm.cursor);
-  if (wlWm.cursorBuffer)
-    wl_buffer_destroy(wlWm.cursorBuffer);
+  for (int i = 0; i < LG_POINTER_COUNT; ++i)
+    if (wlWm.cursors[i])
+      wl_surface_destroy(wlWm.cursors[i]);
+  if (wlWm.cursorTheme)
+    wl_cursor_theme_destroy(wlWm.cursorTheme);
+  if (wlWm.cursorSquareBuffer)
+    wl_buffer_destroy(wlWm.cursorSquareBuffer);
 }
 
 void waylandSetPointer(LG_DSPointer pointer)
 {
-  wlWm.showPointer = pointer != LG_POINTER_NONE;
-  wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, wlWm.showPointer ? wlWm.cursor : NULL, 0, 0);
+  wlWm.cursor     = wlWm.cursors[pointer];
+  wlWm.cursorHotX = wlWm.cursorHot[pointer].x;
+  wlWm.cursorHotY = wlWm.cursorHot[pointer].y;
+  wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, wlWm.cursor, wlWm.cursorHotX, wlWm.cursorHotY);
 }

--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -52,7 +52,7 @@ static void pointerEnterHandler(void * data, struct wl_pointer * pointer,
   wlWm.pointerInSurface = true;
   app_handleEnterEvent(true);
 
-  wl_pointer_set_cursor(pointer, serial, wlWm.showPointer ? wlWm.cursor : NULL, 0, 0);
+  wl_pointer_set_cursor(pointer, serial, wlWm.cursor, wlWm.cursorHotX, wlWm.cursorHotY);
   wlWm.pointerEnterSerial = serial;
 
   wlWm.cursorX = wl_fixed_to_double(sxW);

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -165,7 +165,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .glSwapBuffers       = waylandGLSwapBuffers,
 #endif
   .guestPointerUpdated = waylandGuestPointerUpdated,
-  .showPointer         = waylandShowPointer,
+  .setPointer          = waylandSetPointer,
   .grabPointer         = waylandGrabPointer,
   .ungrabPointer       = waylandUngrabPointer,
   .capturePointer      = waylandCapturePointer,

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -207,7 +207,7 @@ void waylandCBInvalidate(void);
 // cursor module
 bool waylandCursorInit(void);
 void waylandCursorFree(void);
-void waylandShowPointer(bool show);
+void waylandSetPointer(LG_DSPointer pointer);
 
 // gl module
 #if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 
 #if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
 # include <wayland-egl.h>
@@ -127,8 +128,13 @@ struct WaylandDSState
   struct zxdg_toplevel_decoration_v1 * xdgToplevelDecoration;
 #endif
 
-  struct wl_surface * cursor;
-  struct wl_buffer * cursorBuffer;
+  struct wl_cursor_theme * cursorTheme;
+  struct wl_buffer       * cursorSquareBuffer;
+  struct wl_surface      * cursors[LG_POINTER_COUNT];
+  struct Point             cursorHot[LG_POINTER_COUNT];
+  struct wl_surface      * cursor;
+  int                      cursorHotX;
+  int                      cursorHotY;
 
   struct wl_data_device_manager * dataDeviceManager;
 

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1009,9 +1009,9 @@ static void x11GuestPointerUpdated(double x, double y, double localX, double loc
   XSync(x11.display, False);
 }
 
-static void x11ShowPointer(bool show)
+static void x11SetPointer(LG_DSPointer pointer)
 {
-  if (show)
+  if (pointer != LG_POINTER_NONE)
     XDefineCursor(x11.display, x11.window, x11.squareCursor);
   else
     XDefineCursor(x11.display, x11.window, x11.blankCursor);
@@ -1266,7 +1266,7 @@ struct LG_DisplayServerOps LGDS_X11 =
   .glSwapBuffers      = x11GLSwapBuffers,
 #endif
   .guestPointerUpdated = x11GuestPointerUpdated,
-  .showPointer         = x11ShowPointer,
+  .setPointer          = x11SetPointer,
   .grabPointer         = x11GrabPointer,
   .ungrabPointer       = x11UngrabPointer,
   .capturePointer      = x11CapturePointer,

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -62,6 +62,24 @@ enum LG_DSWarpSupport
   LG_DS_WARP_SCREEN,
 };
 
+typedef enum LG_DSPointer
+{
+  LG_POINTER_NONE = 0,
+  LG_POINTER_SQUARE,
+  LG_POINTER_ARROW,
+  LG_POINTER_INPUT,
+  LG_POINTER_MOVE,
+  LG_POINTER_RESIZE_NS,
+  LG_POINTER_RESIZE_EW,
+  LG_POINTER_RESIZE_NESW,
+  LG_POINTER_RESIZE_NWSE,
+  LG_POINTER_HAND,
+  LG_POINTER_NOT_ALLOWED,
+}
+LG_DSPointer;
+
+#define LG_POINTER_COUNT (LG_POINTER_NOT_ALLOWED + 1)
+
 typedef struct LG_DSInitParams
 {
   const char * title;
@@ -131,7 +149,7 @@ struct LG_DisplayServerOps
 
   /* dm specific cursor implementations */
   void (*guestPointerUpdated)(double x, double y, double localX, double localY);
-  void (*showPointer)(bool show);
+  void (*setPointer)(LG_DSPointer pointer);
   void (*grabKeyboard)();
   void (*ungrabKeyboard)();
   /* (un)grabPointer is used to toggle cursor tracking/confine in normal mode */
@@ -202,7 +220,7 @@ struct LG_DisplayServerOps
   ASSERT_OPENGL_FN((x)->glSetSwapInterval); \
   ASSERT_OPENGL_FN((x)->glSwapBuffers    ); \
   assert((x)->guestPointerUpdated); \
-  assert((x)->showPointer        ); \
+  assert((x)->setPointer         ); \
   assert((x)->grabPointer        ); \
   assert((x)->ungrabPointer      ); \
   assert((x)->capturePointer     ); \

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -662,6 +662,35 @@ static inline void mergeRect(struct Rect * dest, const struct Rect * a, const st
   dest->h = y2 - dest->y;
 }
 
+static inline LG_DSPointer mapImGuiCursor(ImGuiMouseCursor cursor)
+{
+  switch (cursor)
+  {
+    case ImGuiMouseCursor_None:
+      return LG_POINTER_NONE;
+    case ImGuiMouseCursor_Arrow:
+      return LG_POINTER_ARROW;
+    case ImGuiMouseCursor_TextInput:
+      return LG_POINTER_INPUT;
+    case ImGuiMouseCursor_ResizeAll:
+      return LG_POINTER_MOVE;
+    case ImGuiMouseCursor_ResizeNS:
+      return LG_POINTER_RESIZE_NS;
+    case ImGuiMouseCursor_ResizeEW:
+      return LG_POINTER_RESIZE_EW;
+    case ImGuiMouseCursor_ResizeNESW:
+      return LG_POINTER_RESIZE_NESW;
+    case ImGuiMouseCursor_ResizeNWSE:
+      return LG_POINTER_RESIZE_NWSE;
+    case ImGuiMouseCursor_Hand:
+      return LG_POINTER_HAND;
+    case ImGuiMouseCursor_NotAllowed:
+      return LG_POINTER_NOT_ALLOWED;
+    default:
+      return LG_POINTER_ARROW;
+  }
+}
+
 int app_renderOverlay(struct Rect * rects, int maxRects)
 {
   int  totalRects  = 0;
@@ -676,6 +705,16 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
     totalDamage = true;
     ImDrawList_AddRectFilled(igGetBackgroundDrawListNil(), (ImVec2) { 0.0f , 0.0f },
       g_state.io->DisplaySize, 0xCC000000, 0, 0);
+
+    bool test;
+    igShowDemoWindow(&test);
+
+    ImGuiMouseCursor cursor = igGetMouseCursor();
+    if (cursor != g_state.cursorLast)
+    {
+      g_state.ds->setPointer(mapImGuiCursor(cursor));
+      g_state.cursorLast = cursor;
+    }
   }
 
   // render the overlays

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -94,7 +94,7 @@ void app_handleFocusEvent(bool focused)
           app_handleKeyRelease(key);
 
     if (!g_params.showCursorDot)
-      g_state.ds->showPointer(false);
+      g_state.ds->setPointer(LG_POINTER_NONE);
 
     if (g_params.minimizeOnFocusLoss)
       g_state.ds->minimize();

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -66,7 +66,7 @@ void core_setCursorInView(bool enable)
   if (enable)
   {
     if (g_params.hideMouse)
-      g_state.ds->showPointer(false);
+      g_state.ds->setPointer(LG_POINTER_NONE);
 
     if (warpSupport != LG_DS_WARP_NONE && !g_params.captureInputOnly)
       g_state.ds->grabPointer();
@@ -77,7 +77,7 @@ void core_setCursorInView(bool enable)
   else
   {
     if (g_params.hideMouse)
-      g_state.ds->showPointer(true);
+      g_state.ds->setPointer(LG_POINTER_SQUARE);
 
     if (warpSupport != LG_DS_WARP_NONE)
       g_state.ds->ungrabPointer();
@@ -102,7 +102,7 @@ void core_setGrabQuiet(bool enable)
 {
   /* we always do this so that at init the cursor is in the right state */
   if (g_params.captureInputOnly && g_params.hideMouse)
-    g_state.ds->showPointer(!enable);
+    g_state.ds->setPointer(enable ? LG_POINTER_NONE : LG_POINTER_SQUARE);
 
   if (g_cursor.grab == enable)
     return;

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -136,6 +136,7 @@ static void bind_passthrough(int sc, void * opaque)
 static void bind_toggleOverlay(int sc, void * opaque)
 {
   g_state.overlayInput ^= true;
+  g_state.cursorLast    = -2;
   if (g_state.overlayInput)
     g_state.io->ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
   else

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -780,6 +780,8 @@ static int lg_run(void)
   g_state.io    = igGetIO();
   g_state.style = igGetStyle();
 
+  g_state.io->BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
+
   g_state.windowScale = 1.0;
   g_state.fontName    = util_getUIFont(g_params.uiFont);
   DEBUG_INFO("Using font: %s", g_state.fontName);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -92,9 +92,9 @@ static void lgInit(void)
 
   // if spice is not in use, hide the local cursor
   if (!core_inputEnabled() && g_params.hideMouse)
-    g_state.ds->showPointer(false);
+    g_state.ds->setPointer(LG_POINTER_NONE);
   else
-    g_state.ds->showPointer(true);
+    g_state.ds->setPointer(LG_POINTER_SQUARE);
 }
 
 static bool fpsTimerFn(void * unused)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -48,12 +48,13 @@ struct AppState
 {
   enum RunState state;
 
-  ImGuiIO    * io;
-  ImGuiStyle * style;
-  struct ll  * overlays;
-  char       * fontName;
-  ImFont     * fontLarge;
-  bool         overlayInput;
+  ImGuiIO        * io;
+  ImGuiStyle     * style;
+  struct ll      * overlays;
+  char           * fontName;
+  ImFont         * fontLarge;
+  bool             overlayInput;
+  ImGuiMouseCursor cursorLast;
 
   bool        alertShow;
   char      * alertMessage;


### PR DESCRIPTION
The display server gains an enumeration of supported cursors:

* On Wayland, we use `wayland-cursor` which comes with `libwayland` to load cursors. This is implemented.
* On X11, we likely need to use `Xcursor` to load cursors.