### PR TITLE
[client] X11: skip Leave event generated by FocusIn

### DIFF
--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -987,7 +987,8 @@ static void x11XInputEvent(XGenericEventCookie *cookie)
       atomic_store(&x11.lastWMEvent, microtime());
       XILeaveEvent *xie = cookie->data;
       if (!x11.entered || xie->event != x11.window ||
-          button_state != 0 || app_isCaptureMode())
+          button_state != 0 || app_isCaptureMode() ||
+          xie->detail == XINotifyAncestor)
         return;
 
       app_updateCursorPos(xie->event_x, xie->event_y);


### PR DESCRIPTION
Fixes #856 
Not sure if this is correct way to solve this issue, because i can't find what exactly these event detail mean.
Alternatively Enter Event can be fixed, to work after Focus event, but I don't understand code enough to fix it.