### PR TITLE
[common] paths: add library to manage platform-specific paths

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -24,6 +24,7 @@
 
 #include "common/option.h"
 #include "common/debug.h"
+#include "common/paths.h"
 #include "common/stringutils.h"
 
 #include <sys/stat.h>
@@ -497,14 +498,7 @@ bool config_load(int argc, char * argv[])
 
   // load config from XDG_CONFIG_HOME
   char * xdgFile;
-  char * dir;
-
-  if ((dir = getenv("XDG_CONFIG_HOME")) != NULL)
-    alloc_sprintf(&xdgFile, "%s/looking-glass/client.ini", dir);
-  else if ((dir = getenv("HOME")) != NULL)
-    alloc_sprintf(&xdgFile, "%s/.config/looking-glass/client.ini", dir);
-  else
-    alloc_sprintf(&xdgFile, "%s/.config/looking-glass/client.ini", pw->pw_dir);
+  alloc_sprintf(&xdgFile, "%s/client.ini", lgConfigDir());
 
   if (xdgFile && stat(xdgFile, &st) >= 0 && S_ISREG(st.st_mode))
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -48,6 +48,7 @@
 #include "common/ivshmem.h"
 #include "common/time.h"
 #include "common/version.h"
+#include "common/paths.h"
 
 #include "core.h"
 #include "app.h"
@@ -1235,6 +1236,7 @@ int main(int argc, char * argv[])
   if (!installCrashHandler("/proc/self/exe"))
     DEBUG_WARN("Failed to install the crash handler");
 
+  lgPathsInit("looking-glass");
   config_init();
   ivshmemOptionsInit();
   egl_dynProcsInit();

--- a/common/include/common/paths.h
+++ b/common/include/common/paths.h
@@ -1,0 +1,28 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _H_LG_COMMON_DIRS_
+#define _H_LG_COMMON_DIRS_
+
+void lgPathsInit(const char * appName);
+const char * lgConfigDir(void);
+const char * lgDataDir(void);
+
+#endif

--- a/common/src/platform/linux/CMakeLists.txt
+++ b/common/src/platform/linux/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(lg_common_platform_code STATIC
     event.c
     ivshmem.c
     time.c
+    paths.c
 )
 
 if(ENABLE_BACKTRACE)

--- a/common/src/platform/linux/paths.c
+++ b/common/src/platform/linux/paths.c
@@ -1,0 +1,90 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/paths.h"
+#include "common/debug.h"
+
+#include <errno.h>
+#include <linux/limits.h>
+#include <pwd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char configDir[PATH_MAX];
+static char dataDir[PATH_MAX];
+
+static void ensureDir(char * path, mode_t mode)
+{
+  struct stat st;
+  if (stat(path, &st) >= 0)
+  {
+    if (S_ISDIR(st.st_mode))
+      return;
+
+    DEBUG_ERROR("Expected to be a directory: %s", path);
+    exit(2);
+  }
+
+  for (char * p = strchr(path + 1, '/'); p; p = strchr(p + 1, '/')) {
+    *p = '\0';
+    if (mkdir(path, mode) < 0 && errno != EEXIST)
+    {
+      *p = '/';
+      DEBUG_ERROR("Failed to create directory: %s", path);
+      return;
+    }
+    *p = '/';
+  }
+
+  if (mkdir(path, mode) < 0 && errno != EEXIST)
+    DEBUG_ERROR("Failed to create directory: %s", path);
+}
+
+void lgPathsInit(const char * appName)
+{
+  const char * home = getenv("HOME");
+  if (!home)
+    home = getpwuid(getuid())->pw_dir;
+
+  const char * dir;
+  if ((dir = getenv("XDG_CONFIG_HOME")) != NULL)
+    snprintf(configDir, sizeof(configDir), "%s/%s", dir, appName);
+  else
+    snprintf(configDir, sizeof(configDir), "%s/.config/%s", home, appName);
+
+  if ((dir = getenv("XDG_DATA_HOME")) != NULL)
+    snprintf(dataDir, sizeof(configDir), "%s/%s", dir, appName);
+  else
+    snprintf(dataDir, sizeof(configDir), "%s/.local/share/%s", home, appName);
+
+  ensureDir(configDir, S_IRWXU);
+  ensureDir(dataDir,   S_IRWXU);
+}
+
+const char * lgConfigDir(void)
+{
+  return configDir;
+}
+
+const char * lgDataDir(void)
+{
+  return dataDir;
+}


### PR DESCRIPTION
This abstracts away stuff like XDG base directory specification.
Currently, this is implemented for Linux only.

Also, the client now loads its config file based on new the `lgConfigDir()` function.