### PR TITLE
[client] ds: add stopWaitFrame to terminate waitFrame early

### DIFF
--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -70,7 +70,7 @@ static void libdecorFrameConfigure(struct libdecor_frame * frame,
     wlWm.needsResize = true;
     wlWm.resizeSerial = configuration->serial;
     app_invalidateWindow();
-    waylandForceRender();
+    waylandStopWaitFrame();
   }
   else
     wlWm.configured = true;

--- a/client/displayservers/Wayland/shell_xdg.c
+++ b/client/displayservers/Wayland/shell_xdg.c
@@ -47,7 +47,7 @@ static void xdgSurfaceConfigure(void * data, struct xdg_surface * xdgSurface,
     wlWm.needsResize  = true;
     wlWm.resizeSerial = serial;
     app_invalidateWindow();
-    waylandForceRender();
+    waylandStopWaitFrame();
   }
   else
   {

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -174,6 +174,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
 #endif
   .waitFrame           = waylandWaitFrame,
   .skipFrame           = waylandSkipFrame,
+  .stopWaitFrame       = waylandStopWaitFrame,
   .guestPointerUpdated = waylandGuestPointerUpdated,
   .setPointer          = waylandSetPointer,
   .grabPointer         = waylandGrabPointer,

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -308,4 +308,4 @@ void waylandSetWindowSize(int x, int y);
 bool waylandIsValidPointerPos(int x, int y);
 void waylandWaitFrame(void);
 void waylandSkipFrame(void);
-void waylandForceRender(void);
+void waylandStopWaitFrame(void);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -151,7 +151,7 @@ void waylandSkipFrame(void)
   wl_surface_commit(wlWm.surface);
 }
 
-void waylandForceRender(void)
+void waylandStopWaitFrame(void)
 {
   lgSignalEvent(wlWm.frameEvent);
 }

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -156,6 +156,9 @@ struct LG_DisplayServerOps
   /* This must be called when waitFrame returns, but no frame is actually rendered. */
   void (*skipFrame)(void);
 
+  /* This is used to interrupt waitFrame. */
+  void (*stopWaitFrame)(void);
+
   /* dm specific cursor implementations */
   void (*guestPointerUpdated)(double x, double y, double localX, double localY);
   void (*setPointer)(LG_DSPointer pointer);
@@ -228,6 +231,7 @@ struct LG_DisplayServerOps
   ASSERT_OPENGL_FN((x)->glMakeCurrent    ); \
   ASSERT_OPENGL_FN((x)->glSetSwapInterval); \
   ASSERT_OPENGL_FN((x)->glSwapBuffers    ); \
+  assert(!(x)->waitFrame == !(x)->stopWaitFrame); \
   assert((x)->guestPointerUpdated); \
   assert((x)->setPointer         ); \
   assert((x)->grabPointer        ); \

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1163,6 +1163,8 @@ static void lg_shutdown(void)
   g_state.state = APP_STATE_SHUTDOWN;
   if (t_render)
   {
+    if (g_state.ds->stopWaitFrame)
+      g_state.ds->stopWaitFrame();
     lgSignalEvent(e_startup);
     lgSignalEvent(g_state.frameEvent);
     lgJoinThread(t_render, NULL);


### PR DESCRIPTION
This is used on exit to unblock the render thread.

This is implemented for Wayland.