### PR TITLE
[host] nvfbc: remove rectangles that are entirely contained in others

### DIFF
--- a/common/include/common/rects.h
+++ b/common/include/common/rects.h
@@ -47,5 +47,6 @@ void rectsFramebufferToBuffer(FrameDamageRect * rects, int count,
   const FrameBuffer * frame, int srcStride);
 
 int rectsMergeOverlapping(FrameDamageRect * rects, int count);
+int rectsRejectContained(FrameDamageRect * rects, int count);
 
 #endif

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -428,6 +428,8 @@ static void updateDamageRects(CaptureFrame * frame)
         };
       }
 
+  rectId = rectsRejectContained(frame->damageRects, rectId);
+
 done:
   frame->damageRectsCount = rectId;
 }


### PR DESCRIPTION
This makes nvfbc report less useless damage and makes the client run faster.