### PR TITLE
[all] cmake: fail if wrong submodule version is checked out

### DIFF
--- a/cmake/CheckSubmodule.cmake
+++ b/cmake/CheckSubmodule.cmake
@@ -6,3 +6,14 @@ if (EXISTS "${PROJECT_TOP}/.git" AND (
 ))
     message(FATAL_ERROR "Submodules are not initialized. Run\n\tgit submodule update --init --recursive")
 endif()
+
+if (EXISTS "${PROJECT_TOP}/.git" AND NOT DEFINED DEVELOPER)
+    execute_process(
+        COMMAND git submodule summary
+        WORKING_DIRECTORY "${PROJECT_TOP}"
+        OUTPUT_VARIABLE SUBMODULE_SUMMARY
+    )
+    if (NOT "${SUBMODULE_SUMMARY}" STREQUAL "")
+       message(FATAL_ERROR "Wrong submodule version checked out. Run\n\tgit submodule update --init --recursive")
+    endif()
+endif()


### PR DESCRIPTION
This runs `git submodule summary` and fails the build if there is any
output. For developers, use `cmake -DDEVELOPER=yes` to bypass this
check.