### PR TITLE
[client] egl: fix buffer overflow in desktop_rects module

### DIFF
--- a/client/renderers/EGL/desktop_rects.c
+++ b/client/renderers/EGL/desktop_rects.c
@@ -107,7 +107,7 @@ inline static void rectToVertices(GLfloat * vertex, const FrameDamageRect * rect
 void egl_desktopRectsUpdate(EGL_DesktopRects * rects, const struct DamageRects * data,
     int width, int height)
 {
-  GLfloat vertices[KVMFR_MAX_DAMAGE_RECTS * 8];
+  GLfloat vertices[(!data || data->count < 0 ? 1 : data->count) * 8];
   if (!data || data->count < 0)
   {
     FrameDamageRect full = {


### PR DESCRIPTION
The module has been changed to support variable amount of rectangles,
so we should just allocate a VLA.