### PR TITLE
[client] imgui: implement mouse wheel motion support

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -90,6 +90,7 @@ static void pointerAxisHandler(void * data, struct wl_pointer * pointer,
     4 /* SPICE_MOUSE_BUTTON_UP */;
   app_handleButtonPress(button);
   app_handleButtonRelease(button);
+  app_handleWheelMotion(wl_fixed_to_double(value) / 15.0);
 }
 
 static int mapWaylandToSpiceButton(uint32_t button)

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -56,6 +56,7 @@ void app_resyncMouseBasic(void);
 
 void app_handleButtonPress(int button);
 void app_handleButtonRelease(int button);
+void app_handleWheelMotion(double motion);
 void app_handleKeyPress(int scancode);
 void app_handleKeyRelease(int scancode);
 void app_handleEnterEvent(bool entered);

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -272,6 +272,12 @@ void app_handleButtonRelease(int button)
     DEBUG_ERROR("app_handleButtonRelease: failed to send message");
 }
 
+void app_handleWheelMotion(double motion)
+{
+  if (g_state.overlayInput)
+    g_state.io->MouseWheel -= motion;
+}
+
 void app_handleKeyPress(int sc)
 {
   if (sc == g_params.escapeKey && !g_state.escapeActive)


### PR DESCRIPTION
The display server should call `app_handleWheelMotion` as necessary. This is done for Wayland, but not X11.