### PR TITLE
[host] dxgi: fix d3d11 assertion failure

### DIFF
--- a/host/platform/Windows/capture/DXGI/src/d3d11.c
+++ b/host/platform/Windows/capture/DXGI/src/d3d11.c
@@ -105,6 +105,7 @@ static void d3d11_free(void)
 
   runningavg_free(&this->avgMapTime);
   free(this);
+  this = NULL;
 }
 
 static bool d3d11_copyFrame(Texture * tex, ID3D11Texture2D * src)


### PR DESCRIPTION
`DEBUG_ASSERT(!this)` in `d3d11_create` is firing on the second
instantiation because we are not clearing `this` in `d3d11_free`.