### PR TITLE
[client] wayland: make waitFrame work when not rendering

### DIFF
--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -70,6 +70,7 @@ static void libdecorFrameConfigure(struct libdecor_frame * frame,
     wlWm.needsResize = true;
     wlWm.resizeSerial = configuration->serial;
     app_invalidateWindow();
+    waylandForceRender();
   }
   else
     wlWm.configured = true;

--- a/client/displayservers/Wayland/shell_xdg.c
+++ b/client/displayservers/Wayland/shell_xdg.c
@@ -47,6 +47,7 @@ static void xdgSurfaceConfigure(void * data, struct xdg_surface * xdgSurface,
     wlWm.needsResize  = true;
     wlWm.resizeSerial = serial;
     app_invalidateWindow();
+    waylandForceRender();
   }
   else
   {

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -173,6 +173,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .glSwapBuffers       = waylandGLSwapBuffers,
 #endif
   .waitFrame           = waylandWaitFrame,
+  .skipFrame           = waylandSkipFrame,
   .guestPointerUpdated = waylandGuestPointerUpdated,
   .setPointer          = waylandSetPointer,
   .grabPointer         = waylandGrabPointer,

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -307,3 +307,5 @@ void waylandWindowUpdateScale(void);
 void waylandSetWindowSize(int x, int y);
 bool waylandIsValidPointerPos(int x, int y);
 void waylandWaitFrame(void);
+void waylandSkipFrame(void);
+void waylandForceRender(void);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -144,3 +144,14 @@ void waylandWaitFrame(void)
   if (callback)
     wl_callback_add_listener(callback, &frame_listener, NULL);
 }
+
+void waylandSkipFrame(void)
+{
+  // If we decided to not render, we must commit the surface so that the callback is registered.
+  wl_surface_commit(wlWm.surface);
+}
+
+void waylandForceRender(void)
+{
+  lgSignalEvent(wlWm.frameEvent);
+}

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -150,9 +150,11 @@ struct LG_DisplayServerOps
 #endif
 
   /* Waits for a good time to render the next frame in time for the next vblank.
-   * Once this returns, a frame must be rendered.
    * This is optional and a display server may choose to not implement it. */
   void (*waitFrame)(void);
+
+  /* This must be called when waitFrame returns, but no frame is actually rendered. */
+  void (*skipFrame)(void);
 
   /* dm specific cursor implementations */
   void (*guestPointerUpdated)(double x, double y, double localX, double localY);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -173,7 +173,11 @@ static int renderThread(void * unused)
       g_state.ds->waitFrame();
       if (!lgResetEvent(g_state.frameEvent) && !g_state.overlayInput &&
           !g_state.lgr->needs_render(g_state.lgrData))
+      {
+        if (g_state.ds->skipFrame)
+          g_state.ds->skipFrame();
         continue;
+      }
     }
     else if (g_params.fpsMin != 0)
     {


### PR DESCRIPTION
Add `skipFrame` to display server interface. If this exists, it should be called when `waitFrame` returns but we don't wish to render. This is used to allow Wayland `waitFrame` to work when called without rendering in between.

We also need to signal `frameEvent` to render the first frame. Otherwise, Wayland fails to configure the window, as configuration happens in EGL swap.