### PR TITLE
[client] egl: use linear filter when not scaling

### DIFF
--- a/client/renderers/EGL/desktop.c
+++ b/client/renderers/EGL/desktop.c
@@ -400,11 +400,11 @@ bool egl_desktopRender(EGL_Desktop * desktop, unsigned int outputWidth,
     case EGL_SCALE_AUTO:
       switch (scaleType)
       {
-        case EGL_DESKTOP_NOSCALE:
         case EGL_DESKTOP_UPSCALE:
           scaleAlgo = EGL_SCALE_NEAREST;
           break;
 
+        case EGL_DESKTOP_NOSCALE:
         case EGL_DESKTOP_DOWNSCALE:
           scaleAlgo = EGL_SCALE_LINEAR;
           break;


### PR DESCRIPTION
This appears to eliminate artifacts related to non-full screen paints
due to precision errors with the nearest filter.