### PR TITLE
[client] imgui: use consistent modal background colours

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -821,7 +821,7 @@ int app_renderOverlay(struct Rect * rects, int maxRects)
   {
     totalDamage = true;
     ImDrawList_AddRectFilled(igGetBackgroundDrawListNil(), (ImVec2) { 0.0f , 0.0f },
-      g_state.io->DisplaySize, 0x66000000, 0, 0);
+      g_state.io->DisplaySize, igGetColorU32Col(ImGuiCol_ModalWindowDimBg, 1.0f), 0, 0);
 
 //    bool test;
 //    igShowDemoWindow(&test);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -823,6 +823,8 @@ static int lg_run(void)
   g_state.io    = igGetIO();
   g_state.style = igGetStyle();
 
+  g_state.style->Colors[ImGuiCol_ModalWindowDimBg] = (ImVec4) { 0.0f, 0.0f, 0.0f, 0.4f };
+
   alloc_sprintf(&g_state.imGuiIni, "%s/imgui.ini", lgConfigDir());
   g_state.io->IniFilename   = g_state.imGuiIni;
   g_state.io->BackendFlags |= ImGuiBackendFlags_HasMouseCursors;


### PR DESCRIPTION
The translucent white modal background sort of cancels out the dark
background we apply to the overlay, which is undesirable. It should
instead further darken the background.

For consistency, we now use igGetColorU32Col(ImGuiCol_ModalWindowDimBg)
to draw the overlay background, to avoid hardcoding the same colour in
multiple places.