### PR TITLE
[client] spice: fix mouse realignment issues

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -320,7 +320,7 @@ void core_handleGuestMouseUpdate(void)
   if (!util_guestCurToLocal(&localPos))
     return;
 
-  if (g_state.overlayInput)
+  if (g_state.overlayInput || !g_cursor.inView)
     return;
 
   g_state.ds->guestPointerUpdated(

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -385,17 +385,14 @@ void core_handleMouseNormal(double ex, double ey)
   }
 
   bool testExit = true;
+  const bool inView = isInView();
   if (!g_cursor.inView)
   {
-    const bool inView = isInView();
-    core_setCursorInView(inView);
     if (inView)
       g_cursor.realign = true;
+    else /* nothing to do if we are outside the viewport */
+      return;
   }
-
-  /* nothing to do if we are outside the viewport */
-  if (!g_cursor.inView)
-    return;
 
   /*
    * do not pass mouse events to the guest if we do not have focus, this must be
@@ -403,7 +400,10 @@ void core_handleMouseNormal(double ex, double ey)
    * we know if we should be drawing the cursor.
    */
   if (!g_state.focused)
+  {
+    core_setCursorInView(inView);
     return;
+  }
 
   /* if we have been instructed to realign */
   if (g_cursor.realign)
@@ -440,6 +440,7 @@ void core_handleMouseNormal(double ex, double ey)
         g_cursor.guest.x = msg.x;
         g_cursor.guest.y = msg.y;
         g_cursor.realign = false;
+        core_setCursorInView(true);
         return;
       }
     }
@@ -448,6 +449,7 @@ void core_handleMouseNormal(double ex, double ey)
       /* add the difference to the offset */
       ex += guest.x - (g_cursor.guest.x + g_cursor.guest.hx);
       ey += guest.y - (g_cursor.guest.y + g_cursor.guest.hy);
+      core_setCursorInView(true);
     }
 
     g_cursor.realign = false;


### PR DESCRIPTION
This PR fixes two annoying issues with guest-side mouse realignment:

1. We no longer display the mouse before the realignment is finished. This avoids showing the mouse briefly at the old position when reentering the window.
2. We no longer warp the hose cursor if the guest cursor is not visible. This avoids warping the host cursor when the guest-side warp has not finished, which will result in the host cursor exiting at the wrong position if it exits at that moment.