### PR TITLE
[client] input: fix race between window size and guest cursor

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -268,6 +268,19 @@ void core_updatePositionInfo(void)
   {
     g_state.posInfoValid = true;
     g_state.ds->realignPointer();
+
+    // g_cursor.guest.valid could have become true in the meantime.
+    if (g_cursor.guest.valid)
+    {
+      // Since posInfoValid was false, core_handleGuestMouseUpdate becomes a
+      // noop when called on the cursor thread, which means we need to call it
+      // again in order for the cursor to show up.
+      core_handleGuestMouseUpdate();
+
+      // Similarly, the position needs to be valid before the initial mouse
+      // move, otherwise we wouldn't know if the cursor is in the viewport.
+      app_handleMouseRelative(0.0, 0.0, 0.0, 0.0);
+    }
   }
 
 done:


### PR DESCRIPTION
`g_state.posInfoValid` could become valid after the guest reports the
cursor position, in which case we did not show the cursor until another
update occurs.

This commit eliminates the race by performing the update when
`g_state.posInfoValid` becomes true.