### PR TITLE
[client] egl: miscellaneous fixes in buffer age related code

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -54,7 +54,7 @@
 #define MAX_BUFFER_AGE       3
 #define DESKTOP_DAMAGE_COUNT 4
 #define MAX_ACCUMULATED_DAMAGE ((KVMFR_MAX_DAMAGE_RECTS + MAX_OVERLAY_RECTS + 2) * MAX_BUFFER_AGE)
-#define IDX_AGO(counter, i, total) ((counter) + (total) - i) % (total)
+#define IDX_AGO(counter, i, total) (((counter) + (total) - (i)) % (total))
 
 struct Options
 {


### PR DESCRIPTION
Fixes:

* [x] erasure artifacts in the letterbox at some locations
* [x] naming of `egl_bufferAge`
* [x] parentheses in `IDX_AGO` definition that might break in presence of more complex arguments

Note that this PR does not fix the desktop artifacts reported by some users.