### PR TITLE
[client] imgui: run animations at consistent speeds

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -811,6 +811,10 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
   g_state.io->KeyAlt   = g_state.modAlt;
   g_state.io->KeySuper = g_state.modSuper;
 
+  uint64_t now = nanotime();
+  g_state.io->DeltaTime  = (now - g_state.lastImGuiFrame) * 1e-9f;
+  g_state.lastImGuiFrame = now;
+
   igNewFrame();
 
   if (g_state.overlayInput)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -60,6 +60,7 @@ struct AppState
   bool             modShift;
   bool             modAlt;
   bool             modSuper;
+  uint64_t         lastImGuiFrame;
 
   bool        alertShow;
   char      * alertMessage;


### PR DESCRIPTION
Currently, this is visible through how fast the cursor blinks, with it blinking faster at higher refresh rates. This commit makes the timing consistent.