### PR TITLE
[client] audio: fix assertion failure on exit if graph is open

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -532,7 +532,8 @@ void app_invalidateWindow(bool full)
   if (g_state.jitRender && g_state.ds->stopWaitFrame)
     g_state.ds->stopWaitFrame();
 
-  lgSignalEvent(g_state.frameEvent);
+  if (g_state.frameEvent)
+    lgSignalEvent(g_state.frameEvent);
 }
 
 void app_handleCloseEvent(void)


### PR DESCRIPTION
This is a bit intermittent, but can be triggered reliably by putting a short sleep at the beginning of `audio_free`.