### PR TITLE
[client] egl: add tooltip about Ctrl+Click on sharpness sliders

### DIFF
--- a/client/renderers/EGL/filter_ffx_cas.c
+++ b/client/renderers/EGL/filter_ffx_cas.c
@@ -177,6 +177,8 @@ static bool egl_filterFFXCASImguiConfig(EGL_Filter * filter)
       igGetStyle()->WindowPadding.x);
 
   igSliderFloat("##casSharpness", &casSharpness, 0.0f, 1.0f, NULL, 0);
+  if (igIsItemHovered(ImGuiHoveredFlags_None))
+    igSetTooltip("Ctrl+Click to enter a value");
   igPopItemWidth();
 
   if (casSharpness != this->sharpness)

--- a/client/renderers/EGL/filter_ffx_cas.c
+++ b/client/renderers/EGL/filter_ffx_cas.c
@@ -177,6 +177,7 @@ static bool egl_filterFFXCASImguiConfig(EGL_Filter * filter)
       igGetStyle()->WindowPadding.x);
 
   igSliderFloat("##casSharpness", &casSharpness, 0.0f, 1.0f, NULL, 0);
+  casSharpness = util_clamp(casSharpness, 0.0f, 1.0f);
   if (igIsItemHovered(ImGuiHoveredFlags_None))
     igSetTooltip("Ctrl+Click to enter a value");
   igPopItemWidth();

--- a/client/renderers/EGL/filter_ffx_fsr1.c
+++ b/client/renderers/EGL/filter_ffx_fsr1.c
@@ -280,6 +280,7 @@ static bool egl_filterFFXFSR1ImguiConfig(EGL_Filter * filter)
   igPushItemWidth(igGetWindowWidth() - igGetCursorPosX() -
       igGetStyle()->WindowPadding.x);
   igSliderFloat("##fsr1Sharpness", &sharpness, 0.0f, 1.0f, NULL, 0);
+  sharpness = util_clamp(sharpness, 0.0f, 1.0f);
   if (igIsItemHovered(ImGuiHoveredFlags_None))
     igSetTooltip("Ctrl+Click to enter a value");
   igPopItemWidth();

--- a/client/renderers/EGL/filter_ffx_fsr1.c
+++ b/client/renderers/EGL/filter_ffx_fsr1.c
@@ -280,6 +280,8 @@ static bool egl_filterFFXFSR1ImguiConfig(EGL_Filter * filter)
   igPushItemWidth(igGetWindowWidth() - igGetCursorPosX() -
       igGetStyle()->WindowPadding.x);
   igSliderFloat("##fsr1Sharpness", &sharpness, 0.0f, 1.0f, NULL, 0);
+  if (igIsItemHovered(ImGuiHoveredFlags_None))
+    igSetTooltip("Ctrl+Click to enter a value");
   igPopItemWidth();
 
   if (sharpness != this->sharpness)


### PR DESCRIPTION
With the new keymap feature, we are now able to properly support letting
the user enter exact values into the sliders. This commit adds a tooltip
to help the user discover this feature.

Note that this currently only works on Wayland. The X11 backend will need
to call app_handleKeyboardModifiers.