### PR TITLE
[client] spice: allow volume control keys to be sent to the guest

### DIFF
--- a/client/src/kb.h
+++ b/client/src/kb.h
@@ -24,6 +24,10 @@
 #include <linux/input.h>
 #include <stdint.h>
 
+#define PS2_MUTE        0xE020
+#define PS2_VOLUME_UP   0xE030
+#define PS2_VOLUME_DOWN 0xE02E
+
 extern const uint32_t linux_to_ps2[KEY_MAX];
 extern const char *   linux_to_str[KEY_MAX];
 extern const char *   linux_to_display[KEY_MAX];

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -133,6 +133,12 @@ static void bind_toggleOverlay(int sc, void * opaque)
   app_setOverlay(!g_state.overlayInput);
 }
 
+static void bind_toggleKey(int sc, void * opaque)
+{
+  purespice_keyDown((uintptr_t) opaque);
+  purespice_keyUp((uintptr_t) opaque);
+}
+
 void keybind_register(void)
 {
   app_registerKeybind(KEY_F, bind_fullscreen   , NULL, "Full screen toggle");
@@ -162,5 +168,9 @@ void keybind_register(void)
 
     app_registerKeybind(KEY_LEFTMETA , bind_passthrough, NULL, "Send LWin to the guest");
     app_registerKeybind(KEY_RIGHTMETA, bind_passthrough, NULL, "Send RWin to the guest");
+
+    app_registerKeybind(KEY_UP  , bind_toggleKey, (void *) PS2_VOLUME_UP  , "Send volume up to the guest");
+    app_registerKeybind(KEY_DOWN, bind_toggleKey, (void *) PS2_VOLUME_DOWN, "Send volume down to the guest");
+    app_registerKeybind(KEY_M   , bind_toggleKey, (void *) PS2_MUTE       , "Send mute to the guest");
   }
 }

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -258,9 +258,9 @@ static int renderThread(void * unused)
 
       ImFontAtlas_Clear(g_state.io->Fonts);
       ImFontAtlas_AddFontFromFileTTF(g_state.io->Fonts, g_state.fontName,
-        g_params.uiSize * g_state.windowScale, NULL, NULL);
+        g_params.uiSize * g_state.windowScale, NULL, g_state.fontRange.Data);
       g_state.fontLarge = ImFontAtlas_AddFontFromFileTTF(g_state.io->Fonts,
-        g_state.fontName, 1.3f * g_params.uiSize * g_state.windowScale, NULL, NULL);
+        g_state.fontName, 1.3f * g_params.uiSize * g_state.windowScale, NULL, g_state.fontRange.Data);
       if (!ImFontAtlas_Build(g_state.io->Fonts))
         DEBUG_FATAL("Failed to build font atlas: %s (%s)", g_params.uiFont, g_state.fontName);
 
@@ -1011,6 +1011,17 @@ static int lg_run(void)
     DEBUG_INFO("Using font: %s", g_state.fontName);
   }
 
+  ImVector_ImWchar_Init(&g_state.fontRange);
+  ImFontGlyphRangesBuilder * rangeBuilder =
+    ImFontGlyphRangesBuilder_ImFontGlyphRangesBuilder();
+  ImFontGlyphRangesBuilder_AddRanges(rangeBuilder, (ImWchar[]) {
+    0x0020, 0x00FF, // Basic Latin + Latin Supplement
+    0x2190, 0x2193, // four directional arrows
+    0,
+  });
+  ImFontGlyphRangesBuilder_BuildRanges(rangeBuilder, &g_state.fontRange);
+  ImFontGlyphRangesBuilder_destroy(rangeBuilder);
+
   app_initOverlays();
 
   // initialize metrics ringbuffers
@@ -1560,6 +1571,7 @@ static void lg_shutdown(void)
   ringbuffer_free(&g_state.renderDuration);
 
   free(g_state.fontName);
+  ImVector_ImWchar_UnInit(&g_state.fontRange);
   igDestroyContext(NULL);
   free(g_state.imGuiIni);
 }

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -54,6 +54,7 @@ struct AppState
   struct ll      * overlays;
   char           * fontName;
   ImFont         * fontLarge;
+  ImVector_ImWchar fontRange;
   bool             overlayInput;
   ImGuiMouseCursor cursorLast;
   char           * imGuiIni;


### PR DESCRIPTION
These are implemented as ScrollLock+Up/Down for volume up and down, and
ScrollLock+M to toggle audio mute. These should prove useful especially
when Looking Glass now supports streaming audio, and the volume is
defined in the guest and set on the output stream.