### PR TITLE
[client] main: implement just-in-time render mode

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -277,6 +277,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_INT,
     .value.x_int    = 14
   },
+  {
+    .module         = "win",
+    .name           = "jitRender",
+    .description    = "Enable just-in-time rendering",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false,
+  },
 
   // input options
   {
@@ -562,8 +569,9 @@ bool config_load(int argc, char * argv[])
   g_params.autoScreensaver = option_get_bool  ("win", "autoScreensaver");
   g_params.showAlerts      = option_get_bool  ("win", "alerts"         );
   g_params.quickSplash     = option_get_bool  ("win", "quickSplash"    );
-  g_params.uiFont          = option_get_string("win"  , "uiFont"            );
-  g_params.uiSize          = option_get_int   ("win"  , "uiSize"            );
+  g_params.uiFont          = option_get_string("win"  , "uiFont"       );
+  g_params.uiSize          = option_get_int   ("win"  , "uiSize"       );
+  g_params.jitRender       = option_get_bool  ("win"  , "jitRender"    );
 
   if (g_params.noScreensaver && g_params.autoScreensaver)
   {

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -55,8 +55,6 @@ struct AppState
   ImFont         * fontLarge;
   bool             overlayInput;
   ImGuiMouseCursor cursorLast;
-  LGEvent        * overlayRenderEvent;
-  bool             overlayMustWait;
   char           * imGuiIni;
 
   bool        alertShow;
@@ -66,6 +64,8 @@ struct AppState
 
   struct LG_DisplayServerOps * ds;
   bool                         dsInitialized;
+  bool                         jitRender;
+  LGEvent                    * jitEvent;
 
   bool                 stopVideo;
   bool                 ignoreInput;
@@ -171,6 +171,7 @@ struct AppParams
   uint64_t          helpMenuDelayUs;
   const char *      uiFont;
   int               uiSize;
+  bool              jitRender;
 
   unsigned int      cursorPollInterval;
   unsigned int      framePollInterval;


### PR DESCRIPTION
When requested, JIT render mode will be used if the display server supports it.
Otherwise, a warning is generated instead.

This essentially uses the signalNextFrame logic for imgui, but for everything.
We automatically enable this mode when overlay is on.

Currently, this exposes some damage tracking bugs in the EGL renderer.