### PR TITLE
[all] print out CPU information on startup

### DIFF
--- a/client/src/main.c
+++ b/client/src/main.c
@@ -49,6 +49,7 @@
 #include "common/time.h"
 #include "common/version.h"
 #include "common/paths.h"
+#include "common/cpuinfo.h"
 
 #include "core.h"
 #include "app.h"
@@ -1281,6 +1282,7 @@ int main(int argc, char * argv[])
 
   DEBUG_INFO("Looking Glass (%s)", BUILD_VERSION);
   DEBUG_INFO("Locking Method: " LG_LOCK_MODE);
+  lgDebugCPU();
 
   if (!installCrashHandler("/proc/self/exe"))
     DEBUG_WARN("Failed to install the crash handler");

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -33,6 +33,7 @@ set(COMMON_SOURCES
   src/runningavg.c
   src/ringbuffer.c
   src/vector.c
+  src/cpuinfo.c
 )
 
 add_library(lg_common STATIC ${COMMON_SOURCES})

--- a/common/include/common/cpuinfo.h
+++ b/common/include/common/cpuinfo.h
@@ -1,0 +1,30 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _H_LG_COMMON_CPUINFO_
+#define _H_LG_COMMON_CPUINFO_
+
+#include <stddef.h>
+#include <stdbool.h>
+
+bool lgCPUInfo(char * model, size_t modelSize, int * procs, int * cores);
+void lgDebugCPU(void);
+
+#endif

--- a/common/src/cpuinfo.c
+++ b/common/src/cpuinfo.c
@@ -1,0 +1,38 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/cpuinfo.h"
+#include "common/debug.h"
+
+void lgDebugCPU(void)
+{
+  char model[1024];
+  int procs;
+  int cores;
+
+  if (!lgCPUInfo(model, sizeof model, &procs, &cores))
+  {
+    DEBUG_WARN("Failed to get CPU information");
+    return;
+  }
+
+  DEBUG_INFO("CPU Model: %s", model);
+  DEBUG_INFO("CPU: %d cores, %d threads", cores, procs);
+}

--- a/common/src/platform/linux/CMakeLists.txt
+++ b/common/src/platform/linux/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(lg_common_platform_code STATIC
     time.c
     paths.c
     open.c
+    cpuinfo.c
 )
 
 if(ENABLE_BACKTRACE)

--- a/common/src/platform/linux/cpuinfo.c
+++ b/common/src/platform/linux/cpuinfo.c
@@ -1,0 +1,76 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/cpuinfo.h"
+#include "common/debug.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool lgCPUInfo(char * model, size_t modelSize, int * procs, int * cores)
+{
+  FILE * cpuinfo = fopen("/proc/cpuinfo", "r");
+  if (!cpuinfo)
+  {
+    DEBUG_ERROR("Failed to open /proc/cpuinfo: %s", strerror(errno));
+    return false;
+  }
+
+  if (procs)
+    *procs = 0;
+
+  if (cores)
+    *cores = 0;
+
+  char buffer[1024];
+  while (fgets(buffer, sizeof(buffer), cpuinfo))
+  {
+    if (procs && strncmp(buffer, "processor", 9) == 0)
+      ++*procs;
+    else if (model && strncmp(buffer, "model name", 10) == 0)
+    {
+      const char * name = strstr(buffer, ": ");
+      if (name)
+        name += 2;
+      snprintf(model, modelSize, "%s", name ? name : "Unknown");
+      model = NULL;
+    }
+    else if (cores && strncmp(buffer, "cpu cores", 9) == 0)
+    {
+      const char * num = strstr(buffer, ": ");
+      if (num)
+      {
+        *cores = atoi(num + 2);
+        cores = NULL;
+      }
+    }
+
+    // If a line is too long, skip it.
+    while (buffer[strlen(buffer) - 1] != '\n')
+      if (!fgets(buffer, sizeof(buffer), cpuinfo))
+        goto done;
+  }
+
+done:
+  fclose(cpuinfo);
+  return true;
+}

--- a/common/src/platform/windows/CMakeLists.txt
+++ b/common/src/platform/windows/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(lg_common_platform_code STATIC
     windebug.c
     ivshmem.c
     time.c
+    cpuinfo.c
 )
 
 target_link_libraries(lg_common_platform_code

--- a/common/src/platform/windows/cpuinfo.c
+++ b/common/src/platform/windows/cpuinfo.c
@@ -1,0 +1,94 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "common/cpuinfo.h"
+#include "common/debug.h"
+#include "common/windebug.h"
+
+#include <windows.h>
+
+static void getProcessorCount(int * procs)
+{
+  if (!procs)
+    return;
+
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  *procs = si.dwNumberOfProcessors;
+}
+
+static bool getCPUModel(char * model, size_t modelSize)
+{
+  if (!model)
+    return true;
+
+  LRESULT lr;
+  DWORD cb = modelSize;
+
+  if ((lr = RegGetValueA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\SYSTEM\\CentralProcessor\\0",
+    "ProcessorNameString", RRF_RT_REG_SZ, NULL, model, &cb)))
+  {
+    DEBUG_WINERROR("Failed to query registry", lr);
+    return false;
+  }
+
+  return true;
+}
+
+static bool getCoreCount(int * cores)
+{
+  if (!cores)
+    return true;
+
+  DWORD cb = 0;
+  GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &cb);
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+  {
+    DEBUG_WINERROR("Failed to call GetLogicalProcessorInformationEx", GetLastError());
+    return false;
+  }
+
+  BYTE buffer[cb];
+  if (!GetLogicalProcessorInformationEx(RelationProcessorCore,
+      (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) buffer, &cb))
+  {
+    DEBUG_WINERROR("Failed to call GetLogicalProcessorInformationEx", GetLastError());
+    return false;
+  }
+
+  *cores = 0;
+  DWORD offset = 0;
+  while (offset < cb)
+  {
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX lpi =
+      (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) (buffer + offset);
+    if (lpi->Relationship == RelationProcessorCore)
+      ++*cores;
+    offset += lpi->Size;
+  }
+
+  return true;
+}
+
+bool lgCPUInfo(char * model, size_t modelSize, int * procs, int * cores)
+{
+  getProcessorCount(procs);
+  return getCPUModel(model, modelSize) && getCoreCount(cores);
+}

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -32,6 +32,7 @@
 #include "common/sysinfo.h"
 #include "common/time.h"
 #include "common/stringutils.h"
+#include "common/cpuinfo.h"
 
 #include <lgmp/host.h>
 
@@ -539,6 +540,7 @@ int app_main(int argc, char * argv[])
     return LG_HOST_EXIT_FATAL;
 
   DEBUG_INFO("Looking Glass Host (%s)", BUILD_VERSION);
+  lgDebugCPU();
 
   struct IVSHMEM shmDev = { 0 };
   if (!ivshmemInit(&shmDev))


### PR DESCRIPTION
This is done:

* [x] add `cpuinfo` common library
* [x] implement `cpuinfo` for Linux
* [x] implement `cpuinfo` for Windows
* [x] print CPU information on client startup
* [x] print CPU information on host startup