### PR TITLE
[host] windows/crash: do not report absolute paths on build machines

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -27,6 +27,10 @@ add_compile_options(
 )
 set(CMAKE_C_STANDARD  11)
 
+if(WIN32)
+  add_compile_options("-fdebug-prefix-map=${PROJECT_TOP}/=")
+endif()
+
 add_custom_command(
 	OUTPUT	${CMAKE_BINARY_DIR}/version.c
     ${CMAKE_BINARY_DIR}/include/version.h


### PR DESCRIPTION
This commit makes the crash handler show relative paths instead of absolute
ones, which makes the stack traces generated easier to read.

On the other hand, absolute paths makes sense on Linux, since the user is
expected to build the binaries themselves, and gdb will be able to find the
source code.

Example simulated stack trace before:

```
[E]   1549537856             crash.c:132  | exception_filter               | [trace]:  1: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:nvfbc_deinit+0x12 (\home\quantum\build\LookingGlass\host\platform\Windows\capture\NVFBC\src\nvfbc.c:293+0x0)
[E]   1549538725             crash.c:132  | exception_filter               | [trace]:  2: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:captureStop+0xcf (\home\quantum\build\LookingGlass\host\src\app.c:356+0xa)
[E]   1549539477             crash.c:132  | exception_filter               | [trace]:  3: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:app_main+0x165a (\home\quantum\build\LookingGlass\host\src\app.c:802+0x0)
[E]   1549540200             crash.c:132  | exception_filter               | [trace]:  4: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:appThread+0x30 (\home\quantum\build\LookingGlass\host\platform\Windows\src\platform.c:262+0x0)
[E]   1549541001             crash.c:132  | exception_filter               | [trace]:  5: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:threadWrapper+0xf (\home\quantum\build\LookingGlass\common\src\platform\windows\thread.c:41+0x0)
[E]   1549541792             crash.c:134  | exception_filter               | [trace]:  6: C:\WINDOWS\System32\KERNEL32.DLL:BaseThreadInitThunk+0x14
[E]   1549542261             crash.c:134  | exception_filter               | [trace]:  7: C:\WINDOWS\SYSTEM32\ntdll.dll:RtlUserThreadStart+0x21
```

Example simulated stack trace after:

```
[E]   1927632253             crash.c:132  | exception_filter               | [trace]:  1: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:nvfbc_deinit+0x12 (host\platform\Windows\capture\NVFBC\src\nvfbc.c:293+0x0)
[E]   1927632998             crash.c:132  | exception_filter               | [trace]:  2: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:captureStop+0xcf (host\src\app.c:356+0xa)
[E]   1927633628             crash.c:132  | exception_filter               | [trace]:  3: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:app_main+0x165a (host\src\app.c:802+0x0)
[E]   1927634233             crash.c:132  | exception_filter               | [trace]:  4: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:appThread+0x30 (host\platform\Windows\src\platform.c:262+0x0)
[E]   1927634909             crash.c:132  | exception_filter               | [trace]:  5: C:\Program Files\Looking Glass (host)\looking-glass-host.exe:threadWrapper+0xf (common\src\platform\windows\thread.c:41+0x0)
[E]   1927635588             crash.c:134  | exception_filter               | [trace]:  6: C:\WINDOWS\System32\KERNEL32.DLL:BaseThreadInitThunk+0x14
[E]   1927636043             crash.c:134  | exception_filter               | [trace]:  7: C:\WINDOWS\SYSTEM32\ntdll.dll:RtlUserThreadStart+0x21
```