### PR TITLE
[doc] build: Fix apt command overflowing page

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -116,15 +116,16 @@ Fetching with APT
 
 You can fetch these dependencies with the following command:
 
-``apt-get install binutils-dev cmake fonts-dejavu-core libfontconfig-dev
-gcc g++ pkg-config libegl-dev libgl-dev libgles-dev libspice-protocol-dev
-nettle-dev libx11-dev libxcursor-dev libxi-dev libxinerama-dev
-libxpresent-dev libxss-dev libxkbcommon-dev libwayland-dev wayland-protocols``
+.. code:: bash
+
+   apt-get install binutils-dev cmake fonts-dejavu-core libfontconfig-dev \
+   gcc g++ pkg-config libegl-dev libgl-dev libgles-dev libspice-protocol-dev \
+   nettle-dev libx11-dev libxcursor-dev libxi-dev libxinerama-dev \
+   libxpresent-dev libxss-dev libxkbcommon-dev libwayland-dev wayland-protocols
 
 You may omit some dependencies, if you disable the feature which requires them
 when running :ref:`cmake <client_building>`.
 (See :ref:`client_deps_may_be_disabled`)
-
 
 .. _client_building:
 


### PR DESCRIPTION
![Screenshot_20211227_180010](https://user-images.githubusercontent.com/5211576/147488142-ed169b28-2a4e-4f61-a7ed-b5ae3f2e71cb.png)
