### PR TITLE
[client] egl: use new EGL damage count semantics

### DIFF
--- a/client/renderers/EGL/damage.c
+++ b/client/renderers/EGL/damage.c
@@ -190,11 +190,11 @@ bool egl_damage_render(EGL_Damage * damage, bool rotate, const struct DesktopDam
   egl_shader_use(damage->shader);
   glUniformMatrix3x2fv(damage->uTransform, 1, GL_FALSE, damage->transform);
 
-  if (data)
+  if (data && data->count != 0)
   {
     damage->count = data->count;
     GLfloat vertices[KVMFR_MAX_DAMAGE_RECTS * 8];
-    if (damage->count == 0)
+    if (damage->count == -1)
     {
       FrameDamageRect full = {
         .x = 0, .y = 0, .width = damage->width, .height = damage->height,

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -514,7 +514,8 @@ static bool egl_on_frame(void * opaque, const FrameBuffer * frame, int dmaFd,
 
   INTERLOCKED_SECTION(this->desktopDamageLock, {
     struct DesktopDamage * damage = this->desktopDamage + this->desktopDamageIdx;
-    if (damage->count == -1 || damage->count + damageRectsCount >= KVMFR_MAX_DAMAGE_RECTS)
+    if (damage->count == -1 || damageRectsCount == 0 ||
+        damage->count + damageRectsCount >= KVMFR_MAX_DAMAGE_RECTS)
       damage->count = -1;
     else
     {


### PR DESCRIPTION
After the damage queue PR, EGL damage count 0 means no change, and -1 means
invalidate the entire window. However, several other places have different
semantics, and we are not handling them correctly:

1. KVMFR uses 0 to signal invalidating the entire frame, so if we receive 0
   rectangles in egl_on_frame, we should set damage count to -1.
2. The damage overlay treated 0 as full damage, which is now incorrect. This
   is fixed, and now it treats 0 as no update, and -1 as full damage.