### PR TITLE
[client] egl: increase texture processing timeout

### DIFF
--- a/client/renderers/EGL/texture_buffer.c
+++ b/client/renderers/EGL/texture_buffer.c
@@ -225,7 +225,7 @@ EGL_TexStatus egl_texBufferStreamGet(EGL_Texture * texture, GLuint * tex)
 
   if (this->sync)
   {
-    switch(glClientWaitSync(this->sync, 0, 20000000)) // 20ms
+    switch(glClientWaitSync(this->sync, 0, 40000000)) // 40ms
     {
       case GL_ALREADY_SIGNALED:
       case GL_CONDITION_SATISFIED:


### PR DESCRIPTION
On my machine (Intel UHD Graphics 770), texture processing occasionally
(about 5% of the time) takes more than 20ms (the highest I have seen is
around 32ms) when the host resolution is 2560x1440. This results in the
frame being discarded and the client displays a stale image. Increase the
timeout to 40ms.