### PR TITLE
[client] spice: synchronize keyboard LED state

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -274,6 +274,12 @@ static void keyboardModifiersHandler(void * data,
     xkb_state_mod_name_is_active(wlWm.xkbState, XKB_MOD_NAME_ALT, XKB_STATE_MODS_EFFECTIVE) > 0,
     xkb_state_mod_name_is_active(wlWm.xkbState, XKB_MOD_NAME_LOGO, XKB_STATE_MODS_EFFECTIVE) > 0
   );
+
+  app_handleKeyboardLEDs(
+    xkb_state_led_name_is_active(wlWm.xkbState, XKB_LED_NAME_NUM) > 0,
+    xkb_state_led_name_is_active(wlWm.xkbState, XKB_LED_NAME_CAPS) > 0,
+    xkb_state_led_name_is_active(wlWm.xkbState, XKB_LED_NAME_SCROLL) > 0
+  );
 }
 
 static const struct wl_keyboard_listener keyboardListener = {

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -62,6 +62,7 @@ void app_handleKeyPress(int scancode);
 void app_handleKeyRelease(int scancode);
 void app_handleKeyboardTyped(const char * typed);
 void app_handleKeyboardModifiers(bool ctrl, bool shift, bool alt, bool super);
+void app_handleKeyboardLEDs(bool numLock, bool capsLock, bool scrollLock);
 void app_handleEnterEvent(bool entered);
 void app_handleFocusEvent(bool focused);
 void app_handleCloseEvent(void);

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -412,6 +412,17 @@ void app_handleKeyboardModifiers(bool ctrl, bool shift, bool alt, bool super)
   g_state.io->KeySuper = super;
 }
 
+void app_handleKeyboardLEDs(bool numLock, bool capsLock, bool scrollLock)
+{
+  uint32_t modifiers =
+    (scrollLock ? 1 /* SPICE_SCROLL_LOCK_MODIFIER */ : 0) |
+    (numLock    ? 2 /* SPICE_NUM_LOCK_MODIFIER    */ : 0) |
+    (capsLock   ? 4 /* SPICE_CAPS_LOCK_MODIFIER   */ : 0);
+
+  if (!spice_key_modifiers(modifiers))
+    DEBUG_ERROR("app_handleKeyboardLEDs: failed to send message");
+}
+
 void app_handleMouseRelative(double normx, double normy,
     double rawx, double rawy)
 {


### PR DESCRIPTION
This is currently implemented for Wayland, though it shouldn't be hard to implement for X11 after implementing keyboard input support.