### PR TITLE
[client] imgui: fix modifier key modification race

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -406,10 +406,10 @@ void app_handleKeyboardTyped(const char * typed)
 
 void app_handleKeyboardModifiers(bool ctrl, bool shift, bool alt, bool super)
 {
-  g_state.io->KeyCtrl  = ctrl;
-  g_state.io->KeyShift = shift;
-  g_state.io->KeyAlt   = alt;
-  g_state.io->KeySuper = super;
+  g_state.modCtrl  = ctrl;
+  g_state.modShift = shift;
+  g_state.modAlt   = alt;
+  g_state.modSuper = super;
 }
 
 void app_handleKeyboardLEDs(bool numLock, bool capsLock, bool scrollLock)
@@ -805,6 +805,11 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
   bool totalDamage = false;
   struct Overlay * overlay;
   struct Rect buffer[MAX_OVERLAY_RECTS];
+
+  g_state.io->KeyCtrl  = g_state.modCtrl;
+  g_state.io->KeyShift = g_state.modShift;
+  g_state.io->KeyAlt   = g_state.modAlt;
+  g_state.io->KeySuper = g_state.modSuper;
 
   igNewFrame();
 

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -56,6 +56,10 @@ struct AppState
   bool             overlayInput;
   ImGuiMouseCursor cursorLast;
   char           * imGuiIni;
+  bool             modCtrl;
+  bool             modShift;
+  bool             modAlt;
+  bool             modSuper;
 
   bool        alertShow;
   char      * alertMessage;


### PR DESCRIPTION
imgui really hates it when we update the modifier key state after `igNewFrame`.
The result is:

    void ImGui::ErrorCheckEndFrameSanityChecks(): Assertion `(key_mod_flags == 0 || g.IO.KeyMods == key_mod_flags) && "Mismatching io.KeyCtrl/io.KeyShift/io.KeyAlt/io.KeySuper vs io.KeyMods"' failed.

Therefore, we buffer the modifier state information and update it in the IO object right before we call `igNewFrame`.