### PR TITLE
[host] installer: build 64-bit NSIS installers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Build Windows host installer
       run: |
         cd host\build
-        makensis platform\Windows\installer.nsi
+        makensis -DBUILD_32BIT platform\Windows\installer.nsi
 
   obs:
     runs-on: ubuntu-latest

--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -26,12 +26,16 @@
 
 ;Settings
 Name "Looking Glass (host)"
-OutFile "looking-glass-host-setup.exe" 
+OutFile "looking-glass-host-setup.exe"
 Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"
 ShowUninstDetails "show"
 InstallDir "$PROGRAMFILES64\Looking Glass (host)"
+
+!ifndef BUILD_32BIT
+Target AMD64-Unicode
+!endif
 
 !define MUI_ICON "icon.ico"
 !define MUI_UNICON "icon.ico"


### PR DESCRIPTION
The host is a 64-bit application, so requiring 64-bit Windows isn't an
issue. However, not using 32-bit installers has an advantage: we don't
need to require WoW64.

Please test [looking-glass-host-setup.zip](https://github.com/gnif/LookingGlass/files/7202713/looking-glass-host-setup.zip) (requires bleeding edge client).