### PR TITLE
[client] config: print error when app:configFile is not a valid file

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -503,6 +503,12 @@ bool config_load(int argc, char * argv[])
   const char * configFile = option_get_string("app", "configFile");
   if (configFile)
   {
+    if (stat(configFile, &st) < 0 || !S_ISREG(st.st_mode))
+    {
+      DEBUG_ERROR("app:configFile set to invalid file: %s", configFile);
+      return false;
+    }
+
     DEBUG_INFO("Loading config from: %s", configFile);
     if (!option_load(configFile))
       return false;


### PR DESCRIPTION
This makes it clear to the user that app:configFile is at fault.

This is inspired by an incident on Discord today that took a while to figure out.