### PR TITLE
[client] Change default grabKeyboardOnFocus to false

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -291,7 +291,7 @@ static struct Option options[] =
     .name           = "grabKeyboardOnFocus",
     .description    = "Grab the keyboard when focused",
     .type           = OPTION_TYPE_BOOL,
-    .value.x_bool   = true,
+    .value.x_bool   = false,
   },
   {
     .module         = "input",

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -470,7 +470,7 @@ The following is a complete list of options accepted by this application
   +==============================+=======+=====================+==================================================================================+
   | input:grabKeyboard           | -G    | yes                 | Grab the keyboard in capture mode                                                |
   +------------------------------+-------+---------------------+----------------------------------------------------------------------------------+
-  | input:grabKeyboardOnFocus    |       | yes                 | Grab the keyboard when focused                                                   |
+  | input:grabKeyboardOnFocus    |       | no                  | Grab the keyboard when focused                                                   |
   +------------------------------+-------+---------------------+----------------------------------------------------------------------------------+
   | input:releaseKeysOnFocusLoss |       | yes                 | On focus loss, send key up events to guest for all held keys                     |
   +------------------------------+-------+---------------------+----------------------------------------------------------------------------------+


### PR DESCRIPTION
As per gnif comment on Discord, modify `grabKeyboardOnFocus` default value to false for B5