### PR TITLE
[host] linux: build with PipeWire by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,12 +76,16 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: Install PipeWire repository
+      run: |
+        echo 'deb [trusted=yes] https://pipewire-ubuntu.quantum5.workers.dev ./' | sudo tee /etc/apt/sources.list.d/pipewire.list
     - name: Update apt
       run: |
         sudo apt-get update
     - name: Install Linux host dependencies
       run: |
-        sudo apt-get install binutils-dev libgl1-mesa-dev libxcb-xfixes0-dev
+        sudo apt-get install binutils-dev libgl1-mesa-dev libxcb-xfixes0-dev \
+          libpipewire-0.3-dev
     - name: Configure Linux host
       run: |
         mkdir host/build

--- a/host/platform/Linux/capture/CMakeLists.txt
+++ b/host/platform/Linux/capture/CMakeLists.txt
@@ -4,7 +4,7 @@ project(capture LANGUAGES C)
 include("PreCapture")
 
 option(USE_XCB "Enable XSHM Support" ON)
-option(USE_PIPEWIRE "Enable Pipewire Support" OFF)
+option(USE_PIPEWIRE "Enable PipeWire Support" ON)
 
 if (USE_XCB)
   add_capture("XCB")


### PR DESCRIPTION
Since the client already depends on PipeWire by default, there is no
reason why the host shouldn't.