### PR TITLE
[client] config: disable JIT rendering by default

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -282,7 +282,7 @@ static struct Option options[] =
     .name           = "jitRender",
     .description    = "Enable just-in-time rendering",
     .type           = OPTION_TYPE_BOOL,
-    .value.x_bool   = true,
+    .value.x_bool   = false,
   },
 
   // input options


### PR DESCRIPTION
Without configuring Wayland compositors to send frame callbacks as late as
possible, JIT rendering can increase latency by more than one frame.

For example, by default, sway asks applications to render right after a
vblank, and does its own composition right after a vblank, resulting in
~2 frame's worth of latency. If max_render_time is set on the output,
it composes that many milliseconds before the vblank, losing ~1 frame's
worth of latency. If max_render_time is set on the window also, the frame
callback is sent that many milliseconds before composition, and we achieve
perfectly low latency.

Therefore, out of the box, JIT rendering should not be enabled, as manual
compositor configuration is required for optimal results.

For reference, the following sway settings results in the best latency:

    output <insert output name> max_render_time 1
    for_window [app_id="looking-glass-client"] max_render_time 1

This reverts commit 3baed057281b9953bd642dfb9faaad443bdf1a3f.