### PR TITLE
[host] nvfbc: shorten nvfbc_getName() result

### DIFF
--- a/host/platform/Windows/capture/NVFBC/src/nvfbc.c
+++ b/host/platform/Windows/capture/NVFBC/src/nvfbc.c
@@ -121,7 +121,7 @@ static void on_mouseMove(int x, int y)
 
 static const char * nvfbc_getName(void)
 {
-  return "NVFBC (NVidia Frame Buffer Capture)";
+  return "NVFBC";
 };
 
 static void nvfbc_initOptions(void)


### PR DESCRIPTION
To avoid client showing `Using    : NVFBC (NVidia Frame Buffer Capt`.

This happens because the string is truncated to 31 characters to fit in the `char capture[32];` member of `KVMFRRecord_VMInfo`.