### PR TITLE
[client] overlay: realign cursor when turning off overlay

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -502,6 +502,7 @@ void core_handleMouseNormal(double ex, double ey)
         g_cursor.guest.y    = msg.y;
         g_cursor.realign    = false;
         g_cursor.realigning = false;
+        g_cursor.redraw     = true;
 
         if (!g_cursor.inWindow)
           return;

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -668,5 +668,11 @@ void core_updateOverlayState(void)
     core_setGrabQuiet(wasGrabbed);
     core_invalidatePointer(true);
     app_invalidateWindow(false);
+
+    if (!g_cursor.grab)
+    {
+      g_cursor.realign = true;
+      core_handleMouseNormal(0, 0);
+    }
   }
 }


### PR DESCRIPTION
This is only done in non-capture mode to avoid messing up games.

Also, added a redraw after warping. This is because turning off overlay does not involve mouse movement, which means the renderer is not notified of the new cursor position, and thus exposing the fact that the guest cursor is rendered in the wrong location.