### PR TITLE
[client] egl: look at 3x3 around the pixel instead of 4x4

### DIFF
--- a/client/renderers/EGL/shader/downscale_lanczos2.frag
+++ b/client/renderers/EGL/shader/downscale_lanczos2.frag
@@ -29,38 +29,31 @@ void main()
   vec2 invSize = 1.0 / size;
   vec2 uvc = floor(pos) + vec2(0.5, 0.5);
 
-  vec2 uvs[16] = vec2[](
+  vec2 uvs[9] = vec2[](
     uvc + vec2(-1.0, -1.0),
     uvc + vec2(-1.0,  0.0),
     uvc + vec2(-1.0,  1.0),
-    uvc + vec2(-1.0,  2.0),
     uvc + vec2( 0.0, -1.0),
     uvc + vec2( 0.0,  0.0),
     uvc + vec2( 0.0,  1.0),
-    uvc + vec2( 0.0,  2.0),
     uvc + vec2( 1.0, -1.0),
     uvc + vec2( 1.0,  0.0),
-    uvc + vec2( 1.0,  1.0),
-    uvc + vec2( 1.0,  2.0),
-    uvc + vec2( 2.0, -1.0),
-    uvc + vec2( 2.0,  0.0),
-    uvc + vec2( 2.0,  1.0),
-    uvc + vec2( 2.0,  2.0)
+    uvc + vec2( 1.0,  1.0)
   );
 
-  float factors[16];
+  float factors[9];
   float sum = 0.0;
-  for (int i = 0; i < 16; ++i)
+  for (int i = 0; i < 9; ++i)
   {
     factors[i] = lanczos(uvs[i] - fragCoord * size);
     sum += factors[i];
   }
 
-  for (int i = 0; i < 16; ++i)
+  for (int i = 0; i < 9; ++i)
     factors[i] /= sum;
 
   vec3 color = vec3(0.0);
-  for (int i = 0; i < 16; ++i)
+  for (int i = 0; i < 9; ++i)
     color += texture2D(texture, uvs[i] * invSize).rgb * factors[i];
 
   fragColor = vec4(color, 1.0);


### PR DESCRIPTION
Using 4x4 means that some pixels will be outside of the lanczos window. The
ideal lanczos function should in fact be zero in those areas, so we shouldn't
waste time processing those pixels.

I can't notice any difference in the results.