### PR TITLE
[client] client: release escape key on focus loss

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -93,6 +93,8 @@ void app_handleFocusEvent(bool focused)
         if (g_state.keyDown[key])
           app_handleKeyRelease(key);
 
+    g_state.escapeActive = false;
+
     if (!g_params.showCursorDot)
       g_state.ds->showPointer(false);
 


### PR DESCRIPTION
This prevents the escape key from being treated as held down indefinitely when
losing focus while holding the escape key.