### PR TITLE
[client] input: avoid reentrancy when realigning guest cursor

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -421,6 +421,9 @@ void core_handleMouseNormal(double ex, double ey)
   if (!g_cursor.guest.valid)
     return;
 
+  if (g_cursor.realigning)
+    return;
+
   if (!core_inputEnabled())
     return;
 
@@ -478,11 +481,15 @@ void core_handleMouseNormal(double ex, double ey)
       else
       {
         /* wait for the move request to be processed */
+        g_cursor.realigning = true;
         do
         {
           uint32_t hostSerial;
           if (lgmpClientGetSerial(g_state.pointerQueue, &hostSerial) != LGMP_OK)
+          {
+            g_cursor.realigning = false;
             return;
+          }
 
           if (hostSerial >= setPosSerial)
             break;
@@ -491,9 +498,10 @@ void core_handleMouseNormal(double ex, double ey)
         }
         while(app_isRunning());
 
-        g_cursor.guest.x = msg.x;
-        g_cursor.guest.y = msg.y;
-        g_cursor.realign = false;
+        g_cursor.guest.x    = msg.x;
+        g_cursor.guest.y    = msg.y;
+        g_cursor.realign    = false;
+        g_cursor.realigning = false;
 
         if (!g_cursor.inWindow)
           return;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -250,6 +250,9 @@ struct CursorState
   /* true if the guest should be realigned to the host when next drawn */
   bool realign;
 
+  /* true if the guest is currently realigning to the host */
+  bool realigning;
+
   /* true if the cursor needs re-drawing/updating */
   bool redraw;
 


### PR DESCRIPTION
This prevents LGMP_ERR_QUEUE_FULL from happening with high polling rate
mice, which is caused by receiving many more mouse events while the
guest cursor warps, triggering more warps.