### PR TITLE
[host] installer: enable DPI awareness

### DIFF
--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -31,6 +31,7 @@ Unicode true
 RequestExecutionLevel admin
 ShowInstDetails "show"
 ShowUninstDetails "show"
+ManifestDPIAware true
 
 !ifndef BUILD_32BIT
 Target AMD64-Unicode


### PR DESCRIPTION
This should make the installer look less blurry on high DPI displays.

Here's an example on 125% scale:

### Before
![Blurry installer](https://user-images.githubusercontent.com/461885/147396080-c21f6aca-e4e9-4737-98cf-5ac17748c021.png)

### After
![Not blurry text in installer](https://user-images.githubusercontent.com/461885/147396083-e5ca94e1-7879-4144-b0a8-a841f7ed4abf.png)
