### PR TITLE
[common] array: add ALIGN_PAD macro for common logic

### DIFF
--- a/common/include/common/array.h
+++ b/common/include/common/array.h
@@ -22,5 +22,6 @@
 #define _LG_ARRAY_H_
 
 #define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof(*(arr)))
+#define ALIGN_PAD(value, align) (((value) + (align) - 1) & -(align))
 
 #endif

--- a/common/src/platform/linux/ivshmem.c
+++ b/common/src/platform/linux/ivshmem.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <errno.h>
 
+#include "common/array.h"
 #include "common/debug.h"
 #include "common/option.h"
 #include "common/sysinfo.h"
@@ -232,7 +233,7 @@ int ivshmemGetDMABuf(struct IVSHMEM * dev, uint64_t offset, uint64_t size)
     (struct IVSHMEMInfo *)dev->opaque;
 
   // align to the page size
-  size = (size + pageSize - 1) & -pageSize;
+  size = ALIGN_PAD(size, pageSize);
 
   const struct kvmfr_dmabuf_create create =
   {

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -23,6 +23,7 @@
 #include "common/windebug.h"
 #include "windows/mousehook.h"
 #include "windows/force_compose.h"
+#include "common/array.h"
 #include "common/option.h"
 #include "common/framebuffer.h"
 #include "common/event.h"
@@ -449,7 +450,7 @@ static CaptureResult nvfbc_waitFrame(CaptureFrame * frame,
     this->grabHeight = this->grabInfo.dwHeight;
     this->grabStride = this->grabInfo.dwBufferWidth;
     // Round up stride in IVSHMEM to avoid issues with dmabuf import.
-    this->shmStride  = (this->grabStride + 0x1F) & ~0x1F;
+    this->shmStride  = ALIGN_PAD(this->grabStride, 32);
     ++this->formatVer;
   }
 


### PR DESCRIPTION
`ALIGN_PAD(x, a)` returns `x` rounded up to the nearest multiple of `a`.