### PR TITLE
[client] egl: use standard-compliant way of EGL detection

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -201,8 +201,11 @@ static bool egl_create(LG_Renderer ** renderer, const LG_RendererParams params,
     bool * needsOpenGL)
 {
   // check if EGL is even available
-  if (!eglQueryString(EGL_NO_DISPLAY, EGL_VERSION))
+  if (!eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS))
+  {
+    DEBUG_WARN("EGL is not available");
     return false;
+  }
 
   // create our local storage
   struct Inst * this = calloc(1, sizeof(*this));


### PR DESCRIPTION
According to the [documentation for `eglQueryString`](https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglQueryString.xhtml):

> `EGL_BAD_DISPLAY` is generated if display is not an EGL display connection, unless display is `EGL_NO_DISPLAY` and name is `EGL_EXTENSIONS`.

Therefore, we should check EGL by doing:

```c
eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS)
```

Indeed, the old way of `eglQueryString(EGL_NO_DISPLAY, EGL_VERSION)` works on libglvnd but not using mesa's libEGL.so directly.

Also added a warning to make it more obvious that EGL is not available.