### PR TITLE
[client] egl: use buffer age extension to render only damaged parts

### DIFF
--- a/client/include/util.h
+++ b/client/include/util.h
@@ -40,7 +40,7 @@ bool util_guestCurToLocal(struct DoublePoint *local);
 void util_localCurToGuest(struct DoublePoint *guest);
 void util_rotatePoint(struct DoublePoint *point);
 bool util_hasGLExt(const char * exts, const char * ext);
-int util_mergeOverlappingRects(FrameDamageRect * out, const FrameDamageRect * rects, int count);
+int util_mergeOverlappingRects(FrameDamageRect * rects, int count);
 
 static inline double util_clamp(double x, double min, double max)
 {

--- a/client/renderers/EGL/CMakeLists.txt
+++ b/client/renderers/EGL/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(renderer_EGL STATIC
 	texture_dmabuf.c
 	model.c
 	desktop.c
+	desktop_rects.c
 	cursor.c
 	draw.c
 	splash.c

--- a/client/renderers/EGL/desktop.h
+++ b/client/renderers/EGL/desktop.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 
 #include "interface/renderer.h"
+#include "desktop_rects.h"
 
 typedef struct EGL_Desktop EGL_Desktop;
 
@@ -36,11 +37,11 @@ enum EGL_DesktopScaleType
 struct Option;
 bool egl_desktop_scale_validate(struct Option * opt, const char ** error);
 
-bool egl_desktop_init(EGL_Desktop ** desktop, EGLDisplay * display, bool useDMA);
+bool egl_desktop_init(EGL_Desktop ** desktop, EGLDisplay * display, bool useDMA, int maxRects);
 void egl_desktop_free(EGL_Desktop ** desktop);
 
 bool egl_desktop_setup (EGL_Desktop * desktop, const LG_RendererFormat format);
 bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dmaFd);
 bool egl_desktop_render(EGL_Desktop * desktop, const float x, const float y,
     const float scaleX, const float scaleY, enum EGL_DesktopScaleType scaleType,
-    LG_RendererRotate rotate);
+    LG_RendererRotate rotate, const struct DamageRects * rects);

--- a/client/renderers/EGL/desktop_rects.c
+++ b/client/renderers/EGL/desktop_rects.c
@@ -1,0 +1,230 @@
+/**
+ * Looking Glass
+ * Copyright (C) 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "desktop_rects.h"
+#include "common/debug.h"
+#include "common/KVMFR.h"
+#include "common/locking.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <GLES3/gl3.h>
+
+#include "util.h"
+
+struct EGL_DesktopRects
+{
+  GLuint  buffers[2];
+  GLuint  vao;
+  int     count;
+  int     maxCount;
+};
+
+bool egl_desktopRectsInit(EGL_DesktopRects ** rects_, int maxCount)
+{
+  EGL_DesktopRects * rects = malloc(sizeof(EGL_DesktopRects));
+  if (!rects)
+  {
+    DEBUG_ERROR("Failed to malloc EGL_DesktopRects");
+    return false;
+  }
+  *rects_ = rects;
+  memset(rects, 0, sizeof(EGL_DesktopRects));
+
+  glGenVertexArrays(1, &rects->vao);
+  glBindVertexArray(rects->vao);
+
+  glGenBuffers(2, rects->buffers);
+  glBindBuffer(GL_ARRAY_BUFFER, rects->buffers[0]);
+  glBufferData(GL_ARRAY_BUFFER, maxCount * 8 * sizeof(GLfloat), NULL, GL_STREAM_DRAW);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, NULL);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  GLushort indices[maxCount * 6];
+  for (int i = 0; i < maxCount; ++i)
+  {
+    indices[6 * i + 0] = 4 * i + 0;
+    indices[6 * i + 1] = 4 * i + 1;
+    indices[6 * i + 2] = 4 * i + 2;
+    indices[6 * i + 3] = 4 * i + 0;
+    indices[6 * i + 4] = 4 * i + 2;
+    indices[6 * i + 5] = 4 * i + 3;
+  }
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, rects->buffers[1]);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof indices, indices, GL_STATIC_DRAW);
+
+  glBindVertexArray(0);
+
+  rects->count    = 0;
+  rects->maxCount = maxCount;
+  return true;
+}
+
+void egl_desktopRectsFree(EGL_DesktopRects ** rects_)
+{
+  EGL_DesktopRects * rects = *rects_;
+  if (!rects)
+    return;
+
+  glDeleteVertexArrays(1, &rects->vao);
+  glDeleteBuffers(2, rects->buffers);
+  free(rects);
+  *rects_ = NULL;
+}
+
+inline static void rectToVertices(GLfloat * vertex, const FrameDamageRect * rect)
+{
+  vertex[0] = rect->x;
+  vertex[1] = rect->y;
+  vertex[2] = rect->x + rect->width;
+  vertex[3] = rect->y;
+  vertex[4] = rect->x + rect->width;
+  vertex[5] = rect->y + rect->height;
+  vertex[6] = rect->x;
+  vertex[7] = rect->y + rect->height;
+}
+
+void egl_desktopRectsUpdate(EGL_DesktopRects * rects, const struct DamageRects * data,
+    int width, int height)
+{
+  GLfloat vertices[KVMFR_MAX_DAMAGE_RECTS * 8];
+  if (!data || data->count < 0)
+  {
+    FrameDamageRect full = {
+      .x = 0, .y = 0, .width = width, .height = height,
+    };
+    rects->count = 1;
+    rectToVertices(vertices, &full);
+  }
+  else
+  {
+    rects->count = data->count;
+    assert(rects->count <= rects->maxCount);
+
+    for (int i = 0; i < rects->count; ++i)
+      rectToVertices(vertices + i * 8, data->rects + i);
+  }
+
+  glBindBuffer(GL_ARRAY_BUFFER, rects->buffers[0]);
+  glBufferSubData(GL_ARRAY_BUFFER, 0, rects->count * 8 * sizeof(GLfloat), vertices);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+static void desktopToGLSpace(double matrix[6], int width, int height, double translateX,
+    double translateY, double scaleX, double scaleY, LG_RendererRotate rotate)
+{
+  switch (rotate)
+  {
+    case LG_ROTATE_0:
+      matrix[0] = 2.0 * scaleX / width;
+      matrix[1] = 0.0;
+      matrix[2] = 0.0;
+      matrix[3] = -2.0 * scaleY / height;
+      matrix[4] = translateX - scaleX;
+      matrix[5] = translateY + scaleY;
+      return;
+
+    case LG_ROTATE_90:
+      matrix[0] = 0.0;
+      matrix[1] = -2.0 * scaleY / width;
+      matrix[2] = -2.0 * scaleX / height;
+      matrix[3] = 0.0;
+      matrix[4] = translateX + scaleX;
+      matrix[5] = translateY + scaleY;
+      return;
+
+    case LG_ROTATE_180:
+      matrix[0] = -2.0 * scaleX / width;
+      matrix[1] = 0.0;
+      matrix[2] = 0.0;
+      matrix[3] = 2.0 * scaleY / height;
+      matrix[4] = translateX + scaleX;
+      matrix[5] = translateY - scaleY;
+      return;
+
+    case LG_ROTATE_270:
+      matrix[0] = 0.0;
+      matrix[1] = 2.0 * scaleY / width;
+      matrix[2] = 2.0 * scaleX / height;
+      matrix[3] = 0.0;
+      matrix[4] = translateX - scaleX;
+      matrix[5] = translateY - scaleY;
+  }
+}
+
+void egl_desktopRectsMatrix(float matrix[6], int width, int height, float translateX,
+    float translateY, float scaleX, float scaleY, LG_RendererRotate rotate)
+{
+  double temp[6];
+  desktopToGLSpace(temp, width, height, translateX, translateY, scaleX, scaleY, rotate);
+  for (int i = 0; i < 6; ++i)
+    matrix[i] = temp[i];
+}
+
+void egl_desktopToScreenMatrix(double matrix[6], int frameWidth, int frameHeight,
+    double translateX, double translateY, double scaleX, double scaleY, LG_RendererRotate rotate,
+    double windowWidth, double windowHeight)
+{
+  desktopToGLSpace(matrix, frameWidth, frameHeight, translateX, translateY, scaleX, scaleY, rotate);
+
+  double hw = windowWidth  / 2;
+  double hh = windowHeight / 2;
+  matrix[0] *= hw;
+  matrix[1] *= hh;
+  matrix[2] *= hw;
+  matrix[3] *= hh;
+  matrix[4]  = matrix[4] * hw + hw;
+  matrix[5]  = matrix[5] * hh + hh;
+}
+
+inline static void matrixMultiply(const double matrix[6], double * nx, double * ny, double x, double y)
+{
+  *nx = matrix[0] * x + matrix[2] * y + matrix[4];
+  *ny = matrix[1] * x + matrix[3] * y + matrix[5];
+}
+
+struct Rect egl_desktopToScreen(const double matrix[6], const struct FrameDamageRect * rect)
+{
+  double x1, y1, x2, y2;
+  matrixMultiply(matrix, &x1, &y1, rect->x, rect->y);
+  matrixMultiply(matrix, &x2, &y2, rect->x + rect->width, rect->y + rect->height);
+
+  int x3 = min(x1, x2);
+  int y3 = min(y1, y2);
+  return (struct Rect) {
+    .x = x3,
+    .y = y3,
+    .w = ceil(max(x1, x2)) - x3,
+    .h = ceil(max(y1, y2)) - y3,
+  };
+}
+
+void egl_desktopRectsRender(EGL_DesktopRects * rects)
+{
+  if (!rects->count)
+    return;
+
+  glBindVertexArray(rects->vao);
+  glDrawElements(GL_TRIANGLES, 6 * rects->count, GL_UNSIGNED_SHORT, NULL);
+  glBindVertexArray(0);
+}

--- a/client/renderers/EGL/desktop_rects.h
+++ b/client/renderers/EGL/desktop_rects.h
@@ -21,23 +21,27 @@
 #pragma once
 
 #include <stdbool.h>
-#include "common/KVMFR.h"
+#include "common/types.h"
 #include "interface/renderer.h"
-#include "desktop_rects.h"
 
-struct DesktopDamage
+struct DamageRects
 {
   int count;
-  FrameDamageRect rects[KVMFR_MAX_DAMAGE_RECTS];
+  FrameDamageRect rects[];
 };
 
-typedef struct EGL_Damage EGL_Damage;
+typedef struct EGL_DesktopRects EGL_DesktopRects;
 
-bool egl_damage_init(EGL_Damage ** damage);
-void egl_damage_free(EGL_Damage ** damage);
+bool egl_desktopRectsInit(EGL_DesktopRects ** rects, int maxCount);
+void egl_desktopRectsFree(EGL_DesktopRects ** rects);
 
-void egl_damage_setup(EGL_Damage * damage, int width, int height);
-void egl_damage_resize(EGL_Damage * damage, float translateX, float translateY,
-    float scaleX, float scaleY);
-bool egl_damage_render(EGL_Damage * damage, LG_RendererRotate rotate,
-    const struct DesktopDamage * data);
+void egl_desktopRectsMatrix(float matrix[6], int width, int height, float translateX,
+    float translateY, float scaleX, float scaleY, LG_RendererRotate rotate);
+void egl_desktopToScreenMatrix(double matrix[6], int frameWidth, int frameHeight,
+    double translateX, double translateY, double scaleX, double scaleY, LG_RendererRotate rotate,
+    double windowWidth, double windowHeight);
+struct Rect egl_desktopToScreen(const double matrix[6], const struct FrameDamageRect * rect);
+
+void egl_desktopRectsUpdate(EGL_DesktopRects * rects, const struct DamageRects * data,
+    int width, int height);
+void egl_desktopRectsRender(EGL_DesktopRects * rects);

--- a/client/renderers/EGL/desktop_rects.h
+++ b/client/renderers/EGL/desktop_rects.h
@@ -42,6 +42,12 @@ void egl_desktopToScreenMatrix(double matrix[6], int frameWidth, int frameHeight
     double windowWidth, double windowHeight);
 struct Rect egl_desktopToScreen(const double matrix[6], const struct FrameDamageRect * rect);
 
+void egl_screenToDesktopMatrix(double matrix[6], int frameWidth, int frameHeight,
+    double translateX, double translateY, double scaleX, double scaleY, LG_RendererRotate rotate,
+    double windowWidth, double windowHeight);
+bool egl_screenToDesktop(struct FrameDamageRect * output, const double matrix[6],
+    const struct Rect * rect, int width, int height);
+
 void egl_desktopRectsUpdate(EGL_DesktopRects * rects, const struct DamageRects * data,
     int width, int height);
 void egl_desktopRectsRender(EGL_DesktopRects * rects);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -771,7 +771,7 @@ static bool egl_render_startup(void * opaque, bool useDMA)
 
   eglSwapInterval(this->display, this->opt.vsync ? 1 : 0);
 
-  if (!egl_desktop_init(&this->desktop, this->display, useDMA))
+  if (!egl_desktop_init(&this->desktop, this->display, useDMA, 1))
   {
     DEBUG_ERROR("Failed to initialize the desktop");
     return false;
@@ -833,7 +833,7 @@ static bool egl_render(void * opaque, LG_RendererRotate rotate, const bool newFr
     if (egl_desktop_render(this->desktop,
         this->translateX, this->translateY,
         this->scaleX    , this->scaleY    ,
-        this->scaleType , rotate))
+        this->scaleType , rotate, NULL))
     {
       if (!this->waitFadeTime)
       {

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -735,6 +735,8 @@ static bool egl_render_startup(void * opaque, bool useDMA)
   }
 
   this->hasBufferAge = util_hasGLExt(client_exts, "EGL_EXT_buffer_age");
+  if (!this->hasBufferAge)
+    DEBUG_WARN("GL_EXT_buffer_age is not supported, will not perform as well.");
 
   if (g_egl_dynProcs.glEGLImageTargetTexture2DOES)
   {

--- a/client/renderers/EGL/shader/desktop.vert
+++ b/client/renderers/EGL/shader/desktop.vert
@@ -1,20 +1,13 @@
 #version 300 es
 
-layout(location = 0) in vec3 vertexPosition_modelspace;
-layout(location = 1) in vec2 vertexUV;
-
-uniform vec4 position;
-
+layout(location = 0) in vec2 vertex;
 out highp vec2 uv;
+
+uniform highp vec2 uvScale;
+uniform mat3x2 transform;
 
 void main()
 {
-  gl_Position.xyz = vertexPosition_modelspace; 
-  gl_Position.w   = 1.0;
-  gl_Position.x  -= position.x;
-  gl_Position.y  -= position.y;
-  gl_Position.x  *= position.z;
-  gl_Position.y  *= position.w;
-
-  uv = vertexUV;
+  gl_Position = vec4(transform * vec3(vertex, 1.0), 0.0, 1.0);
+  uv = vertex * uvScale;
 }

--- a/client/renderers/EGL/shader/desktop_rgb.frag
+++ b/client/renderers/EGL/shader/desktop_rgb.frag
@@ -12,7 +12,6 @@ uniform sampler2D sampler1;
 
 uniform       int   scaleAlgo;
 uniform highp vec2  size;
-uniform       int   rotate;
 
 uniform       int   nv;
 uniform highp float nvGain;
@@ -20,35 +19,14 @@ uniform       int   cbMode;
 
 void main()
 {
-  highp vec2 ruv;
-  if (rotate == 0) // 0
-  {
-    ruv = uv;
-  }
-  else if (rotate == 1) // 90
-  {
-    ruv.x =  uv.y;
-    ruv.y = -uv.x + 1.0f;
-  }
-  else if (rotate == 2) // 180
-  {
-    ruv.x = -uv.x + 1.0f;
-    ruv.y = -uv.y + 1.0f;
-  }
-  else if (rotate == 3) // 270
-  {
-    ruv.x = -uv.y + 1.0f;
-    ruv.y =  uv.x;
-  }
-
   switch (scaleAlgo)
   {
     case EGL_SCALE_NEAREST:
-      color = texelFetch(sampler1, ivec2(ruv * size), 0);
+      color = texelFetch(sampler1, ivec2(uv * size), 0);
       break;
 
     case EGL_SCALE_LINEAR:
-      color = texture(sampler1, ruv);
+      color = texture(sampler1, uv);
       break;
   }
 

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -225,13 +225,12 @@ static bool rectIntersects(const FrameDamageRect * r1, const FrameDamageRect * r
          r2->y + r1->height > r2->y;
 }
 
-int util_mergeOverlappingRects(FrameDamageRect * out, const FrameDamageRect * rects, int count)
+int util_mergeOverlappingRects(FrameDamageRect * rects, int count)
 {
   bool removed[count];
   bool changed;
 
   memset(removed, 0, sizeof(removed));
-  memcpy(out, rects, count * sizeof(FrameDamageRect));
 
   do
   {
@@ -239,14 +238,14 @@ int util_mergeOverlappingRects(FrameDamageRect * out, const FrameDamageRect * re
     for (int i = 0; i < count; ++i)
       if (!removed[i])
         for (int j = i + 1; j < count; ++j)
-          if (!removed[j] && rectIntersects(out + i, out + j))
+          if (!removed[j] && rectIntersects(rects + i, rects + j))
           {
-            uint32_t x2 = max(out[i].x + out[i].width, out[j].x + out[j].width);
-            uint32_t y2 = max(out[i].y + out[i].height, out[j].y + out[j].height);
-            out[i].x = min(out[i].x, out[j].x);
-            out[i].y = min(out[i].y, out[j].y);
-            out[i].width  = x2 - out[i].x;
-            out[i].height = y2 - out[i].y;
+            uint32_t x2 = max(rects[i].x + rects[i].width, rects[j].x + rects[j].width);
+            uint32_t y2 = max(rects[i].y + rects[i].height, rects[j].y + rects[j].height);
+            rects[i].x = min(rects[i].x, rects[j].x);
+            rects[i].y = min(rects[i].y, rects[j].y);
+            rects[i].width  = x2 - rects[i].x;
+            rects[i].height = y2 - rects[i].y;
             removed[j] = true;
             changed = true;
           }
@@ -256,7 +255,7 @@ int util_mergeOverlappingRects(FrameDamageRect * out, const FrameDamageRect * re
   int o = 0;
   for (int i = 0; i < count; ++i)
     if (!removed[i])
-      out[o++] = out[i];
+      rects[o++] = rects[i];
   return o;
 }
 


### PR DESCRIPTION
We avoid rendering any area that has not changed since the buffer was used and also not covered by an overlay.

In order to do this, we refactored the damage mesh generation into a new module, `desktop_rects.c`, which is then used by the desktop module to render its mesh.

As part of this, we simplified and refactored all coordinate space conversions, changing them to use matrices. We are also able to remove the texture copy in the dmabuf path.