### PR TITLE
[client] egl: dynamically import glBufferStorageEXT

### DIFF
--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -37,6 +37,8 @@ typedef void (*DEBUGPROC_t)(GLenum source,
     const GLchar *message, const void *userParam);
 typedef void (*glDebugMessageCallback_t)(DEBUGPROC_t callback,
     const void * userParam);
+typedef void (*glBufferStorageEXT_t)(GLenum target, GLsizeiptr size,
+    const void * data, GLbitfield flags);
 
 struct EGLDynProcs
 {
@@ -47,6 +49,7 @@ struct EGLDynProcs
   glEGLImageTargetTexture2DOES_t glEGLImageTargetTexture2DOES;
   glDebugMessageCallback_t       glDebugMessageCallback;
   glDebugMessageCallback_t       glDebugMessageCallbackKHR;
+  glBufferStorageEXT_t           glBufferStorageEXT;
 };
 
 extern struct EGLDynProcs g_egl_dynProcs;

--- a/client/renderers/EGL/texture_util.c
+++ b/client/renderers/EGL/texture_util.c
@@ -26,6 +26,7 @@
 #include <GLES2/gl2ext.h>
 
 #include "egldebug.h"
+#include "egl_dynprocs.h"
 
 /**
  * the following comes from drm_fourcc.h and is included here to avoid the
@@ -108,7 +109,7 @@ bool egl_texUtilGenBuffers(const EGL_TexFormat * fmt, EGL_TexBuffer * buffers,
     buffer->size = fmt->bufferSize;
     glGenBuffers(1, &buffer->pbo);
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer->pbo);
-    glBufferStorageEXT(
+    g_egl_dynProcs.glBufferStorageEXT(
       GL_PIXEL_UNPACK_BUFFER,
       fmt->bufferSize,
       NULL,

--- a/client/src/egl_dynprocs.c
+++ b/client/src/egl_dynprocs.c
@@ -40,6 +40,8 @@ void egl_dynProcsInit(void)
     eglGetProcAddress("glDebugMessageCallback");
   g_egl_dynProcs.glDebugMessageCallbackKHR = (glDebugMessageCallback_t)
     eglGetProcAddress("glDebugMessageCallbackKHR");
+  g_egl_dynProcs.glBufferStorageEXT = (glBufferStorageEXT_t)
+    eglGetProcAddress("glBufferStorageEXT");
 };
 
 #endif


### PR DESCRIPTION
On some implementations (e.g. llvmpipe), the function can only be queried via
`eglGetProcAddress`.