### PR TITLE
Use variable-relative sizeof where possible

### DIFF
--- a/client/displayservers/Wayland/clipboard.c
+++ b/client/displayservers/Wayland/clipboard.c
@@ -446,7 +446,7 @@ void waylandCBRequest(LG_ClipboardData type)
   wl_data_offer_receive(wlCb.offer, wlCb.mimetypes[type], fds[1]);
   close(fds[1]);
 
-  struct ClipboardRead * data = malloc(sizeof(struct ClipboardRead));
+  struct ClipboardRead * data = malloc(sizeof(*data));
   if (!data)
   {
     DEBUG_ERROR("Failed to allocate memory to read clipboard");
@@ -518,7 +518,7 @@ static void dataSourceHandleSend(void * data, struct wl_data_source * source,
   struct WCBTransfer * transfer = (struct WCBTransfer *) data;
   if (containsMimetype(transfer->mimetypes, mimetype))
   {
-    struct ClipboardWrite * data = malloc(sizeof(struct ClipboardWrite));
+    struct ClipboardWrite * data = malloc(sizeof(*data));
     if (!data)
     {
       DEBUG_ERROR("Out of memory trying to allocate ClipboardWrite");
@@ -554,7 +554,7 @@ static const struct wl_data_source_listener dataSourceListener = {
 static void waylandCBReplyFn(void * opaque, LG_ClipboardData type,
    	uint8_t * data, uint32_t size)
 {
-  struct WCBTransfer * transfer = malloc(sizeof(struct WCBTransfer));
+  struct WCBTransfer * transfer = malloc(sizeof(*transfer));
   if (!transfer)
   {
     DEBUG_ERROR("Out of memory when allocating WCBTransfer");

--- a/client/displayservers/Wayland/poll.c
+++ b/client/displayservers/Wayland/poll.c
@@ -135,7 +135,7 @@ static void waylandPollRemoveNode(struct WaylandPoll * node)
 
 bool waylandPollRegister(int fd, WaylandPollCallback callback, void * opaque, uint32_t events)
 {
-  struct WaylandPoll * node = malloc(sizeof(struct WaylandPoll));
+  struct WaylandPoll * node = malloc(sizeof(*node));
   if (!node)
     return false;
 

--- a/client/displayservers/Wayland/presentation.c
+++ b/client/displayservers/Wayland/presentation.c
@@ -107,7 +107,7 @@ void waylandPresentationFrame(void)
   if (!wlWm.presentation)
     return;
 
-  struct FrameData * data = malloc(sizeof(struct FrameData));
+  struct FrameData * data = malloc(sizeof(*data));
   if (clock_gettime(wlWm.clkId, &data->sent))
   {
     DEBUG_ERROR("clock_gettime failed: %s\n", strerror(errno));

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -56,7 +56,7 @@ void waylandWindowUpdateScale(void)
 
 static void wlSurfaceEnterHandler(void * data, struct wl_surface * surface, struct wl_output * output)
 {
-  struct SurfaceOutput * node = malloc(sizeof(struct SurfaceOutput));
+  struct SurfaceOutput * node = malloc(sizeof(*node));
   node->output = output;
   wl_list_insert(&wlWm.surfaceOutputs, &node->link);
   waylandWindowUpdateScale();

--- a/client/displayservers/X11/clipboard.c
+++ b/client/displayservers/X11/clipboard.c
@@ -153,7 +153,7 @@ static void x11CBReplyFn(void * opaque, LG_ClipboardData type,
 
 static void x11CBSelectionRequest(const XSelectionRequestEvent e)
 {
-  XEvent * s = (XEvent *)malloc(sizeof(XEvent));
+  XEvent * s = (XEvent *)malloc(sizeof(*s));
   s->xselection.type      = SelectionNotify;
   s->xselection.requestor = e.requestor;
   s->xselection.selection = e.selection;

--- a/client/renderers/EGL/cursor.c
+++ b/client/renderers/EGL/cursor.c
@@ -135,14 +135,14 @@ static void cursorTexFree(struct CursorTex * t)
 
 bool egl_cursorInit(EGL_Cursor ** cursor)
 {
-  *cursor = (EGL_Cursor *)malloc(sizeof(EGL_Cursor));
+  *cursor = (EGL_Cursor *)malloc(sizeof(**cursor));
   if (!*cursor)
   {
     DEBUG_ERROR("Failed to malloc EGL_Cursor");
     return false;
   }
 
-  memset(*cursor, 0, sizeof(EGL_Cursor));
+  memset(*cursor, 0, sizeof(**cursor));
   LG_LOCK_INIT((*cursor)->lock);
 
   if (!cursorTexInit(&(*cursor)->norm,

--- a/client/renderers/EGL/damage.c
+++ b/client/renderers/EGL/damage.c
@@ -59,7 +59,7 @@ void egl_damageConfigUI(EGL_Damage * damage)
 
 bool egl_damageInit(EGL_Damage ** damage)
 {
-  *damage = (EGL_Damage *)malloc(sizeof(EGL_Damage));
+  *damage = (EGL_Damage *)malloc(sizeof(**damage));
   if (!*damage)
   {
     DEBUG_ERROR("Failed to malloc EGL_Damage");

--- a/client/renderers/EGL/desktop_rects.c
+++ b/client/renderers/EGL/desktop_rects.c
@@ -40,14 +40,14 @@ struct EGL_DesktopRects
 
 bool egl_desktopRectsInit(EGL_DesktopRects ** rects_, int maxCount)
 {
-  EGL_DesktopRects * rects = malloc(sizeof(EGL_DesktopRects));
+  EGL_DesktopRects * rects = malloc(sizeof(*rects));
   if (!rects)
   {
     DEBUG_ERROR("Failed to malloc EGL_DesktopRects");
     return false;
   }
   *rects_ = rects;
-  memset(rects, 0, sizeof(EGL_DesktopRects));
+  memset(rects, 0, sizeof(*rects));
 
   glGenVertexArrays(1, &rects->vao);
   glBindVertexArray(rects->vao);

--- a/client/renderers/EGL/draw.c
+++ b/client/renderers/EGL/draw.c
@@ -25,7 +25,7 @@
 void egl_drawTorus(EGL_Model * model, unsigned int pts, float x, float y,
     float inner, float outer)
 {
-  GLfloat * v   = (GLfloat *)malloc(sizeof(GLfloat) * (pts + 1) * 6);
+  GLfloat * v   = (GLfloat *)malloc(sizeof(*v) * (pts + 1) * 6);
   GLfloat * dst = v;
 
   for(unsigned int i = 0; i <= pts; ++i)
@@ -48,7 +48,7 @@ void egl_drawTorus(EGL_Model * model, unsigned int pts, float x, float y,
 void egl_drawTorusArc(EGL_Model * model, unsigned int pts, float x, float y,
     float inner, float outer, float s, float e)
 {
-  GLfloat * v   = (GLfloat *)malloc(sizeof(GLfloat) * (pts + 1) * 6);
+  GLfloat * v   = (GLfloat *)malloc(sizeof(*v) * (pts + 1) * 6);
   GLfloat * dst = v;
 
   for(unsigned int i = 0; i <= pts; ++i)

--- a/client/renderers/EGL/model.c
+++ b/client/renderers/EGL/model.c
@@ -54,14 +54,14 @@ void update_uniform_bindings(EGL_Model * model);
 
 bool egl_modelInit(EGL_Model ** model)
 {
-  *model = (EGL_Model *)malloc(sizeof(EGL_Model));
+  *model = (EGL_Model *)malloc(sizeof(**model));
   if (!*model)
   {
     DEBUG_ERROR("Failed to malloc EGL_Model");
     return false;
   }
 
-  memset(*model, 0, sizeof(EGL_Model));
+  memset(*model, 0, sizeof(**model));
 
   (*model)->verticies = ll_new();
 
@@ -123,7 +123,7 @@ void egl_modelSetDefault(EGL_Model * model, bool flipped)
 
 void egl_modelAddVerts(EGL_Model * model, const GLfloat * verticies, const GLfloat * uvs, const size_t count)
 {
-  struct FloatList * fl = (struct FloatList *)malloc(sizeof(struct FloatList));
+  struct FloatList * fl = (struct FloatList *)malloc(sizeof(*fl));
 
   fl->count = count;
   fl->v     = (GLfloat *)malloc(sizeof(GLfloat) * count * 3);

--- a/client/renderers/EGL/splash.c
+++ b/client/renderers/EGL/splash.c
@@ -51,14 +51,14 @@ struct EGL_Splash
 
 bool egl_splashInit(EGL_Splash ** splash)
 {
-  *splash = (EGL_Splash *)malloc(sizeof(EGL_Splash));
+  *splash = (EGL_Splash *)malloc(sizeof(**splash));
   if (!*splash)
   {
     DEBUG_ERROR("Failed to malloc EGL_Splash");
     return false;
   }
 
-  memset(*splash, 0, sizeof(EGL_Splash));
+  memset(*splash, 0, sizeof(**splash));
 
   if (!egl_shaderInit(&(*splash)->bgShader))
   {

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -216,7 +216,7 @@ void app_clipboardRequest(const LG_ClipboardReplyFn replyFn, void * opaque)
   if (!g_params.clipboardToLocal)
     return;
 
-  struct CBRequest * cbr = (struct CBRequest *)malloc(sizeof(struct CBRequest));
+  struct CBRequest * cbr = (struct CBRequest *)malloc(sizeof(*cbr));
 
   cbr->type    = g_state.cbType;
   cbr->replyFn = replyFn;
@@ -658,7 +658,7 @@ KeybindHandle app_registerKeybind(int sc, KeybindFn callback, void * opaque, con
     return NULL;
   }
 
-  KeybindHandle handle = (KeybindHandle)malloc(sizeof(struct KeybindHandle));
+  KeybindHandle handle = (KeybindHandle)malloc(sizeof(*handle));
   handle->sc       = sc;
   handle->callback = callback;
   handle->opaque   = opaque;
@@ -711,7 +711,7 @@ void app_registerOverlay(const struct LG_OverlayOps * ops, const void * params)
 {
   ASSERT_LG_OVERLAY_VALID(ops);
 
-  struct Overlay * overlay = malloc(sizeof(struct Overlay));
+  struct Overlay * overlay = malloc(sizeof(*overlay));
   overlay->ops           = ops;
   overlay->params        = params;
   overlay->udata         = NULL;

--- a/client/src/ll.c
+++ b/client/src/ll.c
@@ -41,7 +41,7 @@ struct ll
 
 struct ll * ll_new(void)
 {
-  struct ll * list = malloc(sizeof(struct ll));
+  struct ll * list = malloc(sizeof(*list));
   list->head  = NULL;
   list->tail  = NULL;
   list->pos   = NULL;
@@ -61,7 +61,7 @@ void ll_free(struct ll * list)
 
 void ll_push(struct ll * list, void * data)
 {
-  struct ll_item * item = malloc(sizeof(struct ll_item));
+  struct ll_item * item = malloc(sizeof(*item));
   item->data = data;
   item->next = NULL;
 

--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -198,7 +198,7 @@ struct LG_OverlayOps LGOverlayGraphs =
 
 GraphHandle overlayGraph_register(const char * name, RingBuffer buffer, float min, float max)
 {
-  struct OverlayGraph * graph = malloc(sizeof(struct OverlayGraph));
+  struct OverlayGraph * graph = malloc(sizeof(*graph));
   graph->name    = name;
   graph->buffer  = buffer;
   graph->enabled = true;

--- a/common/src/countedbuffer.c
+++ b/common/src/countedbuffer.c
@@ -24,7 +24,7 @@
 
 struct CountedBuffer * countedBufferNew(size_t size)
 {
-  struct CountedBuffer * buffer = malloc(sizeof(struct CountedBuffer) + size);
+  struct CountedBuffer * buffer = malloc(sizeof(*buffer) + size);
   if (!buffer)
     return NULL;
 

--- a/common/src/option.c
+++ b/common/src/option.c
@@ -120,14 +120,14 @@ bool option_register(struct Option options[])
 
   state.options = realloc(
     state.options,
-    sizeof(struct Option *) * (state.oCount + new)
+    sizeof(*state.options) * (state.oCount + new)
   );
 
   for(int i = 0; options[i].type != OPTION_TYPE_NONE; ++i)
   {
-    state.options[state.oCount + i] = (struct Option *)malloc(sizeof(struct Option));
+    state.options[state.oCount + i] = (struct Option *)malloc(sizeof(**state.options));
     struct Option * o = state.options[state.oCount + i];
-    memcpy(o, &options[i], sizeof(struct Option));
+    memcpy(o, &options[i], sizeof(*o));
 
     if (!o->parser)
     {
@@ -199,7 +199,7 @@ bool option_register(struct Option options[])
       found = true;
       group->options = realloc(
         group->options,
-        sizeof(struct Option *) * (group->count + 1)
+        sizeof(*group->options) * (group->count + 1)
       );
       group->options[group->count] = o;
 
@@ -215,14 +215,14 @@ bool option_register(struct Option options[])
     {
       state.groups = realloc(
         state.groups,
-        sizeof(struct OptionGroup) * (state.gCount + 1)
+        sizeof(*state.groups) * (state.gCount + 1)
       );
 
       struct OptionGroup * group = &state.groups[state.gCount];
       ++state.gCount;
 
       group->module     = o->module;
-      group->options    = malloc(sizeof(struct Option *));
+      group->options    = malloc(sizeof(*group->options));
       group->options[0] = o;
       group->count      = 1;
       group->pad        = strlen(o->name);

--- a/common/src/platform/linux/crash.c
+++ b/common/src/platform/linux/crash.c
@@ -164,7 +164,7 @@ static int dl_iterate_phdr_callback(struct dl_phdr_info * info, size_t size, voi
       ttl += hdr.p_memsz;
   }
 
-  crash.ranges = realloc(crash.ranges, sizeof(struct range) * (crash.rangeCount + 1));
+  crash.ranges = realloc(crash.ranges, sizeof(*crash.ranges) * (crash.rangeCount + 1));
   crash.ranges[crash.rangeCount].start = info->dlpi_addr;
   crash.ranges[crash.rangeCount].end   = info->dlpi_addr + ttl;
   ++crash.rangeCount;

--- a/common/src/platform/linux/event.c
+++ b/common/src/platform/linux/event.c
@@ -39,7 +39,7 @@ struct LGEvent
 
 LGEvent * lgCreateEvent(bool autoReset, unsigned int msSpinTime)
 {
-  LGEvent * handle = (LGEvent *)calloc(sizeof(LGEvent), 1);
+  LGEvent * handle = (LGEvent *)calloc(sizeof(*handle), 1);
   if (!handle)
   {
     DEBUG_ERROR("Failed to allocate memory");

--- a/common/src/platform/linux/ivshmem.c
+++ b/common/src/platform/linux/ivshmem.c
@@ -171,8 +171,7 @@ bool ivshmemOpenDev(struct IVSHMEM * dev, const char * shmDevice)
     return false;
   }
 
-  struct IVSHMEMInfo * info =
-    (struct IVSHMEMInfo *)malloc(sizeof(struct IVSHMEMInfo));
+  struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)malloc(sizeof(*info));
   info->size   = devSize;
   info->devFd  = devFd;
   info->hasDMA = hasDMA;

--- a/common/src/platform/linux/thread.c
+++ b/common/src/platform/linux/thread.c
@@ -43,7 +43,7 @@ static void * threadWrapper(void * opaque)
 
 bool lgCreateThread(const char * name, LGThreadFunction function, void * opaque, LGThread ** handle)
 {
-  *handle = (LGThread*)malloc(sizeof(LGThread));
+  *handle = (LGThread*)malloc(sizeof(**handle));
   (*handle)->name     = name;
   (*handle)->function = function;
   (*handle)->opaque   = opaque;

--- a/common/src/platform/linux/time.c
+++ b/common/src/platform/linux/time.c
@@ -49,7 +49,7 @@ static void TimerProc(union sigval arg)
 bool lgCreateTimer(const unsigned int intervalMS, LGTimerFn fn,
     void * udata, LGTimer ** result)
 {
-  LGTimer * ret = malloc(sizeof(LGTimer));
+  LGTimer * ret = malloc(sizeof(*ret));
 
   if (!ret)
   {

--- a/common/src/platform/windows/ivshmem.c
+++ b/common/src/platform/windows/ivshmem.c
@@ -80,7 +80,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
   SP_DEVICE_INTERFACE_DATA         devInterfaceData = {0};
   int                              deviceAllocated = 1;
   int                              deviceCount = 0;
-  struct IVSHMEMData             * devices = malloc(sizeof(struct IVSHMEMData) * deviceAllocated);
+  struct IVSHMEMData             * devices = malloc(sizeof(*devices) * deviceAllocated);
 
   devInfoSet = SetupDiGetClassDevs(&GUID_DEVINTERFACE_IVSHMEM, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
   devInfoData.cbSize      = sizeof(SP_DEVINFO_DATA);
@@ -97,7 +97,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
     if (deviceCount >= deviceAllocated)
     {
       int newCount = deviceAllocated * 2;
-      void * new = realloc(devices, newCount * sizeof(struct IVSHMEMData));
+      struct IVSHMEMData * new = realloc(devices, newCount * sizeof(*new));
       if (!new)
       {
         DEBUG_ERROR("Failed to allocate memory");
@@ -133,7 +133,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
   }
 
   const int shmDevice = option_get_int("os", "shmDevice");
-  qsort(devices, deviceCount, sizeof(struct IVSHMEMData), ivshmemComparator);
+  qsort(devices, deviceCount, sizeof(*devices), ivshmemComparator);
 
   for (int i = 0; i < deviceCount; ++i)
   {
@@ -181,8 +181,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
   free(infData);
   SetupDiDestroyDeviceInfoList(devInfoSet);
 
-  struct IVSHMEMInfo * info =
-    (struct IVSHMEMInfo *)malloc(sizeof(struct IVSHMEMInfo));
+  struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)malloc(sizeof(*info));
 
   info->handle = handle;
   dev->opaque  = info;

--- a/common/src/platform/windows/thread.c
+++ b/common/src/platform/windows/thread.c
@@ -44,7 +44,7 @@ static DWORD WINAPI threadWrapper(LPVOID lpParameter)
 
 bool lgCreateThread(const char * name, LGThreadFunction function, void * opaque, LGThread ** handle)
 {
-  *handle             = (LGThread *)malloc(sizeof(LGThread));
+  *handle             = (LGThread *)malloc(sizeof(**handle));
   (*handle)->name     = name;
   (*handle)->function = function;
   (*handle)->opaque   = opaque;

--- a/common/src/platform/windows/time.c
+++ b/common/src/platform/windows/time.c
@@ -45,7 +45,7 @@ static void TimerProc(HWND Arg1, UINT Arg2, UINT_PTR Arg3, DWORD Arg4)
 bool lgCreateTimer(const unsigned int intervalMS, LGTimerFn fn,
     void * udata, LGTimer ** result)
 {
-  LGTimer * ret = malloc(sizeof(LGTimer));
+  LGTimer * ret = malloc(sizeof(*ret));
   if (!ret)
   {
     DEBUG_ERROR("failed to malloc LGTimer struct");

--- a/common/src/stringlist.c
+++ b/common/src/stringlist.c
@@ -32,7 +32,7 @@ struct StringList
 
 StringList stringlist_new(bool owns_strings)
 {
-  StringList sl = malloc(sizeof(struct StringList));
+  StringList sl = malloc(sizeof(*sl));
 
   sl->owns_strings = owns_strings;
   sl->size         = 32;
@@ -58,7 +58,7 @@ int stringlist_push (StringList sl, char * str)
   if (sl->count == sl->size)
   {
     sl->size += 32;
-    sl->list  = realloc(sl->list, sizeof(char *) * sl->size);
+    sl->list  = realloc(sl->list, sizeof(*sl->list) * sl->size);
   }
 
   unsigned int index = sl->count;

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -64,7 +64,7 @@ static const char * xcb_getName(void)
 static bool xcb_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
   DEBUG_ASSERT(!this);
-  this             = (struct xcb *)calloc(sizeof(struct xcb), 1);
+  this             = (struct xcb *)calloc(sizeof(*this), 1);
   this->shmID      = -1;
   this->data       = (void *)-1;
   this->frameEvent = lgCreateEvent(true, 20);

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -170,7 +170,7 @@ static void dxgi_initOptions(void)
 static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
   DEBUG_ASSERT(!this);
-  this = calloc(sizeof(struct iface), 1);
+  this = calloc(sizeof(*this), 1);
   if (!this)
   {
     DEBUG_ERROR("failed to allocate iface struct");
@@ -190,7 +190,7 @@ static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostP
     this->maxTextures = 1;
 
   this->useAcquireLock      = option_get_bool("dxgi", "useAcquireLock");
-  this->texture             = calloc(sizeof(struct Texture), this->maxTextures);
+  this->texture             = calloc(sizeof(*this->texture), this->maxTextures);
   this->getPointerBufferFn  = getPointerBufferFn;
   this->postPointerBufferFn = postPointerBufferFn;
   this->avgMapTime          = runningavg_new(10);
@@ -499,7 +499,7 @@ static bool dxgi_init(void)
         output5,
         (IUnknown *)this->device,
         0,
-        sizeof(supportedFormats) / sizeof(DXGI_FORMAT),
+        ARRAY_LENGTH(supportedFormats),
         supportedFormats,
         &this->dup);
 
@@ -871,7 +871,7 @@ static CaptureResult dxgi_capture(void)
         else
         {
           memcpy(tex->texDamageRects + tex->texDamageCount, tex->damageRects,
-            tex->damageRectsCount * sizeof(FrameDamageRect));
+            tex->damageRectsCount * sizeof(*tex->damageRects));
           tex->texDamageCount += tex->damageRectsCount;
           tex->texDamageCount = rectsMergeOverlapping(tex->texDamageRects, tex->texDamageCount);
         }
@@ -920,7 +920,7 @@ static CaptureResult dxgi_capture(void)
                  t->texDamageCount + tex->damageRectsCount <= KVMFR_MAX_DAMAGE_RECTS)
         {
           memcpy(t->texDamageRects + t->texDamageCount, tex->damageRects,
-            tex->damageRectsCount * sizeof(FrameDamageRect));
+            tex->damageRectsCount * sizeof(*tex->damageRects));
           t->texDamageCount += tex->damageRectsCount;
         }
         else
@@ -1093,7 +1093,7 @@ static CaptureResult dxgi_getFrame(FrameBuffer * frame,
   else
   {
     memcpy(damage->rects + damage->count, tex->damageRects,
-      tex->damageRectsCount * sizeof(FrameDamageRect));
+      tex->damageRectsCount * sizeof(*tex->damageRects));
     damage->count += tex->damageRectsCount;
     rectsBufferToFramebuffer(damage->rects, damage->count, frame, this->pitch,
       height, tex->map.pData, this->pitch);
@@ -1108,7 +1108,7 @@ static CaptureResult dxgi_getFrame(FrameBuffer * frame,
              damage->count + tex->damageRectsCount <= KVMFR_MAX_DAMAGE_RECTS)
     {
       memcpy(damage->rects + damage->count, tex->damageRects,
-        tex->damageRectsCount * sizeof(FrameDamageRect));
+        tex->damageRectsCount * sizeof(*tex->damageRects));
       damage->count += tex->damageRectsCount;
     }
     else

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -153,7 +153,7 @@ static bool nvfbc_create(
   if (!NvFBCInit())
     return false;
 
-  this = (struct iface *)calloc(sizeof(struct iface), 1);
+  this = (struct iface *)calloc(sizeof(*this), 1);
 
   this->seperateCursor      = option_get_bool("nvfbc", "decoupleCursor");
   this->getPointerBufferFn  = getPointerBufferFn;

--- a/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
@@ -133,7 +133,7 @@ bool NvFBCToSysCreate(
     return false;
   }
 
-  *handle = (NvFBCHandle)calloc(sizeof(struct stNvFBCHandle), 1);
+  *handle = (NvFBCHandle)calloc(sizeof(**handle), 1);
   (*handle)->nvfbc = static_cast<NvFBCToSys *>(params.pNvFBC);
 
   if (maxWidth)


### PR DESCRIPTION
This eliminates the class of bugs where the size of the variable being assigned doesn't match the amount of memory being allocated.