### PR TITLE
[client] egl: skip downscale filter setup when not enabled

### DIFF
--- a/client/renderers/EGL/filter_downscale.c
+++ b/client/renderers/EGL/filter_downscale.c
@@ -333,6 +333,9 @@ static bool egl_filterDownscaleSetup(EGL_Filter * filter,
   width  = (float)width  / this->pixelSize;
   height = (float)height / this->pixelSize;
 
+  if (!this->enable)
+    return false;
+
   if (this->prepared               &&
       pixFmt       == this->pixFmt &&
       this->width  == width        &&


### PR DESCRIPTION
Since this->prepared will never be set to true unless the filter is
enabled, this results in the framebuffer setup being done every frame
for no reason, causing a lot of texture reallocations.