### PR TITLE
[host] windows: fix NSIS install directory on 64-bit builds

### DIFF
--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -31,10 +31,12 @@ Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"
 ShowUninstDetails "show"
-InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 
 !ifndef BUILD_32BIT
 Target AMD64-Unicode
+InstallDir "$PROGRAMFILES\Looking Glass (host)"
+!else
+InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 !endif
 
 !define MUI_ICON "icon.ico"


### PR DESCRIPTION
This is probably an NSIS bug.