### PR TITLE
wayland: implement window activation via xdg-activation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
     - name: Install PipeWire repository
       run: |
         echo 'deb [trusted=yes] https://pipewire-ubuntu.quantum5.workers.dev ./' | sudo tee /etc/apt/sources.list.d/pipewire.list
+    - name: Install wayland-protocols repository
+      run: |
+        curl https://quantum5.ca/apt.key | sudo apt-key add -
+        echo 'deb https://apt.quantum2.xyz/sway-utils/ bullseye main' | sudo tee /etc/apt/sources.list.d/wayland-protocols.list
     - name: Update apt
       run: |
         sudo apt-get update

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 
 add_library(displayserver_Wayland STATIC
+	activation.c
 	clipboard.c
 	cursor.c
 	gl.c

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -96,3 +96,6 @@ wayland_generate(
 wayland_generate(
     "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-output/xdg-output-unstable-v1.xml"
     "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-output-unstable-v1-client-protocol")
+wayland_generate(
+    "${WAYLAND_PROTOCOLS_BASE}/staging/xdg-activation/xdg-activation-v1.xml"
+    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-activation-v1-client-protocol")

--- a/client/displayservers/Wayland/activation.c
+++ b/client/displayservers/Wayland/activation.c
@@ -1,0 +1,42 @@
+/**
+ * Looking Glass
+ * Copyright © 2017-2022 The Looking Glass Authors
+ * https://looking-glass.io
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+#include "wayland.h"
+
+#include <stdbool.h>
+#include <wayland-client.h>
+
+#include "common/debug.h"
+
+bool waylandActivationInit(void)
+{
+  if (!wlWm.xdgActivation)
+    DEBUG_WARN("xdg_activation_v1 not exported by compositor, will not be able "
+               "to request host focus on behalf of guest applications");
+  return true;
+}
+
+void waylandActivationFree(void)
+{
+  if (wlWm.xdgActivation)
+  {
+    xdg_activation_v1_destroy(wlWm.xdgActivation);
+  }
+}

--- a/client/displayservers/Wayland/activation.c
+++ b/client/displayservers/Wayland/activation.c
@@ -51,7 +51,7 @@ static const struct xdg_activation_token_v1_listener activationTokenListener = {
   .done = &activationTokenDone,
 };
 
-void waylandActivationRequest(void)
+void waylandActivationRequestActivation(void)
 {
   if (!wlWm.xdgActivation) return;
 

--- a/client/displayservers/Wayland/activation.c
+++ b/client/displayservers/Wayland/activation.c
@@ -40,3 +40,31 @@ void waylandActivationFree(void)
     xdg_activation_v1_destroy(wlWm.xdgActivation);
   }
 }
+
+static void activationTokenDone(void * data,
+    struct xdg_activation_token_v1 * xdgToken, const char * token)
+{
+  xdg_activation_token_v1_destroy(xdgToken);
+}
+
+static const struct xdg_activation_token_v1_listener activationTokenListener = {
+  .done = &activationTokenDone,
+};
+
+void waylandActivationRequest(void)
+{
+  if (!wlWm.xdgActivation) return;
+
+  struct xdg_activation_token_v1 * token =
+    xdg_activation_v1_get_activation_token(wlWm.xdgActivation);
+
+  if (!token)
+  {
+    DEBUG_ERROR("failed to retrieve XDG activation token");
+    return;
+  }
+
+  xdg_activation_token_v1_add_listener(token, &activationTokenListener, NULL);
+  xdg_activation_token_v1_set_surface(token, wlWm.surface);
+  xdg_activation_token_v1_commit(token);
+}

--- a/client/displayservers/Wayland/activation.c
+++ b/client/displayservers/Wayland/activation.c
@@ -44,6 +44,7 @@ void waylandActivationFree(void)
 static void activationTokenDone(void * data,
     struct xdg_activation_token_v1 * xdgToken, const char * token)
 {
+  xdg_activation_v1_activate(wlWm.xdgActivation, token, wlWm.surface);
   xdg_activation_token_v1_destroy(xdgToken);
 }
 

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -72,6 +72,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
     wlWm.xdgOutputManager = wl_registry_bind(wlWm.registry, name,
         // we only need v2 to run, but v3 saves a callback
         &zxdg_output_manager_v1_interface, version > 3 ? 3 : version);
+  else if (!strcmp(interface, xdg_activation_v1_interface.name))
+    wlWm.xdgActivation = wl_registry_bind(wlWm.registry, name,
+        &xdg_activation_v1_interface, 1);
 }
 
 static void registryGlobalRemoveHandler(void * data,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -190,6 +190,7 @@ struct LG_DisplayServerOps LGDS_Wayland =
   .warpPointer         = waylandWarpPointer,
   .realignPointer      = waylandRealignPointer,
   .isValidPointerPos   = waylandIsValidPointerPos,
+  .requestActivation   = waylandActivationRequestActivation,
   .inhibitIdle         = waylandInhibitIdle,
   .uninhibitIdle       = waylandUninhibitIdle,
   .wait                = waylandWait,

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -89,6 +89,9 @@ static bool waylandInit(const LG_DSInitParams params)
   if (!waylandRegistryInit())
     return false;
 
+  if (!waylandActivationInit())
+    return false;
+
   if (!waylandIdleInit())
     return false;
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -237,6 +237,7 @@ extern struct WCBState       wlCb;
 // activation module
 bool waylandActivationInit(void);
 void waylandActivationFree(void);
+void waylandActivationRequest(void);
 
 // clipboard module
 bool waylandCBInit(void);

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -237,7 +237,7 @@ extern struct WCBState       wlCb;
 // activation module
 bool waylandActivationInit(void);
 void waylandActivationFree(void);
-void waylandActivationRequest(void);
+void waylandActivationRequestActivation(void);
 
 // clipboard module
 bool waylandCBInit(void);

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -47,6 +47,7 @@
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
 #include "wayland-xdg-output-unstable-v1-client-protocol.h"
+#include "wayland-xdg-activation-v1-client-protocol.h"
 
 typedef void (*WaylandPollCallback)(uint32_t events, void * opaque);
 
@@ -180,6 +181,8 @@ struct WaylandDSState
   struct zwp_idle_inhibit_manager_v1 * idleInhibitManager;
   struct zwp_idle_inhibitor_v1 * idleInhibitor;
 
+  struct xdg_activation_v1 * xdgActivation;
+
   struct wp_viewporter * viewporter;
   struct wp_viewport * viewport;
   struct zxdg_output_manager_v1 * xdgOutputManager;
@@ -230,6 +233,10 @@ struct WCBState
 
 extern struct WaylandDSState wlWm;
 extern struct WCBState       wlCb;
+
+// activation module
+bool waylandActivationInit(void);
+void waylandActivationFree(void);
 
 // clipboard module
 bool waylandCBInit(void);

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1813,6 +1813,11 @@ static bool x11IsValidPointerPos(int x, int y)
   return ret;
 }
 
+static void x11RequestActivation(void)
+{
+  // TODO
+}
+
 static void x11InhibitIdle(void)
 {
   XScreenSaverSuspend(x11.display, true);
@@ -1903,6 +1908,7 @@ struct LG_DisplayServerOps LGDS_X11 =
   .warpPointer         = x11WarpPointer,
   .realignPointer      = x11RealignPointer,
   .isValidPointerPos   = x11IsValidPointerPos,
+  .requestActivation   = x11RequestActivation,
   .inhibitIdle         = x11InhibitIdle,
   .uninhibitIdle       = x11UninhibitIdle,
   .wait                = x11Wait,

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -194,6 +194,9 @@ struct LG_DisplayServerOps
   void (*inhibitIdle)();
   void (*uninhibitIdle)();
 
+  /* called to request activation */
+  void (*requestActivation)();
+
   /* wait for the specified time without blocking UI processing/event loops */
   void (*wait)(unsigned int time);
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -556,6 +556,8 @@ int main_frameThread(void * unused)
     break;
   }
 
+  g_state.ds->requestActivation();
+
   while(g_state.state == APP_STATE_RUNNING && !g_state.stopVideo)
   {
     LGMPMessage msg;


### PR DESCRIPTION
In a future patchset, this will allow us to plumb activation requests from the guest up to the host.

Example of what this looks like in Sway:

![image](https://user-images.githubusercontent.com/1403503/152702203-d07beb77-9ae5-40fe-b621-fd84e66ef649.png)

Currently, we request activation when we obtain a frame from LGMP for the first time.

Window activation is implementable for X11, but I've not done so in this PR.