### PR TITLE
[client] x11: load glXSwapIntervalEXT dynamically

### DIFF
--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1315,6 +1315,14 @@ static void x11GLMakeCurrent(LG_DSGLContext context)
 
 static void x11GLSetSwapInterval(int interval)
 {
+  static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = NULL;
+  if (!glXSwapIntervalEXT)
+  {
+    glXSwapIntervalEXT = (PFNGLXSWAPINTERVALEXTPROC) glXGetProcAddressARB(
+        (const GLubyte *) "glXSwapIntervalEXT");
+    if (!glXSwapIntervalEXT)
+      DEBUG_FATAL("Failed to load glXSwapIntervalEXT");
+  }
   glXSwapIntervalEXT(x11.display, x11.window, interval);
 }
 


### PR DESCRIPTION
The Linux OpenGL ABI does not guarantee that glXSwapIntervalEXT will be
exported statically from any library, and indeed on some systems this
function does not link at load time, e.g. with amdgpu-pro. All other
GLX functions that we use are from GLX 1.0, which is guaranteed to be
exported statically.

This commit solves this issue by using glXGetProcAddressARB to load the
function. Note that only the ARB version of glXGetProcAddress is
guaranteed to exist by the Linux OpenGL ABI, which is why we must use
it.