### PR TITLE
[client] audio: tune target latency

### DIFF
--- a/client/audiodevs/PulseAudio/pulseaudio.c
+++ b/client/audiodevs/PulseAudio/pulseaudio.c
@@ -246,10 +246,13 @@ static void pulseaudio_overflow_cb(pa_stream * p, void * userdata)
 }
 
 static void pulseaudio_setup(int channels, int sampleRate,
-    LG_AudioPullFn pullFn)
+    int * maxPeriodFrames, LG_AudioPullFn pullFn)
 {
   if (pa.sink && pa.sinkChannels == channels && pa.sinkSampleRate == sampleRate)
+  {
+    *maxPeriodFrames = pa.sinkStart;
     return;
+  }
 
   //TODO: be smarter about this
   const int PERIOD_LEN = 80;
@@ -288,6 +291,8 @@ static void pulseaudio_setup(int channels, int sampleRate,
   pa.sinkPullFn = pullFn;
   pa.sinkStart  = attribs.tlength / pa.sinkStride;
   pa.sinkCorked = true;
+
+  *maxPeriodFrames = pa.sinkStart;
 
   pa_threaded_mainloop_unlock(pa.loop);
 }

--- a/client/include/interface/audiodev.h
+++ b/client/include/interface/audiodev.h
@@ -47,7 +47,8 @@ struct LG_AudioDevOps
     /* setup the stream for playback but don't start it yet
      * Note: the pull function returns f32 samples
      */
-    void (*setup)(int channels, int sampleRate, LG_AudioPullFn pullFn);
+    void (*setup)(int channels, int sampleRate, int * maxPeriodFrames,
+      LG_AudioPullFn pullFn);
 
     /* called when there is data available to start playback
      * return true if playback should start */


### PR DESCRIPTION
The target latency is now based upon the device maximum period size (which may be configured by setting the `PIPEWIRE_LATENCY` environment variable if using PipeWire), with some allowance for timing jitter from Spice and the audio device.

PipeWire can change the period size dynamically at any time which must be taken into account when selecting the target latency to avoid underruns when the period size is increased. This is explained in detail within the commit body.