### PR TITLE
[host] nvfbc: avoid waking up pointer thread for no reason

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -573,10 +573,9 @@ static CaptureResult nvfbc_getFrame(FrameBuffer * frame,
 
 static int pointerThread(void * unused)
 {
-  while(!this->stop)
+  while (!this->stop)
   {
-    if (!lgWaitEvent(this->cursorEvent, 1000))
-      continue;
+    lgWaitEvent(this->cursorEvent, TIMEOUT_INFINITE);
 
     if (this->stop)
       break;


### PR DESCRIPTION
If the wait times out, we used to simply restart the loop, which causes it to check `this->stop` and exit if set to `true`. However, `nvfbc_stop` already calls `lgSignalEvent`, which would wake up the pointer thread to perform the check, so there is no need to set a timeout on the wait.