### PR TITLE
[client] egl: simplify desktop vertex shader

### DIFF
--- a/client/renderers/EGL/shader/desktop.vert
+++ b/client/renderers/EGL/shader/desktop.vert
@@ -8,10 +8,6 @@ uniform mat3x2 transform;
 
 void main()
 {
-  highp vec2 uvScale;
-
   gl_Position = vec4(transform * vec3(vertex, 1.0), 0.0, 1.0);
-  uvScale.x = 1.0 / size.x;
-  uvScale.y = 1.0 / size.y;
-  uv = vertex * uvScale;
+  uv = vertex / size;
 }


### PR DESCRIPTION
In GLSL, using the / operator on two vectors of the same size divides the
vector component-wise, i.e. vec2(a, b) / vec2(c, d) == vec2(a / c, b / d).