### PR TITLE
[all] use correct argument order for calloc

### DIFF
--- a/client/renderers/EGL/texture_dmabuf.c
+++ b/client/renderers/EGL/texture_dmabuf.c
@@ -57,7 +57,7 @@ static void egl_texDMABUFCleanup(TexDMABUF * this)
 
 static bool egl_texDMABUFInit(EGL_Texture ** texture, EGLDisplay * display)
 {
-  TexDMABUF * this = (TexDMABUF *)calloc(sizeof(*this), 1);
+  TexDMABUF * this = (TexDMABUF *)calloc(1, sizeof(*this));
   *texture = &this->base.base;
 
   EGL_Texture * parent = &this->base.base;

--- a/client/renderers/EGL/texture_framebuffer.c
+++ b/client/renderers/EGL/texture_framebuffer.c
@@ -40,7 +40,7 @@ TexFB;
 
 static bool egl_texFBInit(EGL_Texture ** texture, EGLDisplay * display)
 {
-  TexFB * this = calloc(sizeof(*this), 1);
+  TexFB * this = calloc(1, sizeof(*this));
   *texture = &this->base.base;
 
   EGL_Texture * parent = &this->base.base;

--- a/common/src/platform/linux/event.c
+++ b/common/src/platform/linux/event.c
@@ -39,7 +39,7 @@ struct LGEvent
 
 LGEvent * lgCreateEvent(bool autoReset, unsigned int msSpinTime)
 {
-  LGEvent * handle = (LGEvent *)calloc(sizeof(*handle), 1);
+  LGEvent * handle = (LGEvent *)calloc(1, sizeof(*handle));
   if (!handle)
   {
     DEBUG_ERROR("Failed to allocate memory");

--- a/common/src/platform/windows/ivshmem.c
+++ b/common/src/platform/windows/ivshmem.c
@@ -160,7 +160,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
     return false;
   }
 
-  infData         = (PSP_DEVICE_INTERFACE_DETAIL_DATA)calloc(reqSize, 1);
+  infData         = (PSP_DEVICE_INTERFACE_DETAIL_DATA)calloc(1, reqSize);
   infData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
   if (!SetupDiGetDeviceInterfaceDetail(devInfoSet, &devInterfaceData, infData, reqSize, NULL, NULL))
   {

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -64,7 +64,7 @@ static const char * xcb_getName(void)
 static bool xcb_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
   DEBUG_ASSERT(!this);
-  this             = (struct xcb *)calloc(sizeof(*this), 1);
+  this             = (struct xcb *)calloc(1, sizeof(*this));
   this->shmID      = -1;
   this->data       = (void *)-1;
   this->frameEvent = lgCreateEvent(true, 20);

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -170,7 +170,7 @@ static void dxgi_initOptions(void)
 static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
   DEBUG_ASSERT(!this);
-  this = calloc(sizeof(*this), 1);
+  this = calloc(1, sizeof(*this));
   if (!this)
   {
     DEBUG_ERROR("failed to allocate iface struct");
@@ -190,7 +190,7 @@ static bool dxgi_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostP
     this->maxTextures = 1;
 
   this->useAcquireLock      = option_get_bool("dxgi", "useAcquireLock");
-  this->texture             = calloc(sizeof(*this->texture), this->maxTextures);
+  this->texture             = calloc(this->maxTextures, sizeof(*this->texture));
   this->getPointerBufferFn  = getPointerBufferFn;
   this->postPointerBufferFn = postPointerBufferFn;
   this->avgMapTime          = runningavg_new(10);

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -153,7 +153,7 @@ static bool nvfbc_create(
   if (!NvFBCInit())
     return false;
 
-  this = (struct iface *)calloc(sizeof(*this), 1);
+  this = (struct iface *)calloc(1, sizeof(*this));
 
   this->seperateCursor      = option_get_bool("nvfbc", "decoupleCursor");
   this->getPointerBufferFn  = getPointerBufferFn;

--- a/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.cpp
@@ -133,7 +133,7 @@ bool NvFBCToSysCreate(
     return false;
   }
 
-  *handle = (NvFBCHandle)calloc(sizeof(**handle), 1);
+  *handle = (NvFBCHandle)calloc(1, sizeof(**handle));
   (*handle)->nvfbc = static_cast<NvFBCToSys *>(params.pNvFBC);
 
   if (maxWidth)


### PR DESCRIPTION
The signature for calloc is `void *calloc(size_t num, size_t size)`, where `num` is the number of elements to allocate, and `size` is the size. Therefore, to allocate a single struct, we should pass `1` for `num` and the size of the struct as `size`.

In some places, we use the opposite order, and we should flip it.

This is based on #778 and should be rebased after it is merged.