### PR TITLE
[client] wayland: make cursor change work without wl_pointer

### DIFF
--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -217,5 +217,6 @@ void waylandSetPointer(LG_DSPointer pointer)
   wlWm.cursor     = wlWm.cursors[pointer];
   wlWm.cursorHotX = wlWm.cursorHot[pointer].x;
   wlWm.cursorHotY = wlWm.cursorHot[pointer].y;
-  wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, wlWm.cursor, wlWm.cursorHotX, wlWm.cursorHotY);
+  if (wlWm.pointer)
+    wl_pointer_set_cursor(wlWm.pointer, wlWm.pointerEnterSerial, wlWm.cursor, wlWm.cursorHotX, wlWm.cursorHotY);
 }

--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -304,6 +304,7 @@ static void handlePointerCapability(uint32_t capabilities)
   {
     wlWm.pointer = wl_seat_get_pointer(wlWm.seat);
     wl_pointer_add_listener(wlWm.pointer, &pointerListener, NULL);
+    waylandSetPointer(wlWm.cursorId);
   }
 }
 

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -95,6 +95,9 @@ static bool waylandInit(const LG_DSInitParams params)
   if (!waylandPresentationInit())
     return false;
 
+  if (!waylandCursorInit())
+    return false;
+
   if (!waylandInputInit())
     return false;
 
@@ -102,9 +105,6 @@ static bool waylandInit(const LG_DSInitParams params)
     return false;
 
   if (!waylandEGLInit(params.w, params.h))
-    return false;
-
-  if (!waylandCursorInit())
     return false;
 
 #ifdef ENABLE_OPENGL


### PR DESCRIPTION
This is a bug reported by @Xyene, who should confirm it has fixed his issue.