### PR TITLE
[client] wayland: implement resizing for libdecor

### DIFF
--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -76,7 +76,7 @@ static void libdecorFrameConfigure(struct libdecor_frame * frame,
     app_invalidateWindow(true);
     waylandStopWaitFrame();
   }
-  else 
+  else
     wlWm.configured = true;
 }
 

--- a/client/displayservers/Wayland/shell_libdecor.c
+++ b/client/displayservers/Wayland/shell_libdecor.c
@@ -51,9 +51,6 @@ static void libdecorHandleError(struct libdecor * context, enum libdecor_error e
 static void libdecorFrameConfigure(struct libdecor_frame * frame,
     struct libdecor_configuration * configuration, void * opaque)
 {
-  if (wlWm.needsResize)
-    return;
-
   int width, height;
   if (libdecor_configuration_get_content_size(configuration, frame, &width, &height)) 
   {

--- a/client/displayservers/Wayland/shell_xdg.c
+++ b/client/displayservers/Wayland/shell_xdg.c
@@ -87,7 +87,7 @@ static const struct xdg_toplevel_listener xdgToplevelListener = {
   .close     = xdgToplevelClose,
 };
 
-bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless)
+bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
   if (!wlWm.xdgWmBase)
   {
@@ -152,4 +152,8 @@ bool waylandGetFullscreen(void)
 void waylandMinimize(void)
 {
   xdg_toplevel_set_minimized(wlWm.xdgToplevel);
+}
+
+void waylandShellResize(int w, int h)
+{
 }

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -98,7 +98,7 @@ static bool waylandInit(const LG_DSInitParams params)
   if (!waylandInputInit())
     return false;
 
-  if (!waylandWindowInit(params.title, params.fullscreen, params.maximize, params.borderless))
+  if (!waylandWindowInit(params.title, params.fullscreen, params.maximize, params.borderless, params.resizable))
     return false;
 
   if (!waylandEGLInit(params.w, params.h))

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -306,14 +306,15 @@ bool waylandRegistryInit(void);
 void waylandRegistryFree(void);
 
 // shell module
-bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless);
+bool waylandShellInit(const char * title, bool fullscreen, bool maximize, bool borderless, bool resizable);
 void waylandShellAckConfigureIfNeeded(void);
 void waylandSetFullscreen(bool fs);
 bool waylandGetFullscreen(void);
 void waylandMinimize(void);
+void waylandShellResize(int w, int h);
 
 // window module
-bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless);
+bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless, bool resizable);
 void waylandWindowFree(void);
 void waylandWindowUpdateScale(void);
 void waylandSetWindowSize(int x, int y);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -79,7 +79,7 @@ static const struct wl_surface_listener wlSurfaceListener = {
   .leave = wlSurfaceLeaveHandler,
 };
 
-bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless)
+bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
   wlWm.scale = wl_fixed_from_int(1);
 
@@ -106,7 +106,7 @@ bool waylandWindowInit(const char * title, bool fullscreen, bool maximize, bool 
 
   wl_surface_add_listener(wlWm.surface, &wlSurfaceListener, NULL);
 
-  if (!waylandShellInit(title, fullscreen, maximize, borderless))
+  if (!waylandShellInit(title, fullscreen, maximize, borderless, resizable))
     return false;
 
   wl_surface_commit(wlWm.surface);
@@ -121,7 +121,7 @@ void waylandWindowFree(void)
 
 void waylandSetWindowSize(int x, int y)
 {
-  // FIXME: implement.
+    waylandShellResize(x, y);
 }
 
 bool waylandIsValidPointerPos(int x, int y)


### PR DESCRIPTION
# Summary
* Adds autoresize to LG client when running on Wayland with libdecor.
* Fixes an issue where the client would launch pinned to the top left of the display (below GNOME's status bar) as in the screenshot:
![image](https://user-images.githubusercontent.com/7147264/135767382-78b64963-916a-4edd-af1c-7f568e4c9307.png)

# Known Issues
* Occasional segfault during resize when moving quickly. Cause appears to be a race condition between resizes from the main render thread and those incoming from the user. Workaround for now is to disable win:forceAspect.

Tested on Fedora 34, GNOME 40.4