### PR TITLE
[client] cmake: make MakeObject use relative paths

### DIFF
--- a/client/cmake/MakeObject.cmake
+++ b/client/cmake/MakeObject.cmake
@@ -5,14 +5,13 @@ function(make_object out_var)
     file(RELATIVE_PATH out_f ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/${in_f}")
     set(out_h "${CMAKE_CURRENT_BINARY_DIR}/${out_f}.h")
     set(out_f "${CMAKE_CURRENT_BINARY_DIR}/${out_f}.o")
-    string(REGEX REPLACE "[/.-]" "_" sym_in  "${CMAKE_CURRENT_SOURCE_DIR}/${in_f}")
-    string(REGEX REPLACE "[/.-]" "_" sym_out "${in_f}")
+    string(REGEX REPLACE "[/.-]" "_" sym_in "${in_f}")
 
     add_custom_command(OUTPUT ${out_f}
-      COMMAND ${CMAKE_LINKER} -r -b binary -o ${out_f} "${CMAKE_CURRENT_SOURCE_DIR}/${in_f}"
+      COMMAND ${CMAKE_LINKER} -r -b binary -o ${out_f} "${in_f}"
       COMMAND ${CMAKE_OBJCOPY} --rename-section .data=.rodata,CONTENTS,ALLOC,LOAD,READONLY,DATA ${out_f} ${out_f}
-      COMMAND ${CMAKE_OBJCOPY} --redefine-sym _binary_${sym_in}_start=b_${sym_out} ${out_f} ${out_f}
-      COMMAND ${CMAKE_OBJCOPY} --redefine-sym _binary_${sym_in}_end=b_${sym_out}_end ${out_f} ${out_f}
+      COMMAND ${CMAKE_OBJCOPY} --redefine-sym _binary_${sym_in}_start=b_${sym_in} ${out_f} ${out_f}
+      COMMAND ${CMAKE_OBJCOPY} --redefine-sym _binary_${sym_in}_end=b_${sym_in}_end ${out_f} ${out_f}
       COMMAND ${CMAKE_OBJCOPY} --strip-symbol _binary_${sym_in}_size ${out_f} ${out_f}
       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${in_f}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20,9 +19,9 @@ function(make_object out_var)
       VERBATIM
     )
 
-    file(WRITE  ${out_h} "extern const char b_${sym_out}[];\n")
-    file(APPEND ${out_h} "extern const char b_${sym_out}_end[];\n")
-    file(APPEND ${out_h} "#define b_${sym_out}_size (b_${sym_out}_end - b_${sym_out})\n")
+    file(WRITE  ${out_h} "extern const char b_${sym_in}[];\n")
+    file(APPEND ${out_h} "extern const char b_${sym_in}_end[];\n")
+    file(APPEND ${out_h} "#define b_${sym_in}_size (b_${sym_in}_end - b_${sym_in})\n")
 
     get_filename_component(h_dir ${out_h} DIRECTORY)
     list(APPEND result_h ${h_dir})


### PR DESCRIPTION
This prevents issues like obscure characters getting transformed in symbol
names, resulting in an endless game of whack-a-mole finding symbols that are
replaced, such as 58964ce3175a0ca92b4c7e66aedb374d71b8af68.