### PR TITLE
[host] dxgi: use CopySubresourceRegion when possible

### DIFF
--- a/client/include/util.h
+++ b/client/include/util.h
@@ -40,7 +40,6 @@ bool util_guestCurToLocal(struct DoublePoint *local);
 void util_localCurToGuest(struct DoublePoint *guest);
 void util_rotatePoint(struct DoublePoint *point);
 bool util_hasGLExt(const char * exts, const char * ext);
-int util_mergeOverlappingRects(FrameDamageRect * rects, int count);
 
 static inline double util_clamp(double x, double min, double max)
 {

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -24,6 +24,7 @@
 #include "common/KVMFR.h"
 #include "common/option.h"
 #include "common/sysinfo.h"
+#include "common/rects.h"
 #include "common/time.h"
 #include "common/locking.h"
 #include "app.h"
@@ -982,7 +983,7 @@ static bool egl_render(LG_Renderer * renderer, LG_RendererRotate rotate,
         );
     }
 
-    accumulated->count = util_mergeOverlappingRects(accumulated->rects, accumulated->count);
+    accumulated->count = rectsMergeOverlapping(accumulated->rects, accumulated->count);
   }
   ++this->overlayHistoryIdx;
 

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -219,48 +219,6 @@ bool util_hasGLExt(const char * exts, const char * ext)
   return str_containsValue(exts, ' ', ext);
 }
 
-static bool rectIntersects(const FrameDamageRect * r1, const FrameDamageRect * r2)
-{
-  return r1->x < r2->x + r2->width &&
-         r1->x + r1->width > r2->x &&
-         r1->y < r2->y + r2->height &&
-         r2->y + r1->height > r2->y;
-}
-
-int util_mergeOverlappingRects(FrameDamageRect * rects, int count)
-{
-  bool removed[count];
-  bool changed;
-
-  memset(removed, 0, sizeof(removed));
-
-  do
-  {
-    changed = false;
-    for (int i = 0; i < count; ++i)
-      if (!removed[i])
-        for (int j = i + 1; j < count; ++j)
-          if (!removed[j] && rectIntersects(rects + i, rects + j))
-          {
-            uint32_t x2 = max(rects[i].x + rects[i].width, rects[j].x + rects[j].width);
-            uint32_t y2 = max(rects[i].y + rects[i].height, rects[j].y + rects[j].height);
-            rects[i].x = min(rects[i].x, rects[j].x);
-            rects[i].y = min(rects[i].y, rects[j].y);
-            rects[i].width  = x2 - rects[i].x;
-            rects[i].height = y2 - rects[i].y;
-            removed[j] = true;
-            changed = true;
-          }
-  }
-  while (changed);
-
-  int o = 0;
-  for (int i = 0; i < count; ++i)
-    if (!removed[i])
-      rects[o++] = rects[i];
-  return o;
-}
-
 bool util_initUIFonts(void)
 {
   if (FontConfig)

--- a/common/include/common/rects.h
+++ b/common/include/common/rects.h
@@ -46,4 +46,6 @@ void rectsFramebufferToBuffer(FrameDamageRect * rects, int count,
   uint8_t * dst, int dstStride, int height,
   const FrameBuffer * frame, int srcStride);
 
+int rectsMergeOverlapping(FrameDamageRect * rects, int count);
+
 #endif


### PR DESCRIPTION
This PR adds damage tracking to the DXGI textures, and only copies the damaged areas to the textures with `ID3D11DeviceContext::CopySubresourceRegion`.

The sleep logic in `waitFrame` makes it difficult for this to reduce the latency, but removing it shows significant improvements (6-7 ms to ~3 ms) when a tiny portion of the screen is damaged, while showing no difference on full screen damage.

Also included is the refactor of the client's `util_mergeOverlappingRects` to the common `rects` library as `rectsMergeOverlapping`.