### PR TITLE
[client] egl: allow postprocessing filters to be reordered by dragging

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -32,6 +32,7 @@ set(COMMON_SOURCES
   src/rects.c
   src/runningavg.c
   src/ringbuffer.c
+  src/vector.c
 )
 
 add_library(lg_common STATIC ${COMMON_SOURCES})

--- a/common/include/common/vector.h
+++ b/common/include/common/vector.h
@@ -1,0 +1,54 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct Vector
+{
+  size_t itemSize;
+  size_t size;
+  size_t capacity;
+  void * data;
+}
+Vector;
+
+Vector * vector_create(size_t itemSize, size_t capacity);
+void vector_free(Vector * vector);
+
+bool vector_push(Vector * vector, void * item);
+void vector_pop(Vector * vector);
+size_t vector_size(Vector * vector);
+void * vector_data(Vector * vector);
+void vector_at(Vector * vector, size_t index, void * data);
+void * vector_ptrTo(Vector * vector, size_t index);
+
+#define vector_forEach(name, vector) \
+  for (char * vecIterCurrent = (vector)->data, \
+            * vecIterEnd = vecIterCurrent + (vector)->size * (vector)->itemSize; \
+       vecIterCurrent < vecIterEnd ? name = *(__typeof__(name) *)vecIterCurrent, true : false; \
+       vecIterCurrent += (vector)->itemSize)
+
+#define vector_forEachRef(name, vector) \
+  for (char * vecIterCurrent = (vector)->data, \
+            * vecIterEnd = vecIterCurrent + (vector)->size * (vector)->itemSize; \
+       vecIterCurrent < vecIterEnd ? name = (void *)vecIterCurrent, true : false; \
+       vecIterCurrent += (vector)->itemSize)

--- a/common/src/vector.c
+++ b/common/src/vector.c
@@ -1,0 +1,101 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/vector.h"
+#include "common/debug.h"
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+Vector * vector_create(size_t itemSize, size_t capacity)
+{
+  Vector * vector = calloc(1, sizeof(Vector));
+  if (!vector)
+    return NULL;
+
+  vector->itemSize = itemSize;
+  vector->capacity = capacity;
+  if (capacity)
+  {
+    vector->data = malloc(itemSize * capacity);
+    if (!vector->data)
+    {
+      free(vector);
+      return NULL;
+    }
+  }
+  return vector;
+}
+
+void vector_free(Vector * vector)
+{
+  free(vector->data);
+  free(vector);
+}
+
+bool vector_push(Vector * vector, void * item)
+{
+  if (vector->size >= vector->capacity)
+  {
+    size_t newCapacity = vector->capacity < 4 ? 8 : vector->capacity * 2;
+    void * new = realloc(vector->data, newCapacity * vector->itemSize);
+    if (!new)
+    {
+      DEBUG_ERROR("Failed to allocate memory in vector: %" PRIuPTR " bytes", newCapacity * vector->itemSize);
+      return false;
+    }
+
+    vector->capacity = newCapacity;
+    vector->data = new;
+  }
+
+  memcpy((char *)vector->data + vector->size * vector->itemSize, item, vector->itemSize);
+  ++vector->size;
+  return true;
+}
+
+void vector_pop(Vector * vector)
+{
+  DEBUG_ASSERT(vector->size > 0 && "Attempting to pop from empty vector!");
+  --vector->size;
+}
+
+size_t vector_size(Vector * vector)
+{
+  return vector->size;
+}
+
+void * vector_data(Vector * vector)
+{
+  return vector->data;
+}
+
+void vector_at(Vector * vector, size_t index, void * data)
+{
+  DEBUG_ASSERT(index < vector->size && "Out of bounds access");
+  memcpy(data, (char *)vector->data + index * vector->itemSize, vector->itemSize);
+}
+
+void * vector_ptrTo(Vector * vector, size_t index)
+{
+  DEBUG_ASSERT(index < vector->size && "Out of bounds access");
+  return (char *)vector->data + index * vector->itemSize;
+}


### PR DESCRIPTION
Due to the difficulty of swapping elements with `struct ll`, I created a vector common type (based on C++'s `std::vector`) and switched the storage. There are likely other places that could benefit from this new type (e.g. `EGLImage` storage in `texture_dmabuf.c`), and those will be switched over later.