### PR TITLE
[common] windebug: pass FORMAT_MESSAGE_IGNORE_INSERTS to FormatMessage

### DIFF
--- a/common/src/platform/windows/windebug.c
+++ b/common/src/platform/windows/windebug.c
@@ -25,7 +25,7 @@ void DebugWinError(const char * file, const unsigned int line, const char * func
 {
   char *buffer;
   FormatMessageA(
-    FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+    FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
     NULL,
     status,
     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),


### PR DESCRIPTION
This avoids problems when the error message we are told to format contains inserts like `%1`.

See https://devblogs.microsoft.com/oldnewthing/20071128-00/?p=24353 for details (or for fun).