### PR TITLE
[client] egl: implement linear and lanczos downscale filter

### DIFF
--- a/client/renderers/EGL/CMakeLists.txt
+++ b/client/renderers/EGL/CMakeLists.txt
@@ -65,6 +65,7 @@ build_shaders(
 	shader/ffx_fsr1_rcas.frag
 	shader/downscale.frag
 	shader/downscale_lanczos2.frag
+	shader/downscale_linear.frag
 )
 
 make_defines(

--- a/client/renderers/EGL/CMakeLists.txt
+++ b/client/renderers/EGL/CMakeLists.txt
@@ -64,6 +64,7 @@ build_shaders(
 	shader/ffx_fsr1_easu.frag
 	shader/ffx_fsr1_rcas.frag
 	shader/downscale.frag
+	shader/downscale_lanczos2.frag
 )
 
 make_defines(

--- a/client/renderers/EGL/shader/downscale_lanczos2.frag
+++ b/client/renderers/EGL/shader/downscale_lanczos2.frag
@@ -1,0 +1,67 @@
+#version 300 es
+precision mediump float;
+
+#define PI 3.141592653589793
+
+in  vec2  fragCoord;
+out vec4  fragColor;
+
+uniform sampler2D texture;
+float sinc(float x)
+{
+  return x == 0.0 ? 1.0 : sin(x * PI) / (x * PI);
+}
+
+float lanczos(float x)
+{
+  return sinc(x) * sinc(x * 0.5);
+}
+
+float lanczos(vec2 v)
+{
+  return lanczos(v.x) * lanczos(v.y);
+}
+
+void main()
+{
+  vec2 size = vec2(textureSize(texture, 0));
+  vec2 pos = fragCoord * size;
+  vec2 invSize = 1.0 / size;
+  vec2 uvc = floor(pos) + vec2(0.5, 0.5);
+
+  vec2 uvs[16] = vec2[](
+    uvc + vec2(-1.0, -1.0),
+    uvc + vec2(-1.0,  0.0),
+    uvc + vec2(-1.0,  1.0),
+    uvc + vec2(-1.0,  2.0),
+    uvc + vec2( 0.0, -1.0),
+    uvc + vec2( 0.0,  0.0),
+    uvc + vec2( 0.0,  1.0),
+    uvc + vec2( 0.0,  2.0),
+    uvc + vec2( 1.0, -1.0),
+    uvc + vec2( 1.0,  0.0),
+    uvc + vec2( 1.0,  1.0),
+    uvc + vec2( 1.0,  2.0),
+    uvc + vec2( 2.0, -1.0),
+    uvc + vec2( 2.0,  0.0),
+    uvc + vec2( 2.0,  1.0),
+    uvc + vec2( 2.0,  2.0)
+  );
+
+  float factors[16];
+  float sum = 0.0;
+  for (int i = 0; i < 16; ++i)
+  {
+    factors[i] = lanczos(uvs[i] - fragCoord * size);
+    sum += factors[i];
+  }
+
+  for (int i = 0; i < 16; ++i)
+    factors[i] /= sum;
+
+  vec3 color = vec3(0.0);
+  for (int i = 0; i < 16; ++i)
+    color += texture2D(texture, uvs[i] * invSize).rgb * factors[i];
+
+  fragColor = vec4(color, 1.0);
+}

--- a/client/renderers/EGL/shader/downscale_linear.frag
+++ b/client/renderers/EGL/shader/downscale_linear.frag
@@ -1,0 +1,12 @@
+#version 300 es
+precision mediump float;
+
+in  vec2  fragCoord;
+out vec4  fragColor;
+
+uniform sampler2D texture;
+
+void main()
+{
+  fragColor = texture2D(texture, fragCoord);
+}


### PR DESCRIPTION
This pull request adds two new downscaling filters: a bilinear filter and a lanczos filter with window = 2. It also adds UI to switch between the filters.

Note that I am not exactly sure if my lanczos implementation is correct.