### PR TITLE
[client] audio: open device earlier

### DIFF
--- a/common/src/appstrings.c
+++ b/common/src/appstrings.c
@@ -119,5 +119,12 @@ const struct LGTeamMember LG_TEAM[] =
     .blurb  = "Documentation Guru and Discord Community Manager",
     .donate = { { 0 } }
   },
+  {
+    .name   = "Chris Spencer (spencercw)",
+    .blurb  =
+      "Developer. Knows enough about audio programming to cause problems for "
+      "himself.",
+    .donate = { { 0 } }
+  },
   { 0 }
 };


### PR DESCRIPTION
The actual time between opening the device and the device starting to pull data can range anywhere between nearly instant and hundreds of milliseconds. To minimise startup latency, open the device as soon as the first playback data is received from Spice. If the device starts earlier than required, insert a period of silence at the beginning of playback to avoid underrunning. If it starts later, just accept the higher latency and let the adaptive resampling deal with it.