### PR TITLE
[client] Add support for some multimedia keys in capture mode

### DIFF
--- a/client/src/kb.c
+++ b/client/src/kb.c
@@ -142,6 +142,9 @@ const uint32_t linux_to_ps2[KEY_MAX] =
   [KEY_F14]              /* = USB 105 */ = 0x00005E,
   [KEY_F15]              /* = USB 106 */ = 0x00005F,
   [KEY_PRINT]            /* = USB  70 */ = 0x00E037,
+  [KEY_MUTE]             /* = USB 127 */ = 0x00E020,
+  [KEY_VOLUMEUP]         /* = USB 128 */ = 0x00E030,
+  [KEY_VOLUMEDOWN]       /* = USB 129 */ = 0x00E02E,
 };
 
 const char * linux_to_str[KEY_MAX] =
@@ -265,6 +268,9 @@ const char * linux_to_str[KEY_MAX] =
   [KEY_F14]              = "KEY_F14",
   [KEY_F15]              = "KEY_F15",
   [KEY_PRINT]            = "KEY_PRINT",
+  [KEY_MUTE]             = "KEY_MUTE",
+  [KEY_VOLUMEUP]         = "KEY_VOLUMEUP",
+  [KEY_VOLUMEDOWN]       = "KEY_VOLUMEDOWN",
 };
 
 const char * linux_to_display[KEY_MAX] =
@@ -388,6 +394,9 @@ const char * linux_to_display[KEY_MAX] =
   [KEY_F14]              = "F14",
   [KEY_F15]              = "F15",
   [KEY_PRINT]            = "Print",
+  [KEY_MUTE]             = "Mute",
+  [KEY_VOLUMEUP]         = "VolumeUp",
+  [KEY_VOLUMEDOWN]       = "VolumeDown",
 };
 
 void initImGuiKeyMap(int * keymap)

--- a/client/src/kb.c
+++ b/client/src/kb.c
@@ -145,6 +145,10 @@ const uint32_t linux_to_ps2[KEY_MAX] =
   [KEY_MUTE]             /* = USB 127 */ = 0x00E020,
   [KEY_VOLUMEUP]         /* = USB 128 */ = 0x00E030,
   [KEY_VOLUMEDOWN]       /* = USB 129 */ = 0x00E02E,
+  [KEY_NEXTSONG]         /* = USB 235 */ = 0x00E019,
+  [KEY_PLAYPAUSE]        /* = USB 232 */ = 0x00E022,
+  [KEY_PREVIOUSSONG]     /* = USB 234 */ = 0x00E010,
+  [KEY_STOPCD]           /* = USB 233 */ = 0x00E024,
 };
 
 const char * linux_to_str[KEY_MAX] =
@@ -271,6 +275,10 @@ const char * linux_to_str[KEY_MAX] =
   [KEY_MUTE]             = "KEY_MUTE",
   [KEY_VOLUMEUP]         = "KEY_VOLUMEUP",
   [KEY_VOLUMEDOWN]       = "KEY_VOLUMEDOWN",
+  [KEY_NEXTSONG]         = "KEY_NEXTSONG",
+  [KEY_PLAYPAUSE]        = "KEY_PLAYPAUSE",
+  [KEY_PREVIOUSSONG]     = "KEY_PREVIOUSSONG",
+  [KEY_STOPCD]           = "KEY_STOPCD",
 };
 
 const char * linux_to_display[KEY_MAX] =
@@ -397,6 +405,10 @@ const char * linux_to_display[KEY_MAX] =
   [KEY_MUTE]             = "Mute",
   [KEY_VOLUMEUP]         = "VolumeUp",
   [KEY_VOLUMEDOWN]       = "VolumeDown",
+  [KEY_NEXTSONG]         = "NextSong",
+  [KEY_PLAYPAUSE]        = "PlayPause",
+  [KEY_PREVIOUSSONG]     = "PreviousSong",
+  [KEY_STOPCD]           = "StopMedia",
 };
 
 void initImGuiKeyMap(int * keymap)


### PR DESCRIPTION
These include Volume Up, Volume Down, Mute, Play/Pause, Stop, Next Track, and Previous Track.

I discovered this on accident when messing around with #934.

I tried adding these as ScrLk shortcuts alongside the shortcuts added by that PR, to effectively let you passthrough the keys. So pressing ScrLk+Mute would toggle mute, ScrLk+VolumeUp would press Volume Up, etc.

It wasn't working until I added this code to `kb.c`, but when I did that, the keys themselves were working just fine in capture mode, so I didn't need the ScrLk keybinds after all.

(Later, I added the multimedia keys Play/Pause, Stop, Next Track, and Previous Track)

Added @quantum5 as co-author because his PR is what made me look at this, and the PS2 scancodes were lifted from his PR.