### PR TITLE
[client] x11: regrab input devices after resuming from sleep

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -148,6 +148,11 @@ static bool waylandGetProp(LG_DSProperty prop, void * ret)
   return false;
 }
 
+static void waylandSystemChanged(void)
+{
+  // do nothing
+}
+
 struct LG_DisplayServerOps LGDS_Wayland =
 {
   .setup               = waylandSetup,
@@ -193,6 +198,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .setFullscreen       = waylandSetFullscreen,
   .getFullscreen       = waylandGetFullscreen,
   .minimize            = waylandMinimize,
+  .systemChanged       = waylandSystemChanged,
 
   .cbInit    = waylandCBInit,
   .cbNotice  = waylandCBNotice,

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1733,7 +1733,17 @@ static void x11Minimize(void)
 
 static void x11SystemChanged(void)
 {
-  // do nothing
+  if (x11.pointerGrabbed)
+  {
+    x11UngrabPointer();
+    x11GrabPointer();
+  }
+
+  if (x11.keyboardGrabbed)
+  {
+    x11UngrabKeyboard();
+    x11GrabKeyboard();
+  }
 }
 
 struct LG_DisplayServerOps LGDS_X11 =

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1731,6 +1731,11 @@ static void x11Minimize(void)
   XIconifyWindow(x11.display, x11.window, XDefaultScreen(x11.display));
 }
 
+static void x11SystemChanged(void)
+{
+  // do nothing
+}
+
 struct LG_DisplayServerOps LGDS_X11 =
 {
   .setup              = x11Setup,
@@ -1773,6 +1778,7 @@ struct LG_DisplayServerOps LGDS_X11 =
   .setFullscreen       = x11SetFullscreen,
   .getFullscreen       = x11GetFullscreen,
   .minimize            = x11Minimize,
+  .systemChanged       = x11SystemChanged,
 
   .cbInit    = x11CBInit,
   .cbNotice  = x11CBNotice,

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -203,6 +203,9 @@ struct LG_DisplayServerOps
   void (*setFullscreen)(bool fs);
   void (*minimize)(void);
 
+  /* called when the system has changed in some way, e.g. resuming from suspend */
+  void (*systemChanged)(void);
+
   /* clipboard support, optional, if not supported set to NULL */
   bool (*cbInit)(void);
   void (*cbNotice)(LG_ClipboardData type);

--- a/contrib/looking-glass-client-suspend.service
+++ b/contrib/looking-glass-client-suspend.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Signal Looking Glass after waking from suspend
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/killall -USR1 looking-glass-client
+
+[Install]
+WantedBy=suspend.target


### PR DESCRIPTION
This is meant to fix issues with input devices not working after resuming from sleep, as reported on discord. This should only be merged once confirmed to fix the issue.

To test this, install the bleeding edge host application and apply this PR as a patch to the source code:

```console
$ curl https://patch-diff.githubusercontent.com/raw/gnif/LookingGlass/pull/832.diff | patch -p1
```

Then build the client. Also install the systemd unit:

```console
# cp contrib/looking-glass-client-suspend.service /etc/systemd/system/
# systemctl enable /etc/systemd/system/looking-glass-client-suspend.service
```

Then, suspend and resume the system, and see if the issue is resolved.