### PR TITLE
[misc] Prefer debian package to pip3 when checking spelling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,8 +179,7 @@ jobs:
         sudo apt-get update
     - name: Install docs dependencies
       run: |
-        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme
-        sudo pip3 install sphinxcontrib-spelling
+        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme python3-sphinxcontrib.spelling
     - name: Build docs
       run: |
         cd doc


### PR DESCRIPTION
Swaps the pip3 install command for equivalent Debian package when installing `sphinxcontrib-spelling`

This package is also on Ubuntu since Trusty Tahr