### PR TITLE
[common] debug: add DEBUG_ASSERT and DEBUG_UNREACHABLE macros

### DIFF
--- a/client/displayservers/Wayland/clipboard.c
+++ b/client/displayservers/Wayland/clipboard.c
@@ -20,7 +20,6 @@
 
 #include "wayland.h"
 
-#include <assert.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -299,7 +298,7 @@ static void dataDeviceHandleEnter(void * data, struct wl_data_device * device,
     uint32_t serial, struct wl_surface * surface, wl_fixed_t sxW, wl_fixed_t syW,
     struct wl_data_offer * offer)
 {
-  assert(wlCb.dndOffer == NULL);
+  DEBUG_ASSERT(wlCb.dndOffer == NULL);
   wlCb.dndOffer = offer;
 
   struct DataOffer * extra = wl_data_offer_get_user_data(offer);

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include <EGL/egl.h>
 #include "common/types.h"
+#include "common/debug.h"
 
 typedef enum LG_ClipboardData
 {
@@ -210,50 +211,50 @@ struct LG_DisplayServerOps
 };
 
 #ifdef ENABLE_EGL
-  #define ASSERT_EGL_FN(x) assert(x);
+  #define ASSERT_EGL_FN(x) DEBUG_ASSERT(x)
 #else
   #define ASSERT_EGL_FN(x)
 #endif
 
 #ifdef ENABLE_OPENGL
-  #define ASSERT_OPENGL_FN(x) assert(x)
+  #define ASSERT_OPENGL_FN(x) DEBUG_ASSERT(x)
 #else
   #define ASSERT_OPENGL_FN(x)
 #endif
 
 #define ASSERT_LG_DS_VALID(x) \
-  assert((x)->setup              ); \
-  assert((x)->probe              ); \
-  assert((x)->earlyInit          ); \
-  assert((x)->init               ); \
-  assert((x)->startup            ); \
-  assert((x)->shutdown           ); \
-  assert((x)->free               ); \
-  assert((x)->getProp            ); \
-  ASSERT_EGL_FN((x)->getEGLDisplay      ); \
-  ASSERT_EGL_FN((x)->getEGLNativeWindow ); \
-  ASSERT_EGL_FN((x)->eglSwapBuffers     ); \
+  DEBUG_ASSERT((x)->setup    ); \
+  DEBUG_ASSERT((x)->probe    ); \
+  DEBUG_ASSERT((x)->earlyInit); \
+  DEBUG_ASSERT((x)->init     ); \
+  DEBUG_ASSERT((x)->startup  ); \
+  DEBUG_ASSERT((x)->shutdown ); \
+  DEBUG_ASSERT((x)->free     ); \
+  DEBUG_ASSERT((x)->getProp  ); \
+  ASSERT_EGL_FN((x)->getEGLDisplay     ); \
+  ASSERT_EGL_FN((x)->getEGLNativeWindow); \
+  ASSERT_EGL_FN((x)->eglSwapBuffers    ); \
   ASSERT_OPENGL_FN((x)->glCreateContext  ); \
   ASSERT_OPENGL_FN((x)->glDeleteContext  ); \
   ASSERT_OPENGL_FN((x)->glMakeCurrent    ); \
   ASSERT_OPENGL_FN((x)->glSetSwapInterval); \
   ASSERT_OPENGL_FN((x)->glSwapBuffers    ); \
-  assert(!(x)->waitFrame == !(x)->stopWaitFrame); \
-  assert((x)->guestPointerUpdated); \
-  assert((x)->setPointer         ); \
-  assert((x)->grabPointer        ); \
-  assert((x)->ungrabPointer      ); \
-  assert((x)->capturePointer     ); \
-  assert((x)->uncapturePointer   ); \
-  assert((x)->warpPointer        ); \
-  assert((x)->realignPointer     ); \
-  assert((x)->isValidPointerPos  ); \
-  assert((x)->inhibitIdle        ); \
-  assert((x)->uninhibitIdle      ); \
-  assert((x)->wait               ); \
-  assert((x)->setWindowSize      ); \
-  assert((x)->setFullscreen      ); \
-  assert((x)->getFullscreen      ); \
-  assert((x)->minimize           );
+  DEBUG_ASSERT(!(x)->waitFrame == !(x)->stopWaitFrame); \
+  DEBUG_ASSERT((x)->guestPointerUpdated); \
+  DEBUG_ASSERT((x)->setPointer         ); \
+  DEBUG_ASSERT((x)->grabPointer        ); \
+  DEBUG_ASSERT((x)->ungrabPointer      ); \
+  DEBUG_ASSERT((x)->capturePointer     ); \
+  DEBUG_ASSERT((x)->uncapturePointer   ); \
+  DEBUG_ASSERT((x)->warpPointer        ); \
+  DEBUG_ASSERT((x)->realignPointer     ); \
+  DEBUG_ASSERT((x)->isValidPointerPos  ); \
+  DEBUG_ASSERT((x)->inhibitIdle        ); \
+  DEBUG_ASSERT((x)->uninhibitIdle      ); \
+  DEBUG_ASSERT((x)->wait               ); \
+  DEBUG_ASSERT((x)->setWindowSize      ); \
+  DEBUG_ASSERT((x)->setFullscreen      ); \
+  DEBUG_ASSERT((x)->getFullscreen      ); \
+  DEBUG_ASSERT((x)->minimize           );
 
 #endif

--- a/client/include/interface/overlay.h
+++ b/client/include/interface/overlay.h
@@ -22,7 +22,6 @@
 #define _H_I_OVERLAY_
 
 #include <stdbool.h>
-#include <assert.h>
 
 #include "common/types.h"
 
@@ -64,9 +63,9 @@ struct LG_OverlayOps
 };
 
 #define ASSERT_LG_OVERLAY_VALID(x) \
-  assert((x)->name          ); \
-  assert((x)->init          ); \
-  assert((x)->free          ); \
-  assert((x)->render        );
+  DEBUG_ASSERT((x)->name  ); \
+  DEBUG_ASSERT((x)->init  ); \
+  DEBUG_ASSERT((x)->free  ); \
+  DEBUG_ASSERT((x)->render);
 
 #endif

--- a/client/renderers/EGL/cursor.c
+++ b/client/renderers/EGL/cursor.c
@@ -330,7 +330,7 @@ struct CursorState egl_cursorRender(EGL_Cursor * cursor,
       break;
 
     default:
-      assert(!"unreachable");
+      DEBUG_UNREACHABLE();
   }
 
   state.rect.x = max(0, state.rect.x);

--- a/client/renderers/EGL/desktop_rects.c
+++ b/client/renderers/EGL/desktop_rects.c
@@ -119,7 +119,7 @@ void egl_desktopRectsUpdate(EGL_DesktopRects * rects, const struct DamageRects *
   else
   {
     rects->count = data->count;
-    assert(rects->count <= rects->maxCount);
+    DEBUG_ASSERT(rects->count <= rects->maxCount);
 
     for (int i = 0; i < rects->count; ++i)
       rectToVertices(vertices + i * 8, data->rects + i);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -303,7 +303,7 @@ static void egl_calc_mouse_size(struct Inst * this)
   if (!this->formatValid)
     return;
 
-  int w  = 0, h = 0;
+  int w, h;
 
   switch(this->format.rotate)
   {

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -36,7 +36,6 @@
 #include "cimgui.h"
 #include "generator/output/cimgui_impl.h"
 
-#include <assert.h>
 #include <math.h>
 #include <string.h>
 
@@ -325,7 +324,7 @@ static void egl_calc_mouse_size(struct Inst * this)
       break;
 
     default:
-      assert(!"unreachable");
+      DEBUG_UNREACHABLE();
   }
 
   switch((this->format.rotate + this->rotate) % LG_ROTATE_MAX)

--- a/client/renderers/EGL/model.c
+++ b/client/renderers/EGL/model.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 
 struct EGL_Model
 {

--- a/client/renderers/EGL/texture.c
+++ b/client/renderers/EGL/texture.c
@@ -21,7 +21,6 @@
 #include "texture.h"
 
 #include <stdbool.h>
-#include <assert.h>
 #include <string.h>
 #include "shader.h"
 #include "common/framebuffer.h"
@@ -66,12 +65,12 @@ bool egl_textureInit(EGL_Texture ** texture_, EGLDisplay * display,
       break;
 
     case EGL_TEXTYPE_FRAMEBUFFER:
-      assert(streaming);
+      DEBUG_ASSERT(streaming);
       ops = &EGL_TextureFrameBuffer;
       break;
 
     case EGL_TEXTYPE_DMABUF:
-      assert(streaming);
+      DEBUG_ASSERT(streaming);
       ops = &EGL_TextureDMABUF;
       break;
 

--- a/client/renderers/EGL/texture_buffer.c
+++ b/client/renderers/EGL/texture_buffer.c
@@ -23,7 +23,6 @@
 #include "egldebug.h"
 
 #include <string.h>
-#include <assert.h>
 
 // forwards
 extern const EGL_TextureOps EGL_TextureBuffer;
@@ -109,7 +108,7 @@ bool egl_texBufferSetup(EGL_Texture * texture, const EGL_TexSetup * setup)
 static bool egl_texBufferUpdate(EGL_Texture * texture, const EGL_TexUpdate * update)
 {
   TextureBuffer * this = UPCAST(TextureBuffer, texture);
-  assert(update->type == EGL_TEXTYPE_BUFFER);
+  DEBUG_ASSERT(update->type == EGL_TEXTYPE_BUFFER);
 
   glBindTexture(GL_TEXTURE_2D, this->tex[0]);
   glPixelStorei(GL_UNPACK_ROW_LENGTH, texture->format.pitch);
@@ -164,7 +163,7 @@ static bool egl_texBufferStreamUpdate(EGL_Texture * texture,
     const EGL_TexUpdate * update)
 {
   TextureBuffer * this = UPCAST(TextureBuffer, texture);
-  assert(update->type == EGL_TEXTYPE_BUFFER);
+  DEBUG_ASSERT(update->type == EGL_TEXTYPE_BUFFER);
 
   LG_LOCK(this->copyLock);
   memcpy(this->buf[this->bufIndex].map, update->buffer,

--- a/client/renderers/EGL/texture_dmabuf.c
+++ b/client/renderers/EGL/texture_dmabuf.c
@@ -21,8 +21,6 @@
 #include "texture.h"
 #include "texture_buffer.h"
 
-#include <assert.h>
-
 #include "egl_dynprocs.h"
 #include "egldebug.h"
 
@@ -101,7 +99,8 @@ static bool egl_texDMABUFUpdate(EGL_Texture * texture,
 {
   TextureBuffer * parent = UPCAST(TextureBuffer, texture);
   TexDMABUF     * this   = UPCAST(TexDMABUF    , parent);
-  assert(update->type == EGL_TEXTYPE_DMABUF);
+
+  DEBUG_ASSERT(update->type == EGL_TEXTYPE_DMABUF);
 
   EGLImage image = EGL_NO_IMAGE;
 

--- a/client/renderers/EGL/texture_framebuffer.c
+++ b/client/renderers/EGL/texture_framebuffer.c
@@ -20,8 +20,6 @@
 
 #include "texture.h"
 
-#include <assert.h>
-
 #include "texture_buffer.h"
 #include "common/debug.h"
 #include "common/KVMFR.h"
@@ -84,7 +82,7 @@ static bool egl_texFBUpdate(EGL_Texture * texture, const EGL_TexUpdate * update)
   TextureBuffer * parent = UPCAST(TextureBuffer, texture);
   TexFB         * this   = UPCAST(TexFB        , parent );
 
-  assert(update->type == EGL_TEXTYPE_FRAMEBUFFER);
+  DEBUG_ASSERT(update->type == EGL_TEXTYPE_FRAMEBUFFER);
 
   LG_LOCK(parent->copyLock);
 

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -804,7 +804,7 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
 
     // It is an error to run out of rectangles, because we will not be able to
     // correctly calculate the damage of the next frame.
-    assert(written >= 0);
+    DEBUG_ASSERT(written >= 0);
 
     const int toAdd = max(written, overlay->lastRectCount);
     totalDamage |= toAdd > maxRects;

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -166,8 +166,8 @@ void core_updatePositionInfo(void)
   if (!g_state.haveSrcSize)
     goto done;
 
-  float srcW = 0.0f;
-  float srcH = 0.0f;
+  float srcW;
+  float srcH;
 
   switch(g_params.winRotate)
   {

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -27,7 +27,6 @@
 #include "common/debug.h"
 #include "common/array.h"
 
-#include <assert.h>
 #include <math.h>
 
 #define RESIZE_TIMEOUT (10 * 1000) // 10ms
@@ -185,7 +184,7 @@ void core_updatePositionInfo(void)
       break;
 
     default:
-      assert(!"unreachable");
+      DEBUG_UNREACHABLE();
   }
 
   if (g_params.keepAspect)

--- a/client/src/ll.c
+++ b/client/src/ll.c
@@ -20,9 +20,9 @@
 
 #include "ll.h"
 
+#include "common/debug.h"
 #include "common/locking.h"
 #include <stdlib.h>
-#include <assert.h>
 
 struct ll_item
 {
@@ -53,7 +53,7 @@ struct ll * ll_new(void)
 void ll_free(struct ll * list)
 {
   // never free a list with items in it!
-  assert(!list->head);
+  DEBUG_ASSERT(!list->head);
 
   LG_LOCK_FREE(list->lock);
   free(list);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -33,7 +33,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <assert.h>
 #include <math.h>
 #include <stdatomic.h>
 #include <linux/input.h>
@@ -854,7 +853,7 @@ static int lg_run(void)
       break;
     }
 
-  assert(g_state.ds);
+  DEBUG_ASSERT(g_state.ds);
   ASSERT_LG_DS_VALID(g_state.ds);
 
   if (g_params.jitRender)

--- a/client/src/util.c
+++ b/client/src/util.c
@@ -27,7 +27,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <math.h>
 #include <fontconfig/fontconfig.h>
 
@@ -182,7 +181,7 @@ void util_localCurToGuest(struct DoublePoint *guest)
       break;
 
     default:
-      assert(!"unreachable");
+      DEBUG_UNREACHABLE();
   }
 }
 

--- a/common/include/common/debug.h
+++ b/common/include/common/debug.h
@@ -57,6 +57,14 @@ void printBacktrace(void);
   #define DIRECTORY_SEPARATOR '/'
 #endif
 
+#ifdef __GNUC__
+  #define DEBUG_UNREACHABLE_MARKER() __builtin_unreachable()
+#elif __defined__(_MSC_VER)
+  #define DEBUG_UNREACHABLE_MARKER() __assume(0)
+#else
+  #define DEBUG_UNREACHABLE_MARKER()
+#endif
+
 #define STRIPPATH(s) ( \
   sizeof(s) >  2 && (s)[sizeof(s)- 3] == DIRECTORY_SEPARATOR ? (s) + sizeof(s) -  2 : \
   sizeof(s) >  3 && (s)[sizeof(s)- 4] == DIRECTORY_SEPARATOR ? (s) + sizeof(s) -  3 : \
@@ -95,6 +103,7 @@ void printBacktrace(void);
   DEBUG_PRINT(DEBUG_LEVEL_FATAL, fmt, ##__VA_ARGS__); \
   DEBUG_PRINT_BACKTRACE(); \
   abort(); \
+  DEBUG_UNREACHABLE_MARKER(); \
 } while(0)
 
 #define DEBUG_ASSERT_PRINT(...) DEBUG_ERROR("Assertion failed: %s", #__VA_ARGS__)
@@ -113,6 +122,8 @@ void printBacktrace(void);
     } \
   } while (0)
 #endif
+
+#define DEBUG_UNREACHABLE() DEBUG_FATAL("Unreachable code reached")
 
 #if defined(DEBUG_SPICE) | defined(DEBUG_IVSHMEM)
   #define DEBUG_PROTO(fmt, args...) DEBUG_PRINT("[P]", fmt, ##args)

--- a/common/include/common/debug.h
+++ b/common/include/common/debug.h
@@ -97,6 +97,23 @@ void printBacktrace(void);
   abort(); \
 } while(0)
 
+#define DEBUG_ASSERT_PRINT(...) DEBUG_ERROR("Assertion failed: %s", #__VA_ARGS__)
+
+#ifdef NDEBUG
+  #define DEBUG_ASSERT(...) do { \
+    if (!(__VA_ARGS__)) \
+      DEBUG_ASSERT_PRINT(__VA_ARGS__); \
+  } while (0)
+#else
+  #define DEBUG_ASSERT(...) do { \
+    if (!(__VA_ARGS__)) \
+    { \
+      DEBUG_ASSERT_PRINT(__VA_ARGS__); \
+      abort(); \
+    } \
+  } while (0)
+#endif
+
 #if defined(DEBUG_SPICE) | defined(DEBUG_IVSHMEM)
   #define DEBUG_PROTO(fmt, args...) DEBUG_PRINT("[P]", fmt, ##args)
 #else

--- a/common/src/option.c
+++ b/common/src/option.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 struct OptionGroup
 {
@@ -687,7 +686,7 @@ void option_print(void)
       "Value"
     );
 
-    assert(maxLen > 0);
+    DEBUG_ASSERT(maxLen > 0);
     headerLine = line;
     stringlist_push(lines, line);
 
@@ -709,7 +708,7 @@ void option_print(void)
         o->description
       );
 
-      assert(len > 0);
+      DEBUG_ASSERT(len > 0);
       stringlist_push(lines, line);
       if (len > maxLen)
         maxLen = len;
@@ -765,7 +764,7 @@ int option_get_int(const char * module, const char * name)
     DEBUG_ERROR("BUG: Failed to get the value for option %s:%s", module, name);
     return -1;
   }
-  assert(o->type == OPTION_TYPE_INT);
+  DEBUG_ASSERT(o->type == OPTION_TYPE_INT);
   return o->value.x_int;
 }
 
@@ -777,7 +776,7 @@ const char * option_get_string(const char * module, const char * name)
     DEBUG_ERROR("BUG: Failed to get the value for option %s:%s", module, name);
     return NULL;
   }
-  assert(o->type == OPTION_TYPE_STRING);
+  DEBUG_ASSERT(o->type == OPTION_TYPE_STRING);
   return o->value.x_string;
 }
 
@@ -789,7 +788,7 @@ bool option_get_bool(const char * module, const char * name)
     DEBUG_ERROR("BUG: Failed to get the value for option %s:%s", module, name);
     return false;
   }
-  assert(o->type == OPTION_TYPE_BOOL);
+  DEBUG_ASSERT(o->type == OPTION_TYPE_BOOL);
   return o->value.x_bool;
 }
 
@@ -801,6 +800,6 @@ float option_get_float(const char * module, const char * name)
     DEBUG_ERROR("BUG: Failed to get the value for option %s:%s", module, name);
     return false;
   }
-  assert(o->type == OPTION_TYPE_FLOAT);
+  DEBUG_ASSERT(o->type == OPTION_TYPE_FLOAT);
   return o->value.x_float;
 }

--- a/common/src/platform/linux/event.c
+++ b/common/src/platform/linux/event.c
@@ -24,7 +24,6 @@
 
 #include <stdlib.h>
 #include <pthread.h>
-#include <assert.h>
 #include <errno.h>
 #include <stdatomic.h>
 #include <stdint.h>
@@ -78,7 +77,7 @@ LGEvent * lgCreateEvent(bool autoReset, unsigned int msSpinTime)
 
 void lgFreeEvent(LGEvent * handle)
 {
-  assert(handle);
+  DEBUG_ASSERT(handle);
 
   if (atomic_load_explicit(&handle->waiting, memory_order_acquire) != 0)
     DEBUG_ERROR("BUG: Freeing an event that still has threads waiting on it");
@@ -90,7 +89,7 @@ void lgFreeEvent(LGEvent * handle)
 
 bool lgWaitEventAbs(LGEvent * handle, struct timespec * ts)
 {
-  assert(handle);
+  DEBUG_ASSERT(handle);
 
   bool ret   = true;
   int  res;
@@ -173,7 +172,7 @@ bool lgWaitEvent(LGEvent * handle, unsigned int timeout)
 
 bool lgSignalEvent(LGEvent * handle)
 {
-  assert(handle);
+  DEBUG_ASSERT(handle);
 
   if (pthread_mutex_lock(&handle->mutex) != 0)
   {
@@ -202,6 +201,6 @@ bool lgSignalEvent(LGEvent * handle)
 
 bool lgResetEvent(LGEvent * handle)
 {
-  assert(handle);
+  DEBUG_ASSERT(handle);
   return atomic_exchange_explicit(&handle->signaled, false, memory_order_release);
 }

--- a/common/src/platform/linux/ivshmem.c
+++ b/common/src/platform/linux/ivshmem.c
@@ -20,7 +20,6 @@
 
 #include "common/ivshmem.h"
 
-#include <assert.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -118,7 +117,7 @@ bool ivshmemOpen(struct IVSHMEM * dev)
 
 bool ivshmemOpenDev(struct IVSHMEM * dev, const char * shmDevice)
 {
-  assert(dev);
+  DEBUG_ASSERT(dev);
 
   unsigned int devSize;
   int devFd = -1;
@@ -186,7 +185,7 @@ bool ivshmemOpenDev(struct IVSHMEM * dev, const char * shmDevice)
 
 void ivshmemClose(struct IVSHMEM * dev)
 {
-  assert(dev);
+  DEBUG_ASSERT(dev);
 
   if (!dev->opaque)
     return;
@@ -210,7 +209,7 @@ void ivshmemFree(struct IVSHMEM * dev)
 
 bool ivshmemHasDMA(struct IVSHMEM * dev)
 {
-  assert(dev && dev->opaque);
+  DEBUG_ASSERT(dev && dev->opaque);
 
   struct IVSHMEMInfo * info =
     (struct IVSHMEMInfo *)dev->opaque;
@@ -220,9 +219,9 @@ bool ivshmemHasDMA(struct IVSHMEM * dev)
 
 int ivshmemGetDMABuf(struct IVSHMEM * dev, uint64_t offset, uint64_t size)
 {
-  assert(ivshmemHasDMA(dev));
-  assert(dev && dev->opaque);
-  assert(offset + size <= dev->size);
+  DEBUG_ASSERT(ivshmemHasDMA(dev));
+  DEBUG_ASSERT(dev && dev->opaque);
+  DEBUG_ASSERT(offset + size <= dev->size);
 
   static long pageSize = 0;
 

--- a/common/src/platform/windows/ivshmem.c
+++ b/common/src/platform/windows/ivshmem.c
@@ -25,7 +25,6 @@
 #include <windows.h>
 #include "ivshmem.h"
 
-#include <assert.h>
 #include <setupapi.h>
 #include <io.h>
 
@@ -72,7 +71,7 @@ static int ivshmemComparator(const void * a_, const void * b_)
 
 bool ivshmemInit(struct IVSHMEM * dev)
 {
-  assert(dev && !dev->opaque);
+  DEBUG_ASSERT(dev && !dev->opaque);
 
   HANDLE                           handle;
   HDEVINFO                         devInfoSet;
@@ -195,7 +194,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
 
 bool ivshmemOpen(struct IVSHMEM * dev)
 {
-  assert(dev && dev->opaque && !dev->mem);
+  DEBUG_ASSERT(dev && dev->opaque && !dev->mem);
 
   struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)dev->opaque;
 
@@ -226,7 +225,7 @@ bool ivshmemOpen(struct IVSHMEM * dev)
 
 void ivshmemClose(struct IVSHMEM * dev)
 {
-  assert(dev && dev->opaque && dev->mem);
+  DEBUG_ASSERT(dev && dev->opaque && dev->mem);
 
   struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)dev->opaque;
 
@@ -239,7 +238,7 @@ void ivshmemClose(struct IVSHMEM * dev)
 
 void ivshmemFree(struct IVSHMEM * dev)
 {
-  assert(dev && dev->opaque && !dev->mem);
+  DEBUG_ASSERT(dev && dev->opaque && !dev->mem);
 
   struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)dev->opaque;
 

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -23,7 +23,6 @@
 #include "common/debug.h"
 #include "common/event.h"
 #include <string.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <xcb/shm.h>
@@ -64,7 +63,7 @@ static const char * xcb_getName(void)
 
 static bool xcb_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
-  assert(!this);
+  DEBUG_ASSERT(!this);
   this             = (struct xcb *)calloc(sizeof(struct xcb), 1);
   this->shmID      = -1;
   this->data       = (void *)-1;
@@ -82,8 +81,8 @@ static bool xcb_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPo
 
 static bool xcb_init(void)
 {
-  assert(this);
-  assert(!this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(!this->initialized);
 
   lgResetEvent(this->frameEvent);
 
@@ -134,7 +133,7 @@ fail:
 
 static bool xcb_deinit(void)
 {
-  assert(this);
+  DEBUG_ASSERT(this);
 
   if ((uintptr_t)this->data != -1)
   {
@@ -167,8 +166,8 @@ static void xcb_free(void)
 
 static CaptureResult xcb_capture(void)
 {
-  assert(this);
-  assert(this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(this->initialized);
 
   if (!this->hasFrame)
   {
@@ -211,8 +210,8 @@ static CaptureResult xcb_waitFrame(CaptureFrame * frame,
 static CaptureResult xcb_getFrame(FrameBuffer * frame,
     const unsigned int height, int frameIndex)
 {
-  assert(this);
-  assert(this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(this->initialized);
 
   xcb_shm_get_image_reply_t * img;
   img = xcb_shm_get_image_reply(this->xcb, this->imgC, NULL);

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -30,7 +30,6 @@
 #include "common/runningavg.h"
 #include "common/KVMFR.h"
 
-#include <assert.h>
 #include <stdatomic.h>
 #include <unistd.h>
 #include <dxgi.h>
@@ -170,7 +169,7 @@ static void dxgi_initOptions(void)
 
 static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
-  assert(!this);
+  DEBUG_ASSERT(!this);
   this = calloc(sizeof(struct iface), 1);
   if (!this)
   {
@@ -200,7 +199,7 @@ static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostP
 
 static bool dxgi_init(void)
 {
-  assert(this);
+  DEBUG_ASSERT(this);
 
   this->desktop = OpenInputDesktop(0, FALSE, GENERIC_READ);
   if (!this->desktop)
@@ -601,7 +600,7 @@ static void dxgi_stop(void)
 
 static bool dxgi_deinit(void)
 {
-  assert(this);
+  DEBUG_ASSERT(this);
 
   for (int i = 0; i < this->maxTextures; ++i)
   {
@@ -677,7 +676,7 @@ static bool dxgi_deinit(void)
 
 static void dxgi_free(void)
 {
-  assert(this);
+  DEBUG_ASSERT(this);
 
   if (this->initialized)
     dxgi_deinit();
@@ -785,8 +784,8 @@ static void computeFrameDamage(Texture * tex)
 
 static CaptureResult dxgi_capture(void)
 {
-  assert(this);
-  assert(this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(this->initialized);
 
   Texture                 * tex = NULL;
   CaptureResult             result;
@@ -1008,8 +1007,8 @@ static CaptureResult dxgi_capture(void)
 
 static CaptureResult dxgi_waitFrame(CaptureFrame * frame, const size_t maxFrameSize)
 {
-  assert(this);
-  assert(this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(this->initialized);
 
   // NOTE: the event may be signaled when there are no frames available
   if (atomic_load_explicit(&this->texReady, memory_order_acquire) == 0)
@@ -1080,8 +1079,8 @@ static CaptureResult dxgi_waitFrame(CaptureFrame * frame, const size_t maxFrameS
 static CaptureResult dxgi_getFrame(FrameBuffer * frame,
     const unsigned int height, int frameIndex)
 {
-  assert(this);
-  assert(this->initialized);
+  DEBUG_ASSERT(this);
+  DEBUG_ASSERT(this->initialized);
 
   Texture * tex = &this->texture[this->texRIndex];
 
@@ -1127,7 +1126,7 @@ static CaptureResult dxgi_getFrame(FrameBuffer * frame,
 
 static CaptureResult dxgi_releaseFrame(void)
 {
-  assert(this);
+  DEBUG_ASSERT(this);
   if (!this->needsRelease)
     return CAPTURE_RESULT_OK;
 

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -30,7 +30,6 @@
 #include "common/rects.h"
 #include "common/thread.h"
 #include "common/KVMFR.h"
-#include <assert.h>
 #include <stdlib.h>
 #include <stdatomic.h>
 #include <windows.h>


### PR DESCRIPTION
`DEBUG_ASSERT`, unlike the standard `assert` macro, is guaranteed to print the failed assertion to our log file, and tests the assertion even with `NDEBUG` defined so we can more easily catch failures in production binaries without crashing the program. Everywhere `assert` is used, we replace it with `DEBUG_ASSERT`.

The motivation of this is how MinGW handles assertion failures: it creates a dialog window that the headless user will not be able to see, and blocks the program from being restarted by the service. Since the failed assertion is displayed in the dialog, it doesn't print anything to the log, making it impossible to diagnose issues.

`DEBUG_UNREACHABLE` macro lets us mark code as unreachable and signals the compiler that this is the case with `__builtin_unreachable()`. We use this to replace all places where `assert` is used to signal that the code is unreachable. Due to the way `assert` is defined in standard C, compilers in release mode will not treat it as unreachable. This explains a lot about those pesky uninitialized variable bugs, and I reverted the workarounds.

As a bonus, we also mark `DEBUG_FATAL` as unreachable since it aborts.