### PR TITLE
[doc] conf: Fix typo in release git-describe command

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ except IOError:
     import subprocess
     try:
         release = subprocess.check_output([
-            'gist', 'describe', '--always', '--abbrev=10', '--dirty=+', '--tags'
+            'git', 'describe', '--always', '--abbrev=10', '--dirty=+', '--tags'
         ]).decode('utf-8').strip()
     except (subprocess.CalledProcessError, OSError):
         release = '(unknown version)'


### PR DESCRIPTION
We got the gist of it, but in the end, didn't git it right.