### PR TITLE
[module] fix compile on 5.16

### DIFF
--- a/module/kvmfr.c
+++ b/module/kvmfr.c
@@ -571,3 +571,6 @@ MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("Geoffrey McRae <geoff@hostfission.com>");
 MODULE_AUTHOR("Guanzhong Chen <quantum2048@gmail.com>");
 MODULE_VERSION("0.0.7");
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0)
+MODULE_IMPORT_NS(DMA_BUF);
+#endif


### PR DESCRIPTION
The `DMA_BUF` namespace was introduced in https://github.com/torvalds/linux/commit/16b0314aa746be6c84c0bc6eca9dde0dce2e99df

Fixes the following error:
```
MODPOST /build/source/module/Module.symvers
ERROR: modpost: module kvmfr uses symbol dma_buf_fd from namespace DMA_BUF, but does not import it.
ERROR: modpost: module kvmfr uses symbol dma_buf_export from namespace DMA_BUF, but does not import it.
```