### PR TITLE
[client] egl: remove needless precision quantifiers

### DIFF
--- a/client/renderers/EGL/shader/color_blind.h
+++ b/client/renderers/EGL/shader/color_blind.h
@@ -1,9 +1,9 @@
-highp vec4 cbTransform(highp vec4 color, int cbMode)
+vec4 cbTransform(vec4 color, int cbMode)
 {
-  highp float L = (17.8824000 * color.r) + (43.516100 * color.g) + (4.11935 * color.b);
-  highp float M = (03.4556500 * color.r) + (27.155400 * color.g) + (3.86714 * color.b);
-  highp float S = (00.0299566 * color.r) + (00.184309 * color.g) + (1.46709 * color.b);
-  highp float l, m, s;
+  float L = (17.8824000 * color.r) + (43.516100 * color.g) + (4.11935 * color.b);
+  float M = (03.4556500 * color.r) + (27.155400 * color.g) + (3.86714 * color.b);
+  float S = (00.0299566 * color.r) + (00.184309 * color.g) + (1.46709 * color.b);
+  float l, m, s;
 
   if (cbMode == 1) // Protanope
   {
@@ -24,7 +24,7 @@ highp vec4 cbTransform(highp vec4 color, int cbMode)
     s = -0.395913 * L + 0.801109 * M + 0.0 * S;
   }
 
-  highp vec4 error;
+  vec4 error;
   error.r = ( 0.080944447900 * l) + (-0.13050440900 * m) + ( 0.116721066 * s);
   error.g = (-0.010248533500 * l) + ( 0.05401932660 * m) + (-0.113614708 * s);
   error.b = (-0.000365296938 * l) + (-0.00412161469 * m) + ( 0.693511405 * s);

--- a/client/renderers/EGL/shader/cursor.vert
+++ b/client/renderers/EGL/shader/cursor.vert
@@ -1,12 +1,13 @@
 #version 300 es
+precision mediump float;
 
 layout(location = 0) in vec3 vertexPosition_modelspace;
 layout(location = 1) in vec2 vertexUV;
 
 uniform vec4 mouse;
-uniform lowp int rotate;
+uniform int rotate;
 
-out highp vec2 uv;
+out vec2 uv;
 
 void main()
 {

--- a/client/renderers/EGL/shader/cursor_mono.frag
+++ b/client/renderers/EGL/shader/cursor_mono.frag
@@ -1,13 +1,14 @@
 #version 300 es
+precision mediump float;
 
-in  highp vec2 uv;
-out highp vec4 color;
+in  vec2 uv;
+out vec4 color;
 
 uniform sampler2D sampler1;
 
 void main()
 {
-  highp vec4 tmp = texture(sampler1, uv);
+  vec4 tmp = texture(sampler1, uv);
   if (tmp.rgb == vec3(0.0, 0.0, 0.0))
     discard;
   color = tmp;

--- a/client/renderers/EGL/shader/cursor_rgb.frag
+++ b/client/renderers/EGL/shader/cursor_rgb.frag
@@ -1,13 +1,13 @@
 #version 300 es
+precision mediump float;
 
 #include "color_blind.h"
 
-in  highp vec2 uv;
-out highp vec4 color;
+in  vec2 uv;
+out vec4 color;
 
 uniform sampler2D sampler1;
 
-uniform lowp int rotate;
 uniform int cbMode;
 
 void main()

--- a/client/renderers/EGL/shader/damage.frag
+++ b/client/renderers/EGL/shader/damage.frag
@@ -1,6 +1,7 @@
 #version 300 es
+precision mediump float;
 
-out highp vec4 color;
+out vec4 color;
 
 void main()
 {

--- a/client/renderers/EGL/shader/desktop.vert
+++ b/client/renderers/EGL/shader/desktop.vert
@@ -1,9 +1,10 @@
 #version 300 es
+precision mediump float;
 
 layout(location = 0) in vec2 vertex;
-out highp vec2 uv;
+out vec2 uv;
 
-uniform highp vec2 desktopSize;
+uniform vec2   desktopSize;
 uniform mat3x2 transform;
 
 void main()

--- a/client/renderers/EGL/shader/desktop_rgb.frag
+++ b/client/renderers/EGL/shader/desktop_rgb.frag
@@ -1,4 +1,5 @@
 #version 300 es
+precision mediump float;
 
 #define EGL_SCALE_AUTO    0
 #define EGL_SCALE_NEAREST 1
@@ -7,16 +8,16 @@
 
 #include "color_blind.h"
 
-in  highp vec2 uv;
-out highp vec4 color;
+in  vec2 uv;
+out vec4 color;
 
 uniform sampler2D sampler1;
 
-uniform       int   scaleAlgo;
-uniform highp ivec2 textureSize;
+uniform int   scaleAlgo;
+uniform ivec2 textureSize;
 
-uniform highp float nvGain;
-uniform       int   cbMode;
+uniform float nvGain;
+uniform int   cbMode;
 
 void main()
 {

--- a/client/renderers/EGL/shader/splash_bg.frag
+++ b/client/renderers/EGL/shader/splash_bg.frag
@@ -1,7 +1,8 @@
 #version 300 es
+precision mediump float;
 
-in  highp vec3  pos;
-out highp vec4  color;
+in  vec3  pos;
+out vec4  color;
 
 uniform sampler2D sampler1;
 

--- a/client/renderers/EGL/shader/splash_bg.vert
+++ b/client/renderers/EGL/shader/splash_bg.vert
@@ -1,8 +1,9 @@
 #version 300 es
+precision mediump float;
 
 layout(location = 0) in vec3 vertexPosition_modelspace;
 
-out highp vec3  pos;
+out vec3 pos;
 
 void main()
 {

--- a/client/renderers/EGL/shader/splash_logo.frag
+++ b/client/renderers/EGL/shader/splash_logo.frag
@@ -1,6 +1,7 @@
 #version 300 es
+precision mediump float;
 
-out highp vec4 color;
+out vec4 color;
 
 uniform sampler2D sampler1;
 


### PR DESCRIPTION
We simply use precision mediump float; for everything. We don't actually
need highp anyways, and we don't use it for stuff like CAS or FSR.