### PR TITLE
[common] option: change option_dump to option_dump_preset

### DIFF
--- a/client/renderers/EGL/postprocess.c
+++ b/client/renderers/EGL/postprocess.c
@@ -194,7 +194,7 @@ static bool savePreset(struct EGL_PostProcess * this, const char * name)
   free(path);
 
   DEBUG_INFO("Saving preset: %s", name);
-  option_dump(file, "eglFilter");
+  option_dump_preset(file);
   fclose(file);
   return true;
 }

--- a/common/include/common/option.h
+++ b/common/include/common/option.h
@@ -102,8 +102,8 @@ bool option_validate(void);
 // print out the options, help, and their current values
 void option_print(void);
 
-// dump the options in ini format into the file
-bool option_dump(FILE * file, const char * module);
+// dump preset options in ini format into the file
+bool option_dump_preset(FILE * file);
 
 // final cleanup
 void option_free(void);

--- a/common/src/option.c
+++ b/common/src/option.c
@@ -758,21 +758,31 @@ void option_print(void)
 }
 
 // dump the options in ini format into the file
-bool option_dump(FILE * file, const char * module)
+bool option_dump_preset(FILE * file)
 {
-  fprintf(file, "[%s]\n", module);
-
-  for (int i = 0; i < state.oCount; ++i)
+  for (int g = 0; g < state.gCount; ++g)
   {
-    struct Option * o = state.options[i];
-    if (strcasecmp(o->module, module) != 0)
+    bool hasPreset = false;
+    for (int i = 0; i < state.groups[g].count; ++i)
+      hasPreset |= state.groups[g].options[i]->preset;
+    if (!hasPreset)
       continue;
-    char * value = o->toString(o);
-    fprintf(file, "%s=%s\n", o->name, value);
-    free(value);
+
+    fprintf(file, "[%s]\n", state.groups[g].module);
+
+    for (int i = 0; i < state.groups[g].count; ++i)
+    {
+      struct Option * o = state.groups[g].options[i];
+      if (!o->preset)
+        continue;
+
+      char * value = o->toString(o);
+      fprintf(file, "%s=%s\n", o->name, value);
+      free(value);
+    }
+    fputc('\n', file);
   }
 
-  fputc('\n', file);
   return true;
 }
 


### PR DESCRIPTION
This new function dumps all options marked as preset instead of dumping
individual sections. This should allow filter options to not be all grouped
into the [eglFilter] section.