### PR TITLE
[host] nvfbc: make diff map size configurable

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
@@ -145,6 +145,54 @@ bool NvFBCToSysCreate(
   return true;
 }
 
+void NvFBCGetDiffMapBlockSize(
+  int                     diffRes,
+  enum DiffMapBlockSize * diffMapBlockSize,
+  int                   * diffShift,
+  void                  * privData,
+  unsigned int            privDataSize
+)
+{
+  NvFBCStatusEx status = {0};
+  status.dwVersion = NVFBC_STATUS_VER;
+  status.dwPrivateDataSize = privDataSize;
+  status.pPrivateData      = privData;
+
+  NVFBCRESULT result = nvapi.getStatusEx(&status);
+  if (result != NVFBC_SUCCESS)
+    status.bSupportConfigurableDiffMap = FALSE;
+
+  if (!status.bSupportConfigurableDiffMap)
+  {
+    *diffMapBlockSize = DIFFMAP_BLOCKSIZE_128X128;
+    *diffShift        = 7;
+    return;
+  }
+
+  switch (diffRes)
+  {
+    case 16:
+      *diffMapBlockSize = DIFFMAP_BLOCKSIZE_16X16;
+      *diffShift        = 4;
+      break;
+
+    case 32:
+      *diffMapBlockSize = DIFFMAP_BLOCKSIZE_32X32;
+      *diffShift        = 5;
+      break;
+
+    case 64:
+      *diffMapBlockSize = DIFFMAP_BLOCKSIZE_64X64;
+      *diffShift        = 6;
+      break;
+
+    default:
+      *diffMapBlockSize = DIFFMAP_BLOCKSIZE_128X128;
+      *diffShift        = 7;
+      break;
+  }
+}
+
 void NvFBCToSysRelease(NvFBCHandle * handle)
 {
   if (!*handle)

--- a/host/platform/Windows/capture/NVFBC/src/wrapper.h
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.h
@@ -60,6 +60,14 @@ bool NvFBCToSysCreate(
 );
 void NvFBCToSysRelease(NvFBCHandle * handle);
 
+void NvFBCGetDiffMapBlockSize(
+  int                     diffRes,
+  enum DiffMapBlockSize * diffMapBlockSize,
+  int                   * diffShift,
+  void                  * privData,
+  unsigned int            privDataSize
+);
+
 bool NvFBCToSysSetup(
   NvFBCHandle           handle,
   enum                  BufferFormat format,


### PR DESCRIPTION
This commit adds a new host configuration option, nvfbc:diffRes, which
specifies the dimensions of every block in the diff map. This defaults to
128, meaning the default 128x128 block size.

Since block sizes other than 128x128 is not guaranteed to be supported by
NvFBC, the function NvFBCGetDiffMapBlockSize was introduced to query the
support and output the actual block size used.

Not sure if smaller block sizes actually make sense, however. Will need benchmarks to find out.