### PR TITLE
[client] wayland: reject horizontal scroll events

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -85,6 +85,9 @@ static void pointerLeaveHandler(void * data, struct wl_pointer * pointer,
 static void pointerAxisHandler(void * data, struct wl_pointer * pointer,
   uint32_t serial, uint32_t axis, wl_fixed_t value)
 {
+  if (axis != WL_POINTER_AXIS_VERTICAL_SCROLL)
+    return;
+
   int button = value > 0 ?
     5 /* SPICE_MOUSE_BUTTON_DOWN */ :
     4 /* SPICE_MOUSE_BUTTON_UP */;


### PR DESCRIPTION
Currently, we handle horizontal scroll events as if they are vertical scrolls.
This is not correct and we should instead reject them.