### PR TITLE
[host] dxgi: fix frame damage method parameters

### DIFF
--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -694,7 +694,7 @@ static void computeFrameDamage(Texture * tex)
   RECT dirtyRects[maxDamageRectsCount];
   UINT dirtyRectsBufferSizeRequired;
   if (FAILED(IDXGIOutputDuplication_GetFrameDirtyRects(this->dup,
-        ARRAY_LENGTH(dirtyRects), dirtyRects,
+        sizeof(dirtyRects), dirtyRects,
         &dirtyRectsBufferSizeRequired)))
     return;
 
@@ -709,7 +709,7 @@ static void computeFrameDamage(Texture * tex)
   DXGI_OUTDUPL_MOVE_RECT moveRects[(maxDamageRectsCount - dirtyRectsCount) / 2];
   UINT moveRectsBufferSizeRequired;
   if (FAILED(IDXGIOutputDuplication_GetFrameMoveRects(this->dup,
-        ARRAY_LENGTH(moveRects), moveRects,
+        sizeof(moveRects), moveRects,
         &moveRectsBufferSizeRequired)))
     return;
 


### PR DESCRIPTION
The buffer input sizes to the `IDXGIOutputDuplication` methods are measured
in bytes. This dramatically increases the number of dirty/move rects that
can be handled.