### PR TITLE
[client] main: prevent the user from launching looking glass as setuid

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1189,6 +1189,12 @@ int main(int argc, char * argv[])
     return -1;
   }
 
+  if (getuid() != geteuid())
+  {
+    DEBUG_ERROR("Do not run looking glass as setuid!");
+    return -1;
+  }
+
   DEBUG_INFO("Looking Glass (%s)", BUILD_VERSION);
   DEBUG_INFO("Locking Method: " LG_LOCK_MODE);
 


### PR DESCRIPTION
We don't want to encourage craziness of people making the client suid to
bypass permission issues on the shm file.

Note: I see no evidence of this happening in the wild, but let's be
proactive.