### PR TITLE
[client] remove all casts around malloc

### DIFF
--- a/client/displayservers/X11/clipboard.c
+++ b/client/displayservers/X11/clipboard.c
@@ -153,7 +153,7 @@ static void x11CBReplyFn(void * opaque, LG_ClipboardData type,
 
 static void x11CBSelectionRequest(const XSelectionRequestEvent e)
 {
-  XEvent * s = (XEvent *)malloc(sizeof(*s));
+  XEvent * s = malloc(sizeof(*s));
   s->xselection.type      = SelectionNotify;
   s->xselection.requestor = e.requestor;
   s->xselection.selection = e.selection;

--- a/client/renderers/EGL/cursor.c
+++ b/client/renderers/EGL/cursor.c
@@ -135,7 +135,7 @@ static void cursorTexFree(struct CursorTex * t)
 
 bool egl_cursorInit(EGL_Cursor ** cursor)
 {
-  *cursor = (EGL_Cursor *)malloc(sizeof(**cursor));
+  *cursor = malloc(sizeof(**cursor));
   if (!*cursor)
   {
     DEBUG_ERROR("Failed to malloc EGL_Cursor");
@@ -206,7 +206,7 @@ bool egl_cursorSetShape(EGL_Cursor * cursor, const LG_RendererCursor type,
     if (cursor->data)
       free(cursor->data);
 
-    cursor->data = (uint8_t *)malloc(size);
+    cursor->data = malloc(size);
     if (!cursor->data)
     {
       DEBUG_ERROR("Failed to malloc buffer for cursor shape");

--- a/client/renderers/EGL/damage.c
+++ b/client/renderers/EGL/damage.c
@@ -59,7 +59,7 @@ void egl_damageConfigUI(EGL_Damage * damage)
 
 bool egl_damageInit(EGL_Damage ** damage)
 {
-  *damage = (EGL_Damage *)malloc(sizeof(**damage));
+  *damage = malloc(sizeof(**damage));
   if (!*damage)
   {
     DEBUG_ERROR("Failed to malloc EGL_Damage");

--- a/client/renderers/EGL/desktop.c
+++ b/client/renderers/EGL/desktop.c
@@ -116,7 +116,7 @@ static bool egl_initDesktopShader(
 bool egl_desktopInit(EGL * egl, EGL_Desktop ** desktop_, EGLDisplay * display,
     bool useDMA, int maxRects)
 {
-  EGL_Desktop * desktop = (EGL_Desktop *)calloc(1, sizeof(EGL_Desktop));
+  EGL_Desktop * desktop = calloc(1, sizeof(EGL_Desktop));
   if (!desktop)
   {
     DEBUG_ERROR("Failed to malloc EGL_Desktop");

--- a/client/renderers/EGL/draw.c
+++ b/client/renderers/EGL/draw.c
@@ -25,7 +25,7 @@
 void egl_drawTorus(EGL_Model * model, unsigned int pts, float x, float y,
     float inner, float outer)
 {
-  GLfloat * v   = (GLfloat *)malloc(sizeof(*v) * (pts + 1) * 6);
+  GLfloat * v   = malloc(sizeof(*v) * (pts + 1) * 6);
   GLfloat * dst = v;
 
   for(unsigned int i = 0; i <= pts; ++i)
@@ -48,7 +48,7 @@ void egl_drawTorus(EGL_Model * model, unsigned int pts, float x, float y,
 void egl_drawTorusArc(EGL_Model * model, unsigned int pts, float x, float y,
     float inner, float outer, float s, float e)
 {
-  GLfloat * v   = (GLfloat *)malloc(sizeof(*v) * (pts + 1) * 6);
+  GLfloat * v   = malloc(sizeof(*v) * (pts + 1) * 6);
   GLfloat * dst = v;
 
   for(unsigned int i = 0; i <= pts; ++i)

--- a/client/renderers/EGL/model.c
+++ b/client/renderers/EGL/model.c
@@ -54,7 +54,7 @@ void update_uniform_bindings(EGL_Model * model);
 
 bool egl_modelInit(EGL_Model ** model)
 {
-  *model = (EGL_Model *)malloc(sizeof(**model));
+  *model = malloc(sizeof(**model));
   if (!*model)
   {
     DEBUG_ERROR("Failed to malloc EGL_Model");
@@ -123,11 +123,11 @@ void egl_modelSetDefault(EGL_Model * model, bool flipped)
 
 void egl_modelAddVerts(EGL_Model * model, const GLfloat * verticies, const GLfloat * uvs, const size_t count)
 {
-  struct FloatList * fl = (struct FloatList *)malloc(sizeof(*fl));
+  struct FloatList * fl = malloc(sizeof(*fl));
 
   fl->count = count;
-  fl->v     = (GLfloat *)malloc(sizeof(GLfloat) * count * 3);
-  fl->u     = (GLfloat *)malloc(sizeof(GLfloat) * count * 2);
+  fl->v     = malloc(sizeof(GLfloat) * count * 3);
+  fl->u     = malloc(sizeof(GLfloat) * count * 2);
   memcpy(fl->v, verticies, sizeof(GLfloat) * count * 3);
 
   if (uvs)

--- a/client/renderers/EGL/shader.c
+++ b/client/renderers/EGL/shader.c
@@ -38,7 +38,7 @@ struct EGL_Shader
 
 bool egl_shaderInit(EGL_Shader ** this)
 {
-  *this = (EGL_Shader *)calloc(1, sizeof(EGL_Shader));
+  *this = calloc(1, sizeof(EGL_Shader));
   if (!*this)
   {
     DEBUG_ERROR("Failed to malloc EGL_Shader");

--- a/client/renderers/EGL/splash.c
+++ b/client/renderers/EGL/splash.c
@@ -51,7 +51,7 @@ struct EGL_Splash
 
 bool egl_splashInit(EGL_Splash ** splash)
 {
-  *splash = (EGL_Splash *)malloc(sizeof(**splash));
+  *splash = malloc(sizeof(**splash));
   if (!*splash)
   {
     DEBUG_ERROR("Failed to malloc EGL_Splash");

--- a/client/renderers/EGL/texture_buffer.c
+++ b/client/renderers/EGL/texture_buffer.c
@@ -51,7 +51,7 @@ bool egl_texBufferInit(EGL_Texture ** texture, EGLDisplay * display)
   TextureBuffer * this;
   if (!*texture)
   {
-    this = (TextureBuffer *)calloc(1, sizeof(*this));
+    this = calloc(1, sizeof(*this));
     if (!this)
     {
       DEBUG_ERROR("Failed to malloc TexB");

--- a/client/renderers/EGL/texture_dmabuf.c
+++ b/client/renderers/EGL/texture_dmabuf.c
@@ -57,7 +57,7 @@ static void egl_texDMABUFCleanup(TexDMABUF * this)
 
 static bool egl_texDMABUFInit(EGL_Texture ** texture, EGLDisplay * display)
 {
-  TexDMABUF * this = (TexDMABUF *)calloc(1, sizeof(*this));
+  TexDMABUF * this = calloc(1, sizeof(*this));
   *texture = &this->base.base;
 
   EGL_Texture * parent = &this->base.base;

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -326,7 +326,7 @@ bool opengl_onMouseShape(LG_Renderer * renderer, const LG_RendererCursor cursor,
   {
     if (this->mouseData)
       free(this->mouseData);
-    this->mouseData     = (uint8_t *)malloc(size);
+    this->mouseData     = malloc(size);
     this->mouseDataSize = size;
   }
 

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -216,7 +216,7 @@ void app_clipboardRequest(const LG_ClipboardReplyFn replyFn, void * opaque)
   if (!g_params.clipboardToLocal)
     return;
 
-  struct CBRequest * cbr = (struct CBRequest *)malloc(sizeof(*cbr));
+  struct CBRequest * cbr = malloc(sizeof(*cbr));
 
   cbr->type    = g_state.cbType;
   cbr->replyFn = replyFn;
@@ -661,7 +661,7 @@ KeybindHandle app_registerKeybind(int sc, KeybindFn callback, void * opaque, con
     return NULL;
   }
 
-  KeybindHandle handle = (KeybindHandle)malloc(sizeof(*handle));
+  KeybindHandle handle = malloc(sizeof(*handle));
   handle->sc       = sc;
   handle->callback = callback;
   handle->opaque   = opaque;

--- a/common/src/option.c
+++ b/common/src/option.c
@@ -125,7 +125,7 @@ bool option_register(struct Option options[])
 
   for(int i = 0; options[i].type != OPTION_TYPE_NONE; ++i)
   {
-    state.options[state.oCount + i] = (struct Option *)malloc(sizeof(**state.options));
+    state.options[state.oCount + i] = malloc(sizeof(**state.options));
     struct Option * o = state.options[state.oCount + i];
     memcpy(o, &options[i], sizeof(*o));
 

--- a/common/src/platform/linux/crash.c
+++ b/common/src/platform/linux/crash.c
@@ -89,7 +89,7 @@ static bool load_symbols(void)
   }
 
   long storage   = bfd_get_symtab_upper_bound(crash.fd);
-  crash.syms     = (asymbol **)malloc(storage);
+  crash.syms     = malloc(storage);
   crash.symCount = bfd_canonicalize_symtab(crash.fd, crash.syms);
   if (crash.symCount < 0)
   {

--- a/common/src/platform/linux/event.c
+++ b/common/src/platform/linux/event.c
@@ -39,7 +39,7 @@ struct LGEvent
 
 LGEvent * lgCreateEvent(bool autoReset, unsigned int msSpinTime)
 {
-  LGEvent * handle = (LGEvent *)calloc(1, sizeof(*handle));
+  LGEvent * handle = calloc(1, sizeof(*handle));
   if (!handle)
   {
     DEBUG_ERROR("Failed to allocate memory");

--- a/common/src/platform/linux/ivshmem.c
+++ b/common/src/platform/linux/ivshmem.c
@@ -171,7 +171,7 @@ bool ivshmemOpenDev(struct IVSHMEM * dev, const char * shmDevice)
     return false;
   }
 
-  struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)malloc(sizeof(*info));
+  struct IVSHMEMInfo * info = malloc(sizeof(*info));
   info->size   = devSize;
   info->devFd  = devFd;
   info->hasDMA = hasDMA;

--- a/common/src/platform/linux/thread.c
+++ b/common/src/platform/linux/thread.c
@@ -43,7 +43,7 @@ static void * threadWrapper(void * opaque)
 
 bool lgCreateThread(const char * name, LGThreadFunction function, void * opaque, LGThread ** handle)
 {
-  *handle = (LGThread*)malloc(sizeof(**handle));
+  *handle = malloc(sizeof(**handle));
   (*handle)->name     = name;
   (*handle)->function = function;
   (*handle)->opaque   = opaque;

--- a/common/src/platform/windows/ivshmem.c
+++ b/common/src/platform/windows/ivshmem.c
@@ -160,7 +160,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
     return false;
   }
 
-  infData         = (PSP_DEVICE_INTERFACE_DETAIL_DATA)calloc(1, reqSize);
+  infData         = calloc(1, reqSize);
   infData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
   if (!SetupDiGetDeviceInterfaceDetail(devInfoSet, &devInterfaceData, infData, reqSize, NULL, NULL))
   {
@@ -181,7 +181,7 @@ bool ivshmemInit(struct IVSHMEM * dev)
   free(infData);
   SetupDiDestroyDeviceInfoList(devInfoSet);
 
-  struct IVSHMEMInfo * info = (struct IVSHMEMInfo *)malloc(sizeof(*info));
+  struct IVSHMEMInfo * info = malloc(sizeof(*info));
 
   info->handle = handle;
   dev->opaque  = info;

--- a/common/src/platform/windows/thread.c
+++ b/common/src/platform/windows/thread.c
@@ -44,7 +44,7 @@ static DWORD WINAPI threadWrapper(LPVOID lpParameter)
 
 bool lgCreateThread(const char * name, LGThreadFunction function, void * opaque, LGThread ** handle)
 {
-  *handle             = (LGThread *)malloc(sizeof(**handle));
+  *handle             = malloc(sizeof(**handle));
   (*handle)->name     = name;
   (*handle)->function = function;
   (*handle)->opaque   = opaque;

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -64,7 +64,7 @@ static const char * xcb_getName(void)
 static bool xcb_create(CaptureGetPointerBuffer getPointerBufferFn, CapturePostPointerBuffer postPointerBufferFn)
 {
   DEBUG_ASSERT(!this);
-  this             = (struct xcb *)calloc(1, sizeof(*this));
+  this             = calloc(1, sizeof(*this));
   this->shmID      = -1;
   this->data       = (void *)-1;
   this->frameEvent = lgCreateEvent(true, 20);

--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -153,7 +153,7 @@ static bool nvfbc_create(
   if (!NvFBCInit())
     return false;
 
-  this = (struct iface *)calloc(1, sizeof(*this));
+  this = calloc(1, sizeof(*this));
 
   this->seperateCursor      = option_get_bool("nvfbc", "decoupleCursor");
   this->getPointerBufferFn  = getPointerBufferFn;
@@ -176,7 +176,7 @@ static bool nvfbc_init(void)
     GetEnvironmentVariable("NVFBC_PRIV_DATA", buffer, bufferLen);
 
     privDataLen = (bufferLen - 1) / 2;
-    privData    = (uint8_t *)malloc(privDataLen);
+    privData    = malloc(privDataLen);
     char hex[3] = {0};
     for (int i = 0; i < privDataLen; ++i)
     {


### PR DESCRIPTION
The cast is unnecessary in C and should be removed to avoid clutter.

This is dependent on #781 and should be rebased after that one is merged.