### PR TITLE
[client] opengl: indirectly access non-OpenGL 1.3 functions 

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -111,6 +111,7 @@ set(SOURCES
 	src/util.c
 	src/clipboard.c
 	src/kb.c
+	src/gl_dynprocs.c
 	src/egl_dynprocs.c
 	src/eglutil.c
 	src/overlay_utils.c

--- a/client/include/gl_dynprocs.h
+++ b/client/include/gl_dynprocs.h
@@ -1,0 +1,50 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifndef _H_LG_GL_DYNPROCS_
+#define _H_LG_GL_DYNPROCS_
+#ifdef ENABLE_OPENGL
+
+#include <GL/gl.h>
+#include <GL/glext.h>
+
+struct GLDynProcs
+{
+  PFNGLGENBUFFERSPROC     glGenBuffers;
+  PFNGLBINDBUFFERPROC     glBindBuffer;
+  PFNGLBUFFERDATAPROC     glBufferData;
+  PFNGLBUFFERSUBDATAPROC  glBufferSubData;
+  PFNGLDELETEBUFFERSPROC  glDeleteBuffers;
+  PFNGLISSYNCPROC         glIsSync;
+  PFNGLFENCESYNCPROC      glFenceSync;
+  PFNGLCLIENTWAITSYNCPROC glClientWaitSync;
+  PFNGLDELETESYNCPROC     glDeleteSync;
+  PFNGLGENERATEMIPMAPPROC glGenerateMipmap;
+};
+
+extern struct GLDynProcs g_gl_dynProcs;
+
+void gl_dynProcsInit(void);
+
+#else
+  #define gl_dynProcsInit(...)
+#endif
+
+#endif // _H_LG_GL_DYNPROCS_

--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -401,22 +401,16 @@ bool opengl_renderStartup(LG_Renderer * renderer, bool useDMA)
   DEBUG_INFO("Renderer: %s", glGetString(GL_RENDERER));
   DEBUG_INFO("Version : %s", glGetString(GL_VERSION ));
 
-  GLint n;
-  glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-  for(GLint i = 0; i < n; ++i)
+  const char * exts = (const char *)glGetString(GL_EXTENSIONS);
+  if (util_hasGLExt(exts, "GL_AMD_pinned_memory"))
   {
-    const GLubyte *ext = glGetStringi(GL_EXTENSIONS, i);
-    if (strcmp((const char *)ext, "GL_AMD_pinned_memory") == 0)
+    if (this->opt.amdPinnedMem)
     {
-      if (this->opt.amdPinnedMem)
-      {
-        this->amdPinnedMemSupport = true;
-        DEBUG_INFO("Using GL_AMD_pinned_memory");
-      }
-      else
-        DEBUG_INFO("GL_AMD_pinned_memory is available but not in use");
-      break;
+      this->amdPinnedMemSupport = true;
+      DEBUG_INFO("Using GL_AMD_pinned_memory");
     }
+    else
+      DEBUG_INFO("GL_AMD_pinned_memory is available but not in use");
   }
 
   glEnable(GL_TEXTURE_2D);

--- a/client/src/gl_dynprocs.c
+++ b/client/src/gl_dynprocs.c
@@ -1,0 +1,58 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2021 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#ifdef ENABLE_OPENGL
+
+#include "gl_dynprocs.h"
+#include <GL/glx.h>
+
+struct GLDynProcs g_gl_dynProcs = {0};
+
+
+static void * getProcAddressGL(const char * name)
+{
+  return (void *) glXGetProcAddressARB((const GLubyte *) name);
+}
+
+static void * setProcAddressGL2(const char * name, const char * backup)
+{
+  void * func = getProcAddressGL(name);
+  return func ? func : getProcAddressGL(backup);
+}
+
+void gl_dynProcsInit(void)
+{
+  g_gl_dynProcs.glGenBuffers    = setProcAddressGL2("glGenBuffers", "glGenBuffersARB");
+  g_gl_dynProcs.glBindBuffer    = setProcAddressGL2("glBindBuffer", "glBindBufferARB");
+  g_gl_dynProcs.glBufferData    = setProcAddressGL2("glBufferData", "glBufferDataARB");
+  g_gl_dynProcs.glBufferSubData = setProcAddressGL2("glBufferSubData", "glBufferSubDataARB");
+  g_gl_dynProcs.glDeleteBuffers = setProcAddressGL2("glDeleteBuffers", "glDeleteBuffersARB");
+
+  g_gl_dynProcs.glIsSync         = getProcAddressGL("glIsSync");
+  g_gl_dynProcs.glFenceSync      = getProcAddressGL("glFenceSync");
+  g_gl_dynProcs.glClientWaitSync = getProcAddressGL("glClientWaitSync");
+  g_gl_dynProcs.glDeleteSync     = getProcAddressGL("glDeleteSync");
+
+  g_gl_dynProcs.glGenerateMipmap = getProcAddressGL("glGenerateMipmap");
+  if (!g_gl_dynProcs.glGenerateMipmap)
+    g_gl_dynProcs.glGenerateMipmap = getProcAddressGL("glGenerateMipmapEXT");
+};
+
+#endif

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -58,6 +58,7 @@
 #include "kb.h"
 #include "ll.h"
 #include "egl_dynprocs.h"
+#include "gl_dynprocs.h"
 #include "overlays.h"
 #include "overlay_utils.h"
 #include "util.h"
@@ -1297,6 +1298,7 @@ int main(int argc, char * argv[])
   config_init();
   ivshmemOptionsInit();
   egl_dynProcsInit();
+  gl_dynProcsInit();
 
   g_state.overlays = ll_new();
   app_registerOverlay(&LGOverlayConfig, NULL);


### PR DESCRIPTION
This PR adds the `gl_dynprocs` module, which is similar to `egl_dynprocs`, except for OpenGL functions. We then add a check for the extensions that we need and then calls the functions indirectly through `gl_dynprocs`.

This should improve compatibility with older versions of OpenGL, as we now fallback to the ARB extensions if possible, and in the case of `glGenerateMipmap`, we can handle the function not existing at all.