### PR TITLE
[client] kb: rename key code arrays from xfree86_* to linux_*

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -333,7 +333,7 @@ void app_handleKeyPress(int sc)
 
   if (!g_state.keyDown[sc])
   {
-    uint32_t ps2 = xfree86_to_ps2[sc];
+    uint32_t ps2 = linux_to_ps2[sc];
     if (!ps2)
       return;
 
@@ -386,7 +386,7 @@ void app_handleKeyRelease(int sc)
   if (g_params.ignoreWindowsKeys && (sc == KEY_LEFTMETA || sc == KEY_RIGHTMETA))
     return;
 
-  uint32_t ps2 = xfree86_to_ps2[sc];
+  uint32_t ps2 = linux_to_ps2[sc];
   if (!ps2)
     return;
 

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -790,7 +790,7 @@ static char * optScancodeToString(struct Option * opt)
 {
   char * str;
   alloc_sprintf(&str, "%d = %s", opt->value.x_int,
-      xfree86_to_str[opt->value.x_int]);
+      linux_to_str[opt->value.x_int]);
   return str;
 }
 

--- a/client/src/kb.c
+++ b/client/src/kb.c
@@ -21,7 +21,7 @@
 #include "kb.h"
 #include "cimgui.h"
 
-const uint32_t xfree86_to_ps2[KEY_MAX] =
+const uint32_t linux_to_ps2[KEY_MAX] =
 {
   [KEY_RESERVED]         /* = USB   0 */ = 0x000000,
   [KEY_ESC]              /* = USB  41 */ = 0x000001,
@@ -144,7 +144,7 @@ const uint32_t xfree86_to_ps2[KEY_MAX] =
   [KEY_PRINT]            /* = USB  70 */ = 0x00E037,
 };
 
-const char * xfree86_to_str[KEY_MAX] =
+const char * linux_to_str[KEY_MAX] =
 {
   [KEY_RESERVED]         = "KEY_RESERVED",
   [KEY_ESC]              = "KEY_ESC",
@@ -267,7 +267,7 @@ const char * xfree86_to_str[KEY_MAX] =
   [KEY_PRINT]            = "KEY_PRINT",
 };
 
-const char * xfree86_to_display[KEY_MAX] =
+const char * linux_to_display[KEY_MAX] =
 {
   [KEY_RESERVED]         = "Reserved",
   [KEY_ESC]              = "Esc",

--- a/client/src/kb.h
+++ b/client/src/kb.h
@@ -24,9 +24,9 @@
 #include <linux/input.h>
 #include <stdint.h>
 
-extern const uint32_t xfree86_to_ps2[KEY_MAX];
-extern const char *   xfree86_to_str[KEY_MAX];
-extern const char *   xfree86_to_display[KEY_MAX];
+extern const uint32_t linux_to_ps2[KEY_MAX];
+extern const char *   linux_to_str[KEY_MAX];
+extern const char *   linux_to_display[KEY_MAX];
 
 void initImGuiKeyMap(int * keymap);
 

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -104,9 +104,9 @@ static void bind_mouseSens(int sc, void * opaque)
 
 static void bind_ctrlAltFn(int sc, void * opaque)
 {
-  const uint32_t ctrl = xfree86_to_ps2[KEY_LEFTCTRL];
-  const uint32_t alt  = xfree86_to_ps2[KEY_LEFTALT ];
-  const uint32_t fn   = xfree86_to_ps2[sc];
+  const uint32_t ctrl = linux_to_ps2[KEY_LEFTCTRL];
+  const uint32_t alt  = linux_to_ps2[KEY_LEFTALT ];
+  const uint32_t fn   = linux_to_ps2[sc];
   spice_key_down(ctrl);
   spice_key_down(alt );
   spice_key_down(fn  );
@@ -118,7 +118,7 @@ static void bind_ctrlAltFn(int sc, void * opaque)
 
 static void bind_passthrough(int sc, void * opaque)
 {
-  sc = xfree86_to_ps2[sc];
+  sc = linux_to_ps2[sc];
   spice_key_down(sc);
   spice_key_up  (sc);
 }

--- a/client/src/overlay/help.c
+++ b/client/src/overlay/help.c
@@ -56,7 +56,7 @@ static int help_render(void * udata, bool interactive, struct Rect * windowRects
 
   if (igBeginTable("Help", 2, 0, (ImVec2) { 0.0f, 0.0f }, 0.0f))
   {
-    const char * escapeName = xfree86_to_display[g_params.escapeKey];
+    const char * escapeName = linux_to_display[g_params.escapeKey];
 
     igTableNextColumn();
     igText("%s", escapeName);
@@ -67,7 +67,7 @@ static int help_render(void * udata, bool interactive, struct Rect * windowRects
       if (g_state.keyDescription[i])
       {
         igTableNextColumn();
-        igText("%s+%s", escapeName, xfree86_to_display[i]);
+        igText("%s+%s", escapeName, linux_to_display[i]);
         igTableNextColumn();
         igText(g_state.keyDescription[i]);
       }


### PR DESCRIPTION
We are using Linux key codes defined in input-event-codes.h, not XFree86
stuff.