### PR TITLE
[client] egl: implement partial copies for framebuffer textures

### DIFF
--- a/client/renderers/EGL/desktop.c
+++ b/client/renderers/EGL/desktop.c
@@ -256,7 +256,8 @@ bool egl_desktop_setup(EGL_Desktop * desktop, const LG_RendererFormat format)
   return true;
 }
 
-bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dmaFd)
+bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dmaFd,
+    const FrameDamageRect * damageRects, int damageRectsCount)
 {
   if (dmaFd >= 0)
   {
@@ -265,7 +266,7 @@ bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dm
   }
   else
   {
-    if (!egl_texture_update_from_frame(desktop->texture, frame))
+    if (!egl_texture_update_from_frame(desktop->texture, frame, damageRects, damageRectsCount))
       return false;
   }
 

--- a/client/renderers/EGL/desktop.h
+++ b/client/renderers/EGL/desktop.h
@@ -42,7 +42,8 @@ void egl_desktop_free(EGL_Desktop ** desktop);
 
 void egl_desktop_config_ui(EGL_Desktop * desktop);
 bool egl_desktop_setup (EGL_Desktop * desktop, const LG_RendererFormat format);
-bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dmaFd);
+bool egl_desktop_update(EGL_Desktop * desktop, const FrameBuffer * frame, int dmaFd,
+    const FrameDamageRect * damageRects, int damageRectsCount);
 bool egl_desktop_render(EGL_Desktop * desktop, const float x, const float y,
     const float scaleX, const float scaleY, enum EGL_DesktopScaleType scaleType,
     LG_RendererRotate rotate, const struct DamageRects * rects);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -512,7 +512,7 @@ static bool egl_on_frame(void * opaque, const FrameBuffer * frame, int dmaFd,
   struct Inst * this = (struct Inst *)opaque;
 
   uint64_t start = nanotime();
-  if (!egl_desktop_update(this->desktop, frame, dmaFd))
+  if (!egl_desktop_update(this->desktop, frame, dmaFd, damageRects, damageRectsCount))
   {
     DEBUG_INFO("Failed to to update the desktop");
     return false;

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -99,12 +99,15 @@ bool egl_texture_update(EGL_Texture * texture, const uint8_t * buffer)
 }
 
 bool egl_texture_update_from_frame(EGL_Texture * texture,
-    const FrameBuffer * frame)
+    const FrameBuffer * frame, const FrameDamageRect * damageRects,
+    int damageRectsCount)
 {
   const struct EGL_TexUpdate update =
   {
-    .type  = EGL_TEXTYPE_FRAMEBUFFER,
-    .frame = frame
+    .type      = EGL_TEXTYPE_FRAMEBUFFER,
+    .frame     = frame,
+    .rects     = damageRects,
+    .rectCount = damageRectsCount,
   };
   return texture->ops->update(texture, &update);
 }

--- a/client/renderers/EGL/texture.h
+++ b/client/renderers/EGL/texture.h
@@ -92,7 +92,12 @@ typedef struct EGL_TexUpdate
     const uint8_t * buffer;
 
     /* EGL_TEXTURE_FRAMEBUFFER */
-    const FrameBuffer * frame;
+    struct
+    {
+      const FrameBuffer * frame;
+      const FrameDamageRect * rects;
+      int rectCount;
+    };
 
     /* EGL_TEXTURE_DMABUF */
     int dmaFD;
@@ -132,7 +137,8 @@ bool egl_texture_setup(EGL_Texture * texture, enum EGL_PixelFormat pixFmt,
 bool egl_texture_update (EGL_Texture * texture, const uint8_t * buffer);
 
 bool egl_texture_update_from_frame(EGL_Texture * texture,
-    const FrameBuffer * frame);
+    const FrameBuffer * frame, const FrameDamageRect * damageRects,
+    int damageRectsCount);
 
 bool egl_texture_update_from_dma(EGL_Texture * texture,
     const FrameBuffer * frame, const int dmaFd);

--- a/client/renderers/EGL/texture_buffer.h
+++ b/client/renderers/EGL/texture_buffer.h
@@ -24,6 +24,8 @@
 #include "texture_util.h"
 #include "common/locking.h"
 
+#define EGL_TEX_BUFFER_MAX 2
+
 typedef struct TextureBuffer
 {
   EGL_Texture base;
@@ -31,9 +33,9 @@ typedef struct TextureBuffer
 
   EGL_TexFormat format;
   int           texCount;
-  GLuint        tex[2];
+  GLuint        tex[EGL_TEX_BUFFER_MAX];
   GLuint        sampler;
-  EGL_TexBuffer buf[2];
+  EGL_TexBuffer buf[EGL_TEX_BUFFER_MAX];
   int           bufFree;
   GLsync        sync;
   LG_Lock       copyLock;

--- a/client/renderers/EGL/texture_framebuffer.c
+++ b/client/renderers/EGL/texture_framebuffer.c
@@ -24,25 +24,97 @@
 
 #include "texture_buffer.h"
 #include "common/debug.h"
+#include "common/KVMFR.h"
+#include "common/rects.h"
+
+struct TexDamage
+{
+  int             count;
+  FrameDamageRect rects[KVMFR_MAX_DAMAGE_RECTS];
+};
+
+typedef struct TexFB
+{
+  TextureBuffer base;
+  struct TexDamage damage[EGL_TEX_BUFFER_MAX];
+}
+TexFB;
+
+static bool eglTexFB_init(EGL_Texture ** texture, EGLDisplay * display)
+{
+  TexFB * this = calloc(sizeof(*this), 1);
+  *texture = &this->base.base;
+
+  EGL_Texture * parent = &this->base.base;
+  if (!eglTexBuffer_init(&parent, display))
+  {
+    free(this);
+    *texture = NULL;
+    return false;
+  }
+
+  for (int i = 0; i < EGL_TEX_BUFFER_MAX; ++i)
+    this->damage[i].count = -1;
+
+  return true;
+}
 
 static bool eglTexFB_update(EGL_Texture * texture, const EGL_TexUpdate * update)
 {
   TextureBuffer * this = UPCAST(TextureBuffer, texture);
+  TexFB * fb = UPCAST(TexFB, this);
   assert(update->type == EGL_TEXTYPE_FRAMEBUFFER);
 
   LG_LOCK(this->copyLock);
 
-  framebuffer_read(
-    update->frame,
-    this->buf[this->bufIndex].map,
-    this->format.stride,
-    this->format.height,
-    this->format.width,
-    this->format.bpp,
-    this->format.stride
-  );
+  struct TexDamage * damage = fb->damage + this->bufIndex;
+  bool damageAll = !update->rects || update->rectCount == 0 || damage->count < 0 ||
+    damage->count + update->rectCount > KVMFR_MAX_DAMAGE_RECTS;
+
+  if (damageAll)
+    framebuffer_read(
+      update->frame,
+      this->buf[this->bufIndex].map,
+      this->format.stride,
+      this->format.height,
+      this->format.width,
+      this->format.bpp,
+      this->format.stride
+    );
+  else
+  {
+    memcpy(damage->rects + damage->count, update->rects,
+      update->rectCount * sizeof(FrameDamageRect));
+    damage->count += update->rectCount;
+    rectsFramebufferToBuffer(
+      damage->rects,
+      damage->count,
+      this->buf[this->bufIndex].map,
+      this->format.stride,
+      this->format.height,
+      update->frame,
+      this->format.stride
+    );
+  }
 
   this->buf[this->bufIndex].updated = true;
+
+  for (int i = 0; i < EGL_TEX_BUFFER_MAX; ++i)
+  {
+    struct TexDamage * damage = fb->damage + i;
+    if (i == this->bufIndex)
+      damage->count = 0;
+    else if (update->rects && update->rectCount > 0 && damage->count >= 0 &&
+             damage->count + update->rectCount <= KVMFR_MAX_DAMAGE_RECTS)
+    {
+      memcpy(damage->rects + damage->count, update->rects,
+        update->rectCount * sizeof(FrameDamageRect));
+      damage->count += update->rectCount;
+    }
+    else
+      damage->count = -1;
+  }
+
   LG_UNLOCK(this->copyLock);
 
   return true;
@@ -50,7 +122,7 @@ static bool eglTexFB_update(EGL_Texture * texture, const EGL_TexUpdate * update)
 
 EGL_TextureOps EGL_TextureFrameBuffer =
 {
-  .init        = eglTexBuffer_stream_init,
+  .init        = eglTexFB_init,
   .free        = eglTexBuffer_free,
   .setup       = eglTexBuffer_stream_setup,
   .update      = eglTexFB_update,

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -29,6 +29,7 @@ set(COMMON_SOURCES
   src/framebuffer.c
   src/KVMFR.c
   src/countedbuffer.c
+  src/rects.c
   src/runningavg.c
   src/ringbuffer.c
 )

--- a/common/include/common/framebuffer.h
+++ b/common/include/common/framebuffer.h
@@ -63,6 +63,12 @@ bool framebuffer_write(FrameBuffer * frame, const void * src, size_t size);
 
 /**
  * Gets the underlying data buffer of the framebuffer.
+ * For custom read routines only.
+ */
+const uint8_t * framebuffer_get_buffer(const FrameBuffer * frame);
+
+/**
+ * Gets the underlying data buffer of the framebuffer.
  * For custom write routines only.
  */
 uint8_t * framebuffer_get_data(FrameBuffer * frame);

--- a/common/include/common/rects.h
+++ b/common/include/common/rects.h
@@ -1,0 +1,45 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _LG_COMMON_RECTS_H_
+#define _LG_COMMON_RECTS_H_
+
+#include <stdint.h>
+#include <string.h>
+
+#include "common/framebuffer.h"
+#include "common/types.h"
+
+inline static void rectCopyUnaligned(uint8_t * dest, const uint8_t * src,
+    int ystart, int yend, int dx, int dstStride, int srcStride, int width)
+{
+  for (int i = ystart; i < yend; ++i)
+  {
+    unsigned int srcOffset = i * srcStride + dx;
+    unsigned int dstOffset = i * dstStride + dx;
+    memcpy(dest + dstOffset, src + srcOffset, width);
+  }
+}
+
+void rectsBufferToFramebuffer(FrameDamageRect * rects, int count,
+  FrameBuffer * frame, int dstStride, int height,
+  const uint8_t * src, int srcStride);
+
+#endif

--- a/common/include/common/rects.h
+++ b/common/include/common/rects.h
@@ -42,4 +42,8 @@ void rectsBufferToFramebuffer(FrameDamageRect * rects, int count,
   FrameBuffer * frame, int dstStride, int height,
   const uint8_t * src, int srcStride);
 
+void rectsFramebufferToBuffer(FrameDamageRect * rects, int count,
+  uint8_t * dst, int dstStride, int height,
+  const FrameBuffer * frame, int srcStride);
+
 #endif

--- a/common/src/framebuffer.c
+++ b/common/src/framebuffer.c
@@ -214,6 +214,11 @@ bool framebuffer_write(FrameBuffer * frame, const void * restrict src, size_t si
   return true;
 }
 
+const uint8_t * framebuffer_get_buffer(const FrameBuffer * frame)
+{
+  return frame->data;
+}
+
 uint8_t * framebuffer_get_data(FrameBuffer * frame)
 {
   return frame->data;

--- a/common/src/rects.c
+++ b/common/src/rects.c
@@ -1,0 +1,174 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/rects.h"
+
+#include <stdlib.h>
+
+struct Corner
+{
+  int x;
+  int y;
+  int delta;
+};
+
+struct Edge
+{
+  int x;
+  int delta;
+};
+
+static int cornerCompare(const void * a_, const void * b_)
+{
+  const struct Corner * a = a_;
+  const struct Corner * b = b_;
+
+  if (a->y < b->y) return -1;
+  if (a->y > b->y) return +1;
+  if (a->x < b->x) return -1;
+  if (a->x > b->x) return +1;
+  return 0;
+}
+
+inline static void rectsBufferCopy(FrameDamageRect * rects, int count,
+  uint8_t * dst, int dstStride, int height,
+  const uint8_t * src, int srcStride, void * opaque,
+  void (*rowCopyFinish)(int y, void * opaque))
+{
+  const int cornerCount = 4 * count;
+  struct Corner corners[cornerCount];
+
+  for (int i = 0; i < count; ++i)
+  {
+    FrameDamageRect * rect = rects + i;
+    corners[4 * i + 0] = (struct Corner) {
+      .x = rect->x, .y = rect->y, .delta = 1
+    };
+    corners[4 * i + 1] = (struct Corner) {
+      .x = rect->x + rect->width, .y = rect->y, .delta = -1
+    };
+    corners[4 * i + 2] = (struct Corner) {
+      .x = rect->x, .y = rect->y + rect->height, .delta = -1
+    };
+    corners[4 * i + 3] = (struct Corner) {
+      .x = rect->x + rect->width, .y = rect->y + rect->height, .delta = 1
+    };
+  }
+  qsort(corners, cornerCount, sizeof(struct Corner), cornerCompare);
+
+  struct Edge active_[2][cornerCount];
+  struct Edge change[cornerCount];
+  int prev_y = 0;
+  int activeRow = 0;
+  int actives = 0;
+
+  for (int rs = 0;;)
+  {
+    int y = corners[rs].y;
+    int re = rs;
+    while (re < cornerCount && corners[re].y == y)
+      ++re;
+
+    if (y > height)
+      y = height;
+
+    int changes = 0;
+    for (int i = rs; i < re; )
+    {
+      int x = corners[i].x;
+      int delta = 0;
+      while (i < re && corners[i].x == x)
+        delta += corners[i++].delta;
+      change[changes++] = (struct Edge) { .x = x, .delta = delta };
+    }
+
+    struct Edge * active = active_[activeRow];
+    int x1 = 0;
+    int in_rect = 0;
+    for (int i = 0; i < actives; ++i)
+    {
+      if (!in_rect)
+        x1 = active[i].x;
+      in_rect += active[i].delta;
+      if (!in_rect)
+        rectCopyUnaligned(dst, src, prev_y, y, x1 * 4, dstStride, srcStride,
+            (active[i].x - x1) * 4);
+    }
+
+    if (re >= cornerCount || y == height)
+      break;
+
+    if (rowCopyFinish)
+      rowCopyFinish(y, opaque);
+
+    struct Edge * new = active_[activeRow ^ 1];
+    int ai = 0;
+    int ci = 0;
+    int ni = 0;
+
+    while (ai < actives && ci < changes)
+    {
+      if (active[ai].x < change[ci].x)
+        new[ni++] = active[ai++];
+      else if (active[ai].x > change[ci].x)
+        new[ni++] = change[ci++];
+      else
+      {
+        active[ai].delta += change[ci++].delta;
+        if (active[ai].delta != 0)
+          new[ni++] = active[ai];
+        ++ai;
+      }
+    }
+
+    // only one of (actives - ai) and (changes - ci) will be non-zero.
+    memcpy(new + ni, active + ai, (actives - ai) * sizeof(struct Edge));
+    memcpy(new + ni, change + ci, (changes - ci) * sizeof(struct Edge));
+    ni += actives - ai;
+    ni += changes - ci;
+
+    actives = ni;
+    prev_y = y;
+    rs = re;
+    activeRow ^= 1;
+  }
+}
+
+struct ToFramebufferData
+{
+  FrameBuffer * frame;
+  int stride;
+};
+
+static void fbRowFinish(int y, void * opaque)
+{
+  struct ToFramebufferData * data = opaque;
+  framebuffer_set_write_ptr(data->frame, y * data->stride);
+}
+
+void rectsBufferToFramebuffer(FrameDamageRect * rects, int count,
+  FrameBuffer * frame, int dstStride, int height,
+  const uint8_t * src, int srcStride)
+{
+  struct ToFramebufferData data = { .frame = frame, .stride = dstStride };
+  rectsBufferCopy(rects, count, framebuffer_get_data(frame), dstStride, height,
+    src, srcStride, &data, fbRowFinish);
+  framebuffer_set_write_ptr(frame, height * dstStride);
+}

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -26,6 +26,7 @@
 #include "common/option.h"
 #include "common/locking.h"
 #include "common/event.h"
+#include "common/rects.h"
 #include "common/runningavg.h"
 #include "common/KVMFR.h"
 
@@ -1027,144 +1028,6 @@ static CaptureResult dxgi_waitFrame(CaptureFrame * frame, const size_t maxFrameS
   return CAPTURE_RESULT_OK;
 }
 
-struct Corner
-{
-  int x;
-  int y;
-  int delta;
-};
-
-struct Edge
-{
-  int x;
-  int delta;
-};
-
-static int cornerCompare(const void * a_, const void * b_)
-{
-  const struct Corner * a = a_;
-  const struct Corner * b = b_;
-
-  if (a->y < b->y) return -1;
-  if (a->y > b->y) return +1;
-  if (a->x < b->x) return -1;
-  if (a->x > b->x) return +1;
-  return 0;
-}
-
-inline static void rectCopyUnaligned(uint8_t * dest, const uint8_t * src, int ystart,
-    int yend, int dx, int stride, int width)
-{
-  for (int i = ystart; i < yend; ++i)
-  {
-    unsigned int offset = i * stride + dx;
-    memcpy(dest + offset, src + offset, width);
-  }
-}
-
-static void copyRects(struct FrameDamage * damage, FrameBuffer * frame, int height,
-  const uint8_t * src, int stride)
-{
-  uint8_t * frameData = framebuffer_get_data(frame);
-  struct Corner corners[4 * KVMFR_MAX_DAMAGE_RECTS];
-  const int cornerCount = 4 * damage->count;
-
-  for (int i = 0; i < damage->count; ++i)
-  {
-    FrameDamageRect * rect = damage->rects + i;
-    corners[4 * i + 0] = (struct Corner) {
-      .x = rect->x, .y = rect->y, .delta = 1
-    };
-    corners[4 * i + 1] = (struct Corner) {
-      .x = rect->x + rect->width, .y = rect->y, .delta = -1
-    };
-    corners[4 * i + 2] = (struct Corner) {
-      .x = rect->x, .y = rect->y + rect->height, .delta = -1
-    };
-    corners[4 * i + 3] = (struct Corner) {
-      .x = rect->x + rect->width, .y = rect->y + rect->height, .delta = 1
-    };
-  }
-  qsort(corners, cornerCount, sizeof(struct Corner), cornerCompare);
-
-  struct Edge active_[2][4 * KVMFR_MAX_DAMAGE_RECTS];
-  struct Edge change[4 * KVMFR_MAX_DAMAGE_RECTS];
-  int prev_y = 0;
-  int activeRow = 0;
-  int actives = 0;
-
-  for (int rs = 0;;)
-  {
-    int y = corners[rs].y;
-    int re = rs;
-    while (re < cornerCount && corners[re].y == y)
-      ++re;
-
-    if (y > height)
-      y = height;
-
-    int changes = 0;
-    for (int i = rs; i < re; )
-    {
-      int x = corners[i].x;
-      int delta = 0;
-      while (i < re && corners[i].x == x)
-        delta += corners[i++].delta;
-      change[changes++] = (struct Edge) { .x = x, .delta = delta };
-    }
-
-    struct Edge * active = active_[activeRow];
-    int x1 = 0;
-    int in_rect = 0;
-    for (int i = 0; i < actives; ++i)
-    {
-      if (!in_rect)
-        x1 = active[i].x;
-      in_rect += active[i].delta;
-      if (!in_rect)
-        rectCopyUnaligned(frameData, src, prev_y, y, x1 * 4, stride, (active[i].x - x1) * 4);
-    }
-
-    if (re >= cornerCount || y == height)
-      break;
-
-    framebuffer_set_write_ptr(frame, y * stride * 4);
-
-    struct Edge * new = active_[activeRow ^ 1];
-    int ai = 0;
-    int ci = 0;
-    int ni = 0;
-
-    while (ai < actives && ci < changes)
-    {
-      if (active[ai].x < change[ci].x)
-        new[ni++] = active[ai++];
-      else if (active[ai].x > change[ci].x)
-        new[ni++] = change[ci++];
-      else
-      {
-        active[ai].delta += change[ci++].delta;
-        if (active[ai].delta != 0)
-          new[ni++] = active[ai];
-        ++ai;
-      }
-    }
-
-    // only one of (actives - ai) and (changes - ci) will be non-zero.
-    memcpy(new + ni, active + ai, (actives - ai) * sizeof(struct Edge));
-    memcpy(new + ni, change + ci, (changes - ci) * sizeof(struct Edge));
-    ni += actives - ai;
-    ni += changes - ci;
-
-    actives = ni;
-    prev_y = y;
-    rs = re;
-    activeRow ^= 1;
-  }
-
-  framebuffer_set_write_ptr(frame, height * stride * 4);
-}
-
 static CaptureResult dxgi_getFrame(FrameBuffer * frame,
     const unsigned int height, int frameIndex)
 {
@@ -1184,7 +1047,8 @@ static CaptureResult dxgi_getFrame(FrameBuffer * frame,
     memcpy(damage->rects + damage->count, tex->damageRects,
       tex->damageRectsCount * sizeof(FrameDamageRect));
     damage->count += tex->damageRectsCount;
-    copyRects(damage, frame, height, tex->map.pData, this->pitch);
+    rectsBufferToFramebuffer(damage->rects, damage->count, frame, this->pitch,
+      height, tex->map.pData, this->pitch);
   }
 
   for (int i = 0; i < LGMP_Q_FRAME_LEN; ++i)

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -26,6 +26,7 @@
 #include "common/option.h"
 #include "common/framebuffer.h"
 #include "common/event.h"
+#include "common/rects.h"
 #include "common/thread.h"
 #include "common/KVMFR.h"
 #include <assert.h>
@@ -480,17 +481,6 @@ static CaptureResult nvfbc_waitFrame(CaptureFrame * frame,
 
   frame->format = this->grabInfo.bIsHDR ? CAPTURE_FMT_RGBA10 : CAPTURE_FMT_BGRA;
   return CAPTURE_RESULT_OK;
-}
-
-inline static void rectCopyUnaligned(uint8_t * dest, uint8_t * src, int ystart,
-    int yend, int dx, int dstStride, int srcStride, int width)
-{
-  for (int i = ystart; i < yend; ++i)
-  {
-    unsigned int srcOffset = i * srcStride + dx;
-    unsigned int dstOffset = i * dstStride + dx;
-    memcpy(dest + dstOffset, src + srcOffset, width);
-  }
 }
 
 static CaptureResult nvfbc_getFrame(FrameBuffer * frame,


### PR DESCRIPTION
This uses the same line sweep algorithm originally created to copy DXGI textures to IVSHMEM to implement the copy from IVSHMEM to memory-mapped pixel buffer objects.