### PR TITLE
[client] egl: correct assign to gl_Position in basic.vert

### DIFF
--- a/client/renderers/EGL/shader/basic.vert
+++ b/client/renderers/EGL/shader/basic.vert
@@ -9,6 +9,6 @@ out vec2 iFragCoord;
 
 void main()
 {
-  gl_Position.xy = uVertex;
-  iFragCoord     = uUV;
+  gl_Position = vec4(uVertex, 0.0, 1.0);
+  iFragCoord  = uUV;
 }

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -254,7 +254,7 @@ BindInfo;
 typedef struct BindData
 {
   GLuint sampler;
-  GLuint dimensions[0];
+  GLuint dimensions[];
 }
 BindData;
 


### PR DESCRIPTION
`gl_Position` is expected to be using homogeneous coordinates, which requires
w to be a coordinate scale factor, usually 1.0. z should also be set in order
for depth to be well-defined. Therefore, we should set `gl_Position.zw` to
`vec2(0.0, 1.0)`.

Also fixed a flexible array member usage. Note that array size of 0 is a gcc extension, the standard C is not declaring a size.