### PR TITLE
[docs] all: Switch to sphinx-readthedocs-theme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
         sudo apt-get update
     - name: Install docs dependencies
       run: |
-        sudo apt-get install python3-sphinx
+        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme
         sudo pip3 install sphinxcontrib-spelling
     - name: Build docs
       run: |

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ https://looking-glass.io/downloads
 Source code for the documentation can be found in the `/doc` directory.
 
 You may view this locally as HTML by running `make html` with `python3-sphinx`
-installed.
+and `python3-sphinx-rtd-theme` installed.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ rst_prolog = """
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
 ]
 
 try:
@@ -68,11 +69,11 @@ master_doc = 'index'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 html_theme_options = {
-    'logo': 'icon-128x128.png',
-    'fixed_sidebar': 'true',
+    'logo_only': True,
+    'style_nav_header_background': 'transparent',
 }
 
 html_sidebars = {
@@ -86,7 +87,9 @@ html_sidebars = {
 
 html_favicon = '../resources/icon.ico'
 
+html_logo = '../resources/icon-128x128.png'
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['../resources/icon-128x128.png']
+html_static_path = []


### PR DESCRIPTION
From https://github.com/readthedocs/sphinx_rtd_theme

Before this is merged, the debian package `python3-sphinx-rtd-theme` should be installed on the build server

![Screenshot_20211226_033447](https://user-images.githubusercontent.com/5211576/147396743-25c6d3f3-c6a2-4669-a53f-71fead345193.png) ![Screenshot_20211226_034415](https://user-images.githubusercontent.com/5211576/147396756-eeb4f383-cb6a-46f7-811e-662417b30a2d.png)

