### PR TITLE
[commit] wayland: invalidate window on scale changes

### DIFF
--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -119,6 +119,8 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
 
     app_handleResizeEvent(wlWm.width, wlWm.height, wl_fixed_to_double(wlWm.scale),
         (struct Border) {0, 0, 0, 0});
+    app_invalidateWindow();
+    waylandStopWaitFrame();
     wlWm.needsResize = false;
   }
 

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -48,6 +48,8 @@ void waylandWindowUpdateScale(void)
     wlWm.scale = maxScale;
     wlWm.fractionalScale = wl_fixed_from_int(wl_fixed_to_int(maxScale)) != maxScale;
     wlWm.needsResize = true;
+    app_invalidateWindow();
+    waylandStopWaitFrame();
   }
 }
 


### PR DESCRIPTION
This makes it not require new frames for new scale to be properly applied.