### PR TITLE
[host] installer: add ability to install IVSHMEM driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,11 @@ jobs:
       run: |
         cd host/build
         makensis platform/Windows/installer.nsi
+    - name: Build Windows host installer with IVSHMEM drivers
+      run: |
+        cd host/build
+        curl https://dl.quantum2.xyz/ivshmem.tar.gz | tar xz
+        makensis -DIVSHMEM platform/Windows/installer.nsi
 
   host-windows-native:
     runs-on: windows-latest

--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -98,7 +98,7 @@ Function .onInit
   StrCpy $option_noservice     0
 
   Push $R0
-    
+
   ${GetOptions} $cmdLineParams '/startmenu' $R0
   IfErrors +2 0
   StrCpy $option_startMenu 1
@@ -184,7 +184,7 @@ SectionEnd
 
 Section "-Hidden Start Menu" Section5
   SetShellVarContext all
-  
+
   ${If} $option_startMenu == 1
     CreateDirectory "$APPDATA\Looking Glass (host)"
     CreateDirectory "$SMPROGRAMS\Looking Glass (host)"
@@ -195,7 +195,6 @@ Section "-Hidden Start Menu" Section5
   ${If} $option_desktop == 1
     CreateShortCut "$DESKTOP\Looking Glass (host).lnk" $INSTDIR\looking-glass-host.exe
   ${EndIf}
-  
 SectionEnd
 
 Section "Uninstall" Section6
@@ -211,6 +210,7 @@ Section "Uninstall" Section6
   Delete "$DESKTOP\Looking Glass (host).lnk"
   Delete "$INSTDIR\uninstaller.exe"
   Delete "$INSTDIR\looking-glass-host.exe"
+  Delete "$INSTDIR\looking-glass-host.pdb"
   Delete "$INSTDIR\LICENSE.txt"
 
   RMDir $INSTDIR


### PR DESCRIPTION
To use this, run `makensis` with `-DIVSHMEM` with the driver files in the
`ivshmem` subdirectory under the build directory.

Preview:
![NSIS installer](https://user-images.githubusercontent.com/461885/147396026-a99aa218-49aa-4714-bdf7-e46cc4a666b4.png)
