### PR TITLE
[client] spice: stop if pointer left during guest warp

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -440,6 +440,10 @@ void core_handleMouseNormal(double ex, double ey)
         g_cursor.guest.x = msg.x;
         g_cursor.guest.y = msg.y;
         g_cursor.realign = false;
+
+        if (!g_cursor.inWindow)
+          return;
+
         core_setCursorInView(true);
         return;
       }


### PR DESCRIPTION
This prevents attempts to grab the pointer after the guest side warp
finishes if the pointer has left the window in the meantime. On Wayland,
this would result in the pointer moving to the middle of the window when
the confine is created.