### PR TITLE
[client] main/renderer: implement smart vsync mode 

### DIFF
--- a/client/include/interface/renderer.h
+++ b/client/include/interface/renderer.h
@@ -40,9 +40,8 @@
 
 typedef struct LG_RendererParams
 {
-//  TTF_Font * font;
-//  TTF_Font * alertFont;
-  bool       quickSplash;
+  bool quickSplash;
+  bool vsync;
 }
 LG_RendererParams;
 

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -198,7 +198,7 @@ static bool egl_create(void ** opaque, const LG_RendererParams params, bool * ne
   struct Inst * this = (struct Inst *)*opaque;
   memcpy(&this->params, &params, sizeof(LG_RendererParams));
 
-  this->opt.vsync        = option_get_bool("egl", "vsync");
+  this->opt.vsync        = option_get_bool("egl", "vsync") || params.vsync;
   this->opt.doubleBuffer = option_get_bool("egl", "doubleBuffer");
 
   this->translateX   = 0;

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -202,7 +202,7 @@ bool opengl_create(void ** opaque, const LG_RendererParams params,
   memcpy(&this->params, &params, sizeof(LG_RendererParams));
 
   this->opt.mipmap        = option_get_bool("opengl", "mipmap"       );
-  this->opt.vsync         = option_get_bool("opengl", "vsync"        );
+  this->opt.vsync         = option_get_bool("opengl", "vsync"        ) || params.vsync;
   this->opt.preventBuffer = option_get_bool("opengl", "preventBuffer");
   this->opt.amdPinnedMem  = option_get_bool("opengl", "amdPinnedMem" );
 

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -277,6 +277,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_INT,
     .value.x_int    = 14
   },
+  {
+    .module         = "win",
+    .name           = "vsync",
+    .description    = "Enable smart vsync",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false,
+  },
 
   // input options
   {
@@ -562,8 +569,9 @@ bool config_load(int argc, char * argv[])
   g_params.autoScreensaver = option_get_bool  ("win", "autoScreensaver");
   g_params.showAlerts      = option_get_bool  ("win", "alerts"         );
   g_params.quickSplash     = option_get_bool  ("win", "quickSplash"    );
-  g_params.uiFont          = option_get_string("win"  , "uiFont"            );
-  g_params.uiSize          = option_get_int   ("win"  , "uiSize"            );
+  g_params.uiFont          = option_get_string("win"  , "uiFont"       );
+  g_params.uiSize          = option_get_int   ("win"  , "uiSize"       );
+  g_params.vsync           = option_get_bool  ("win"  , "vsync"        );
 
   if (g_params.noScreensaver && g_params.autoScreensaver)
   {

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -171,6 +171,7 @@ struct AppParams
   uint64_t          helpMenuDelayUs;
   const char *      uiFont;
   int               uiSize;
+  bool              vsync;
 
   unsigned int      cursorPollInterval;
   unsigned int      framePollInterval;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -55,8 +55,6 @@ struct AppState
   ImFont         * fontLarge;
   bool             overlayInput;
   ImGuiMouseCursor cursorLast;
-  LGEvent        * overlayRenderEvent;
-  bool             overlayMustWait;
   char           * imGuiIni;
 
   bool        alertShow;
@@ -66,6 +64,8 @@ struct AppState
 
   struct LG_DisplayServerOps * ds;
   bool                         dsInitialized;
+  bool                         smartVsync;
+  LGEvent                    * vsyncEvent;
 
   bool                 stopVideo;
   bool                 ignoreInput;


### PR DESCRIPTION
This mode uses `signalNextFrame` to implement vsync without latency if possible, falling back to asking the renderer to use vsync.

We introduce a new parameter `win:vsync`, which enables this logic. In the future, we may make this the default on display servers that support it, i.e. Wayland.

This essentially uses the same `signalNextFrame` logic that we currently use for imgui, but for everything. We automatically enable this mode when overlay is on, preserving the current behaviour.

Currently, this exposes some damage tracking bugs in the EGL renderer, which is why it's not enabled by default.