### PR TITLE
[client] egl: eliminate GLsync object leaks

### DIFF
--- a/client/renderers/EGL/texture_buffer.h
+++ b/client/renderers/EGL/texture_buffer.h
@@ -31,16 +31,16 @@ typedef struct TextureBuffer
   EGL_Texture base;
   bool free;
 
-  EGL_TexFormat format;
-  int           texCount;
-  GLuint        tex[EGL_TEX_BUFFER_MAX];
-  GLuint        sampler;
-  EGL_TexBuffer buf[EGL_TEX_BUFFER_MAX];
-  int           bufFree;
-  GLsync        sync;
-  LG_Lock       copyLock;
-  int           bufIndex;
-  int           rIndex;
+  EGL_TexFormat   format;
+  int             texCount;
+  GLuint          tex[EGL_TEX_BUFFER_MAX];
+  GLuint          sampler;
+  EGL_TexBuffer   buf[EGL_TEX_BUFFER_MAX];
+  int             bufFree;
+  _Atomic(GLsync) sync;
+  LG_Lock         copyLock;
+  int             bufIndex;
+  int             rIndex;
 }
 TextureBuffer;
 


### PR DESCRIPTION
It used to be the case that we overwrite this->sync even if it was non-zero
when updating the texture, without deleting the sync object. If we update
faster than we render, the result would be leaking sync objects.

This commit ensures that sync objects are deleted when they are replaced.