### PR TITLE
[doc] build: Add source comment for listing deps

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -59,6 +59,13 @@ These required libraries and tools should be installed first.
 Required Dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
+..
+   Editor note: Listed dependencies are Debian packages containing the
+   required resources. All dependencies must be explicitly defined.
+   Omitting required dependencies that happen to be pulled in via
+   Depends: or Recommends: from another listed package is not allowed.
+   All required packages must be listed.
+
 -  cmake
 -  gcc, g++ \| clang
 -  libegl-dev


### PR DESCRIPTION
Webedit because I'm super sleepy and don't want to turn on my laptop.

Just a future proofing warning so the rule of the Reqired Dependencies section is shown to prospective future editors and developers.

I don't yet know if this will show up on the rendered html or not, I followed https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#comments so it should be visible in the source only.