### PR TITLE
[all] gitignore: ignore __pycache__ and *.py[co]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ module/modules.order
 *.o
 *.exe
 */build
+__pycache__
+*.py[co]


### PR DESCRIPTION
This prevents accidental commits of the compiled spellchecker.