### PR TITLE
[common] kvmfr: increase maximum damage rects

### DIFF
--- a/common/include/common/KVMFR.h
+++ b/common/include/common/KVMFR.h
@@ -28,9 +28,9 @@
 #include "types.h"
 
 #define KVMFR_MAGIC   "KVMFR---"
-#define KVMFR_VERSION 16
+#define KVMFR_VERSION 17
 
-#define KVMFR_MAX_DAMAGE_RECTS 64
+#define KVMFR_MAX_DAMAGE_RECTS 96
 
 #define LGMP_Q_POINTER     1
 #define LGMP_Q_FRAME       2


### PR DESCRIPTION
I am seeing the number of damage rects regularly exceeding 64 under normal desktop usage on Windows 11, with a peak of 95 seen in my testing. Increase the limit to 96.