### PR TITLE
[client] egl: use eglCreateImage and eglDestroyImage indirectly

### DIFF
--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -23,33 +23,21 @@
 #ifdef ENABLE_EGL
 
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
+#undef GL_KHR_debug
 #include <GLES3/gl3.h>
 #include <GLES2/gl2ext.h>
 
-typedef EGLDisplay (*eglGetPlatformDisplayEXT_t)(EGLenum platform,
-    void *native_display, const EGLint *attrib_list);
-typedef EGLBoolean (*eglSwapBuffersWithDamageKHR_t)(EGLDisplay dpy,
-    EGLSurface surface, const EGLint *rects, EGLint n_rects);
-typedef void (*glEGLImageTargetTexture2DOES_t)(GLenum target,
-    GLeglImageOES image);
-typedef void (*DEBUGPROC_t)(GLenum source,
-    GLenum type, GLuint id, GLenum severity, GLsizei length,
-    const GLchar *message, const void *userParam);
-typedef void (*glDebugMessageCallback_t)(DEBUGPROC_t callback,
-    const void * userParam);
-typedef void (*glBufferStorageEXT_t)(GLenum target, GLsizeiptr size,
-    const void * data, GLbitfield flags);
-
 struct EGLDynProcs
 {
-  eglGetPlatformDisplayEXT_t     eglGetPlatformDisplay;
-  eglGetPlatformDisplayEXT_t     eglGetPlatformDisplayEXT;
-  eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageKHR;
-  eglSwapBuffersWithDamageKHR_t  eglSwapBuffersWithDamageEXT;
-  glEGLImageTargetTexture2DOES_t glEGLImageTargetTexture2DOES;
-  glDebugMessageCallback_t       glDebugMessageCallback;
-  glDebugMessageCallback_t       glDebugMessageCallbackKHR;
-  glBufferStorageEXT_t           glBufferStorageEXT;
+  PFNEGLGETPLATFORMDISPLAYPROC        eglGetPlatformDisplay;
+  PFNEGLGETPLATFORMDISPLAYPROC        eglGetPlatformDisplayEXT;
+  PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC  eglSwapBuffersWithDamageKHR;
+  PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC  eglSwapBuffersWithDamageEXT;
+  PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
+  PFNGLDEBUGMESSAGECALLBACKKHRPROC    glDebugMessageCallback;
+  PFNGLDEBUGMESSAGECALLBACKKHRPROC    glDebugMessageCallbackKHR;
+  PFNGLBUFFERSTORAGEEXTPROC           glBufferStorageEXT;
 };
 
 extern struct EGLDynProcs g_egl_dynProcs;

--- a/client/include/egl_dynprocs.h
+++ b/client/include/egl_dynprocs.h
@@ -38,6 +38,8 @@ struct EGLDynProcs
   PFNGLDEBUGMESSAGECALLBACKKHRPROC    glDebugMessageCallback;
   PFNGLDEBUGMESSAGECALLBACKKHRPROC    glDebugMessageCallbackKHR;
   PFNGLBUFFERSTORAGEEXTPROC           glBufferStorageEXT;
+  PFNEGLCREATEIMAGEPROC               eglCreateImage;
+  PFNEGLDESTROYIMAGEPROC              eglDestroyImage;
 };
 
 extern struct EGLDynProcs g_egl_dynProcs;

--- a/client/include/eglutil.h
+++ b/client/include/eglutil.h
@@ -23,14 +23,14 @@
 
 #include <stdbool.h>
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 
 #include "common/types.h"
-#include "egl_dynprocs.h"
 
 struct SwapWithDamageData
 {
   bool init;
-  eglSwapBuffersWithDamageKHR_t func;
+  PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC func;
 };
 
 void swapWithDamageInit(struct SwapWithDamageData * data, EGLDisplay display);

--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -781,15 +781,16 @@ static bool egl_renderStartup(LG_Renderer * renderer, bool useDMA)
   if (!this->hasBufferAge)
     DEBUG_WARN("GL_EXT_buffer_age is not supported, will not perform as well.");
 
-  if (g_egl_dynProcs.glEGLImageTargetTexture2DOES)
-  {
-    if (util_hasGLExt(client_exts, "EGL_EXT_image_dma_buf_import"))
-      this->dmaSupport = true;
-    else
-      DEBUG_INFO("EGL_EXT_image_dma_buf_import unavailable, DMA support disabled");
-  }
-  else
+  if (!g_egl_dynProcs.glEGLImageTargetTexture2DOES)
     DEBUG_INFO("glEGLImageTargetTexture2DOES unavilable, DMA support disabled");
+  else if (!g_egl_dynProcs.eglCreateImage || !g_egl_dynProcs.eglDestroyImage)
+    DEBUG_INFO("eglCreateImage or eglDestroyImage unavailable, DMA support disabled");
+  else if (!util_hasGLExt(client_exts, "EGL_EXT_image_dma_buf_import"))
+    DEBUG_INFO("EGL_EXT_image_dma_buf_import unavailable, DMA support disabled");
+  else if ((maj < 1 || (maj == 1 && min < 5)) && !util_hasGLExt(client_exts, "EGL_KHR_image_base"))
+    DEBUG_INFO("Need EGL 1.5+ or EGL_KHR_image_base for eglCreateImage(KHR)");
+  else
+    this->dmaSupport = true;
 
   if (!this->dmaSupport)
     useDMA = false;

--- a/client/renderers/EGL/texture_dmabuf.c
+++ b/client/renderers/EGL/texture_dmabuf.c
@@ -132,7 +132,7 @@ static bool egl_texDMABUFUpdate(EGL_Texture * texture,
       EGL_NONE                     , EGL_NONE
     };
 
-    image = eglCreateImage(
+    image = g_egl_dynProcs.eglCreateImage(
         this->display,
         EGL_NO_CONTEXT,
         EGL_LINUX_DMA_BUF_EXT,
@@ -151,7 +151,7 @@ static bool egl_texDMABUFUpdate(EGL_Texture * texture,
     }))
     {
       DEBUG_ERROR("Failed to store EGLImage");
-      eglDestroyImage(this->display, image);
+      g_egl_dynProcs.eglDestroyImage(this->display, image);
       return false;
     }
   }

--- a/client/src/egl_dynprocs.c
+++ b/client/src/egl_dynprocs.c
@@ -26,21 +26,21 @@ struct EGLDynProcs g_egl_dynProcs = {0};
 
 void egl_dynProcsInit(void)
 {
-  g_egl_dynProcs.eglGetPlatformDisplay = (eglGetPlatformDisplayEXT_t)
+  g_egl_dynProcs.eglGetPlatformDisplay = (PFNEGLGETPLATFORMDISPLAYPROC)
     eglGetProcAddress("eglGetPlatformDisplay");
-  g_egl_dynProcs.eglGetPlatformDisplayEXT = (eglGetPlatformDisplayEXT_t)
+  g_egl_dynProcs.eglGetPlatformDisplayEXT = (PFNEGLGETPLATFORMDISPLAYPROC)
     eglGetProcAddress("eglGetPlatformDisplayEXT");
-  g_egl_dynProcs.glEGLImageTargetTexture2DOES = (glEGLImageTargetTexture2DOES_t)
+  g_egl_dynProcs.glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)
     eglGetProcAddress("glEGLImageTargetTexture2DOES");
-  g_egl_dynProcs.eglSwapBuffersWithDamageKHR = (eglSwapBuffersWithDamageKHR_t)
+  g_egl_dynProcs.eglSwapBuffersWithDamageKHR = (PFNEGLSWAPBUFFERSWITHDAMAGEKHRPROC)
     eglGetProcAddress("eglSwapBuffersWithDamageKHR");
-  g_egl_dynProcs.eglSwapBuffersWithDamageEXT = (eglSwapBuffersWithDamageKHR_t)
+  g_egl_dynProcs.eglSwapBuffersWithDamageEXT = (PFNEGLSWAPBUFFERSWITHDAMAGEEXTPROC)
     eglGetProcAddress("eglSwapBuffersWithDamageEXT");
-  g_egl_dynProcs.glDebugMessageCallback = (glDebugMessageCallback_t)
+  g_egl_dynProcs.glDebugMessageCallback = (PFNGLDEBUGMESSAGECALLBACKKHRPROC)
     eglGetProcAddress("glDebugMessageCallback");
-  g_egl_dynProcs.glDebugMessageCallbackKHR = (glDebugMessageCallback_t)
+  g_egl_dynProcs.glDebugMessageCallbackKHR = (PFNGLDEBUGMESSAGECALLBACKKHRPROC)
     eglGetProcAddress("glDebugMessageCallbackKHR");
-  g_egl_dynProcs.glBufferStorageEXT = (glBufferStorageEXT_t)
+  g_egl_dynProcs.glBufferStorageEXT = (PFNGLBUFFERSTORAGEEXTPROC)
     eglGetProcAddress("glBufferStorageEXT");
 };
 

--- a/client/src/egl_dynprocs.c
+++ b/client/src/egl_dynprocs.c
@@ -42,6 +42,17 @@ void egl_dynProcsInit(void)
     eglGetProcAddress("glDebugMessageCallbackKHR");
   g_egl_dynProcs.glBufferStorageEXT = (PFNGLBUFFERSTORAGEEXTPROC)
     eglGetProcAddress("glBufferStorageEXT");
+  g_egl_dynProcs.eglCreateImage = (PFNEGLCREATEIMAGEPROC)
+    eglGetProcAddress("eglCreateImage");
+  g_egl_dynProcs.eglDestroyImage = (PFNEGLDESTROYIMAGEPROC)
+    eglGetProcAddress("eglDestroyImage");
+
+  if (!g_egl_dynProcs.eglCreateImage)
+    g_egl_dynProcs.eglCreateImage = (PFNEGLCREATEIMAGEPROC)
+      eglGetProcAddress("eglCreateImageKHR");
+  if (!g_egl_dynProcs.eglDestroyImage)
+    g_egl_dynProcs.eglDestroyImage = (PFNEGLDESTROYIMAGEPROC)
+      eglGetProcAddress("eglDestroyImageKHR");
 };
 
 #endif


### PR DESCRIPTION
The dmabuf path is optional, so we shouldn't require those functions to link our program.

In this PR, we also switch to using the prototypes defined in EGL and GLES headers instead of defining them ourselves.