### PR TITLE
[client] egl: remove extra samplers

### DIFF
--- a/client/renderers/EGL/desktop.c
+++ b/client/renderers/EGL/desktop.c
@@ -57,7 +57,6 @@ struct EGL_Desktop
   EGLDisplay * display;
 
   EGL_Texture          * texture;
-  GLuint                 sampler;
   struct DesktopShader shader;
   EGL_DesktopRects     * mesh;
   CountedBuffer        * matrix;
@@ -296,12 +295,6 @@ bool egl_desktopSetup(EGL_Desktop * desktop, const LG_RendererFormat format)
     return false;
   }
 
-  glGenSamplers(1, &desktop->sampler);
-  glSamplerParameteri(desktop->sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glSamplerParameteri(desktop->sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glSamplerParameteri(desktop->sampler, GL_TEXTURE_WRAP_S    , GL_CLAMP_TO_EDGE);
-  glSamplerParameteri(desktop->sampler, GL_TEXTURE_WRAP_T    , GL_CLAMP_TO_EDGE);
-
   return true;
 }
 
@@ -396,7 +389,7 @@ bool egl_desktopRender(EGL_Desktop * desktop, unsigned int outputWidth,
 
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, texture);
-  glBindSampler(0, desktop->sampler);
+  glBindSampler(0, desktop->texture->sampler);
 
   if (finalSizeX > desktop->width || finalSizeY > desktop->height)
     scaleType = EGL_DESKTOP_DOWNSCALE;

--- a/client/renderers/EGL/texture_buffer.h
+++ b/client/renderers/EGL/texture_buffer.h
@@ -33,7 +33,6 @@ typedef struct TextureBuffer
 
   int           texCount;
   GLuint        tex[EGL_TEX_BUFFER_MAX];
-  GLuint        sampler;
   EGL_TexBuffer buf[EGL_TEX_BUFFER_MAX];
   int           bufFree;
   GLsync        sync;


### PR DESCRIPTION
There was an unused sampler in `TextureBuffer`, any time it was bound it used the `base->sampler` instead.

The real point of this, however, is the sampler in the EGL Desktop. If I understand correctly, the desktop doesn't need its own sampler. There is already an identically configured one in the `desktop->texture`.

For some reason, using the texture sampler fixes a black screen issue caused by f0ea882 (where the separate desktop sampler was added) with my GTX 660 using the 470.86 driver. Maybe hitting some limit for how many samplers can be allocated?