### PR TITLE
[client] ds/imgui: render at screen refresh rate on Wayland

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -164,6 +164,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .glSetSwapInterval   = waylandGLSetSwapInterval,
   .glSwapBuffers       = waylandGLSwapBuffers,
 #endif
+  .signalNextFrame     = waylandSignalNextFrame,
   .guestPointerUpdated = waylandGuestPointerUpdated,
   .setPointer          = waylandSetPointer,
   .grabPointer         = waylandGrabPointer,

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -289,3 +289,4 @@ void waylandWindowFree(void);
 void waylandWindowUpdateScale(void);
 void waylandSetWindowSize(int x, int y);
 bool waylandIsValidPointerPos(int x, int y);
+void waylandSignalNextFrame(LGEvent * event);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -27,6 +27,7 @@
 
 #include "app.h"
 #include "common/debug.h"
+#include "common/event.h"
 
 // Surface-handling listeners.
 
@@ -113,4 +114,22 @@ void waylandSetWindowSize(int x, int y)
 bool waylandIsValidPointerPos(int x, int y)
 {
   return x >= 0 && x < wlWm.width && y >= 0 && y < wlWm.height;
+}
+
+static void frameHandler(void * opaque, struct wl_callback * callback, unsigned int data)
+{
+  LGEvent * event = opaque;
+  lgSignalEvent(event);
+  wl_callback_destroy(callback);
+}
+
+static const struct wl_callback_listener frame_listener = {
+   .done = frameHandler,
+};
+
+void waylandSignalNextFrame(LGEvent * event)
+{
+  struct wl_callback * callback = wl_surface_frame(wlWm.surface);
+  if (callback)
+    wl_callback_add_listener(callback, &frame_listener, event);
 }

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -101,6 +101,8 @@ typedef void (* LG_ClipboardReplyFn)(void * opaque, const LG_ClipboardData type,
 typedef struct LG_DSGLContext
   * LG_DSGLContext;
 
+typedef struct LGEvent LGEvent;
+
 struct LG_DisplayServerOps
 {
   /* called before options are parsed, useful for registering options */
@@ -146,6 +148,12 @@ struct LG_DisplayServerOps
   void (*glSetSwapInterval)(int interval);
   void (*glSwapBuffers)(void);
 #endif
+
+  /* Signals event when the next frame should be rendered in time for the next vblank.
+   * This must be invoked on the render thread before swapping buffers.
+   * If used, the render thread MUST wait for event before rendering the next frame.
+   * This is optional and a display server may choose to not implement it. */
+  void (*signalNextFrame)(LGEvent * event);
 
   /* dm specific cursor implementations */
   void (*guestPointerUpdated)(double x, double y, double localX, double localY);

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -55,6 +55,8 @@ struct AppState
   ImFont         * fontLarge;
   bool             overlayInput;
   ImGuiMouseCursor cursorLast;
+  LGEvent        * overlayRenderEvent;
+  bool             overlayMustWait;
 
   bool        alertShow;
   char      * alertMessage;


### PR DESCRIPTION
This PR adds the optional display server method `signalNextFrame(LGEvent)`, which takes an LGEvent and signals it when the next frame should be rendered in time for the next vblank. This is currently implemented only for Wayland, and must be invoked before swapping buffers.

This is currently used to render imgui at screen refresh rate.

In theory, this could potentially be used later to implement a better form of vsync for supported display servers. Currently, vsync blocks inside swap until the next vblank, upon which the frame is displayed. This is undesirable as we perform the render early and then waits for the vblank. With `signalNextFrame`, we could render the next frame just in time for vblank.


