### PR TITLE
[client] wayland: improve fractional scale handling

### DIFF
--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -75,6 +75,9 @@ wayland_generate(
     "${WAYLAND_PROTOCOLS_BASE}/stable/presentation-time/presentation-time.xml"
     "${CMAKE_BINARY_DIR}/wayland/wayland-presentation-time-client-protocol")
 wayland_generate(
+    "${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
+    "${CMAKE_BINARY_DIR}/wayland/wayland-viewporter-client-protocol")
+wayland_generate(
     "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
     "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-decoration-unstable-v1-client-protocol")
 wayland_generate(
@@ -89,3 +92,6 @@ wayland_generate(
 wayland_generate(
     "${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
     "${CMAKE_BINARY_DIR}/wayland/wayland-idle-inhibit-unstable-v1-client-protocol")
+wayland_generate(
+    "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-output/xdg-output-unstable-v1.xml"
+    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-output-unstable-v1-client-protocol")

--- a/client/displayservers/Wayland/output.c
+++ b/client/displayservers/Wayland/output.c
@@ -31,7 +31,7 @@ static void outputUpdateScale(struct WaylandOutput * node)
 {
   wl_fixed_t original = node->scale;
 
-  if (!wlWm.viewporter || !node->logicalWidth || !node->logicalHeight)
+  if (!wlWm.useFractionalScale || !wlWm.viewporter || !node->logicalWidth)
     node->scale = wl_fixed_from_int(node->scaleInt);
   else
   {

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -70,7 +70,8 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
         &zwp_idle_inhibit_manager_v1_interface, 1);
   else if (!strcmp(interface, zxdg_output_manager_v1_interface.name) && version >= 2)
     wlWm.xdgOutputManager = wl_registry_bind(wlWm.registry, name,
-        &zxdg_output_manager_v1_interface, 2);
+        // we only need v2 to run, but v3 saves a callback
+        &zxdg_output_manager_v1_interface, version > 3 ? 3 : version);
 }
 
 static void registryGlobalRemoveHandler(void * data,

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -50,6 +50,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, wp_presentation_interface.name))
     wlWm.presentation = wl_registry_bind(wlWm.registry, name,
         &wp_presentation_interface, 1);
+  else if (!strcmp(interface, wp_viewporter_interface.name))
+    wlWm.viewporter = wl_registry_bind(wlWm.registry, name,
+        &wp_viewporter_interface, 1);
   else if (!strcmp(interface, zwp_relative_pointer_manager_v1_interface.name))
     wlWm.relativePointerManager = wl_registry_bind(wlWm.registry, name,
         &zwp_relative_pointer_manager_v1_interface, 1);
@@ -65,6 +68,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name))
     wlWm.idleInhibitManager = wl_registry_bind(wlWm.registry, name,
         &zwp_idle_inhibit_manager_v1_interface, 1);
+  else if (!strcmp(interface, zxdg_output_manager_v1_interface.name) && version >= 2)
+    wlWm.xdgOutputManager = wl_registry_bind(wlWm.registry, name,
+        &zxdg_output_manager_v1_interface, 2);
 }
 
 static void registryGlobalRemoveHandler(void * data,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -37,6 +37,13 @@ static struct Option waylandOptions[] =
     .type         = OPTION_TYPE_BOOL,
     .value.x_bool = true,
   },
+  {
+    .module       = "wayland",
+    .name         = "fractionScale",
+    .description  = "Enable fractional scale",
+    .type         = OPTION_TYPE_BOOL,
+    .value.x_bool = true,
+  },
   {0}
 };
 
@@ -66,7 +73,8 @@ static bool waylandInit(const LG_DSInitParams params)
   memset(&wlWm, 0, sizeof(wlWm));
   wl_list_init(&wlWm.surfaceOutputs);
 
-  wlWm.warpSupport = option_get_bool("wayland", "warpSupport");
+  wlWm.warpSupport        = option_get_bool("wayland", "warpSupport");
+  wlWm.useFractionalScale = option_get_bool("wayland", "fractionScale");
 
   wlWm.display = wl_display_connect(NULL);
   wlWm.width = params.w;

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -174,6 +174,7 @@ struct WaylandDSState
   struct zxdg_output_manager_v1 * xdgOutputManager;
   struct wl_list outputs; // WaylandOutput::link
   struct wl_list surfaceOutputs; // SurfaceOutput::link
+  bool useFractionalScale;
 
   struct wl_list poll; // WaylandPoll::link
   struct wl_list pollFree; // WaylandPoll::link

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -33,12 +33,12 @@
 
 void waylandWindowUpdateScale(void)
 {
-  int32_t maxScale = 0;
+  wl_fixed_t maxScale = 0;
   struct SurfaceOutput * node;
 
   wl_list_for_each(node, &wlWm.surfaceOutputs, link)
   {
-    int32_t scale = waylandOutputGetScale(node->output);
+    wl_fixed_t scale = waylandOutputGetScale(node->output);
     if (scale > maxScale)
       maxScale = scale;
   }
@@ -46,6 +46,7 @@ void waylandWindowUpdateScale(void)
   if (maxScale)
   {
     wlWm.scale = maxScale;
+    wlWm.fractionalScale = wl_fixed_from_int(wl_fixed_to_int(maxScale)) != maxScale;
     wlWm.needsResize = true;
   }
 }
@@ -77,7 +78,7 @@ static const struct wl_surface_listener wlSurfaceListener = {
 
 bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless)
 {
-  wlWm.scale = 1;
+  wlWm.scale = wl_fixed_from_int(1);
 
   if (!wlWm.compositor)
   {


### PR DESCRIPTION
Currently, we scale the desktop up to the next largest integer, and rely on
the wayland compositor to scale it back down to the correct size.
This is obviously undesirable.

In this commit, we attempt to detect the actual fractional scaling by finding
the current active mode in wl_output, and dividing it by the logical screen
size reported by xdg_output, taking into consideration screen rotation.

We then use wp_viewporter to set the exact buffer and viewport sizes if
fractional scaling is needed.

Since the method used is not guaranteed to work on all Wayland compositors, we add an option to make this opt-out. We need to support it anyways in case xdg_output or wp_viewporter protocols are not available.