### PR TITLE
[client] egl: remove textureGather implementation in compat.h

### DIFF
--- a/client/renderers/EGL/shader/compat.h
+++ b/client/renderers/EGL/shader/compat.h
@@ -1,20 +1,3 @@
-#if __VERSION__ == 300
-  vec4 textureGather(sampler2D tex, vec2 uv, int comp)
-  {
-    vec4 c0 = textureOffset(tex, uv, ivec2(0,1));
-    vec4 c1 = textureOffset(tex, uv, ivec2(1,1));
-    vec4 c2 = textureOffset(tex, uv, ivec2(1,0));
-    vec4 c3 = textureOffset(tex, uv, ivec2(0,0));
-    return vec4(c0[comp], c1[comp], c2[comp],c3[comp]);
-  }
-#elif __VERSION__ < 300
-  vec4 textureGather(sampler2D tex, vec2 uv, int comp)
-  {
-    vec4 c3 = texture2D(tex, uv);
-    return vec4(c3[comp], c3[comp], c3[comp],c3[comp]);
-  }
-#endif
-
 #if __VERSION__ < 310
   uint bitfieldExtract(uint val, int off, int size)
   {

--- a/client/renderers/EGL/shader/ffx_fsr1_easu.frag
+++ b/client/renderers/EGL/shader/ffx_fsr1_easu.frag
@@ -18,19 +18,21 @@ uniform uvec2     uOutRes;
 
 #define FSR_EASU_F 1
 
-vec4 _textureGather(sampler2D tex, vec2 uv, int comp)
-{
-  ivec2 p = ivec2((uv * vec2(uInRes[0])) - 0.5f);
-  vec4 c0 = texelFetchOffset(tex, p, 0, ivec2(0,1));
-  vec4 c1 = texelFetchOffset(tex, p, 0, ivec2(1,1));
-  vec4 c2 = texelFetchOffset(tex, p, 0, ivec2(1,0));
-  vec4 c3 = texelFetchOffset(tex, p, 0, ivec2(0,0));
-  return vec4(c0[comp], c1[comp], c2[comp],c3[comp]);
-}
+#if __VERSION__ <= 310
+  vec4 textureGather(sampler2D tex, vec2 uv, int comp)
+  {
+    ivec2 p = ivec2((uv * vec2(uInRes[0])) - 0.5f);
+    vec4 c0 = texelFetchOffset(tex, p, 0, ivec2(0,1));
+    vec4 c1 = texelFetchOffset(tex, p, 0, ivec2(1,1));
+    vec4 c2 = texelFetchOffset(tex, p, 0, ivec2(1,0));
+    vec4 c3 = texelFetchOffset(tex, p, 0, ivec2(0,0));
+    return vec4(c0[comp], c1[comp], c2[comp], c3[comp]);
+  }
+#endif
 
-AF4 FsrEasuRF(AF2 p){return AF4(_textureGather(iChannel0, p, 0));}
-AF4 FsrEasuGF(AF2 p){return AF4(_textureGather(iChannel0, p, 1));}
-AF4 FsrEasuBF(AF2 p){return AF4(_textureGather(iChannel0, p, 2));}
+AF4 FsrEasuRF(AF2 p){return AF4(textureGather(iChannel0, p, 0));}
+AF4 FsrEasuGF(AF2 p){return AF4(textureGather(iChannel0, p, 1));}
+AF4 FsrEasuBF(AF2 p){return AF4(textureGather(iChannel0, p, 2));}
 
 #include "ffx_fsr1.h"
 


### PR DESCRIPTION
The shader works correctly with #version 320 es and the normal textureGather,
so the problem seems to be the version in compat.h. Since our implementation
needs uInRes[0], we should just move the fallback into ffx_fsr1_easu.frag.