### PR TITLE
[common] time: fixed time values in nsleep

### DIFF
--- a/common/include/common/time.h
+++ b/common/include/common/time.h
@@ -61,8 +61,8 @@ static inline void nsleep(uint64_t ns)
 #else
   const struct timespec ts =
   {
-    .tv_sec  = ns / 1e9,
-    .tv_nsec = ns - ((ns / 1e9) * 1e9)
+    .tv_sec  = ns / 1000000000,
+    .tv_nsec = ns % 1000000000,
   };
   nanosleep(&ts, NULL);
 #endif


### PR DESCRIPTION
Time values of scientific notation replaced with expanded values
and `tv_nsec` simplified with modulo