### PR TITLE
[all] cmake: tell users to clone submodules when they haven't

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -4,6 +4,7 @@ project(looking-glass-client C CXX)
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_TOP}/cmake/" "${PROJECT_SOURCE_DIR}/cmake/")
 
+include(CheckSubmodule)
 include(GNUInstallDirs)
 include(CheckCCompilerFlag)
 include(FeatureSummary)

--- a/cmake/CheckSubmodule.cmake
+++ b/cmake/CheckSubmodule.cmake
@@ -1,0 +1,8 @@
+if (EXISTS "${PROJECT_TOP}/.git" AND (
+    (NOT EXISTS "${PROJECT_TOP}/repos/cimgui/.git") OR
+    (NOT EXISTS "${PROJECT_TOP}/repos/LGMP/.git") OR
+    (NOT EXISTS "${PROJECT_TOP}/repos/PureSpice/.git") OR
+    (NOT EXISTS "${PROJECT_TOP}/repos/cimgui/imgui/.git")
+))
+    message(FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
+endif()

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "compiler flag
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_TOP}/cmake/" "${PROJECT_SOURCE_DIR}/cmake/")
 
+include(CheckSubmodule)
 include(GNUInstallDirs)
 include(CheckCCompilerFlag)
 include(FeatureSummary)

--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -4,6 +4,7 @@ project(looking-glass-obs C)
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_TOP}/cmake/" "${PROJECT_SOURCE_DIR}/cmake/")
 
+include(CheckSubmodule)
 include(GNUInstallDirs)
 include(CheckCCompilerFlag)
 include(FeatureSummary)


### PR DESCRIPTION
This gives users a command to run that will automagically fix the submodule
situation, and should reduce the amount of support requests.