### PR TITLE
Build with -Wstrict-prototypes

### DIFF
--- a/client/audiodevs/PulseAudio/pulseaudio.c
+++ b/client/audiodevs/PulseAudio/pulseaudio.c
@@ -187,7 +187,7 @@ err:
   return false;
 }
 
-static void pulseaudio_sink_close_nl()
+static void pulseaudio_sink_close_nl(void)
 {
   if (!pa.sink)
     return;

--- a/client/displayservers/X11/clipboard.h
+++ b/client/displayservers/X11/clipboard.h
@@ -28,7 +28,7 @@
 
 bool x11CBEventThread(const XEvent xe);
 
-bool x11CBInit();
+bool x11CBInit(void);
 void x11CBNotice(LG_ClipboardData type);
 void x11CBRelease(void);
 void x11CBRequest(LG_ClipboardData type);

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -123,13 +123,13 @@ struct LG_DisplayServerOps
   bool (*init)(const LG_DSInitParams params);
 
   /* called at startup after window creation, renderer and SPICE is ready */
-  void (*startup)();
+  void (*startup)(void);
 
   /* called just before final window destruction, before final free */
-  void (*shutdown)();
+  void (*shutdown)(void);
 
   /* final free */
-  void (*free)();
+  void (*free)(void);
 
   /*
    * return a system specific property, returns false if unsupported or failure
@@ -170,14 +170,14 @@ struct LG_DisplayServerOps
   /* dm specific cursor implementations */
   void (*guestPointerUpdated)(double x, double y, double localX, double localY);
   void (*setPointer)(LG_DSPointer pointer);
-  void (*grabKeyboard)();
-  void (*ungrabKeyboard)();
+  void (*grabKeyboard)(void);
+  void (*ungrabKeyboard)(void);
   /* (un)grabPointer is used to toggle cursor tracking/confine in normal mode */
-  void (*grabPointer)();
-  void (*ungrabPointer)();
+  void (*grabPointer)(void);
+  void (*ungrabPointer)(void);
   /* (un)capturePointer is used do toggle special cursor tracking in capture mode */
-  void (*capturePointer)();
-  void (*uncapturePointer)();
+  void (*capturePointer)(void);
+  void (*uncapturePointer)(void);
 
   /* exiting = true if the warp is to leave the window */
   void (*warpPointer)(int x, int y, bool exiting);
@@ -185,17 +185,17 @@ struct LG_DisplayServerOps
   /* called when the client needs to realign the pointer. This should simply
    * call the appropriate app_handleMouse* method for the platform with zero
    * deltas */
-  void (*realignPointer)();
+  void (*realignPointer)(void);
 
   /* returns true if the position specified is actually valid */
   bool (*isValidPointerPos)(int x, int y);
 
   /* called to disable/enable the screensaver */
-  void (*inhibitIdle)();
-  void (*uninhibitIdle)();
+  void (*inhibitIdle)(void);
+  void (*uninhibitIdle)(void);
 
   /* called to request activation */
-  void (*requestActivation)();
+  void (*requestActivation)(void);
 
   /* wait for the specified time without blocking UI processing/event loops */
   void (*wait)(unsigned int time);

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -46,7 +46,7 @@ static bool       optScancodeValidate(struct Option * opt, const char ** error);
 static char *     optScancodeToString(struct Option * opt);
 static bool       optRotateValidate  (struct Option * opt, const char ** error);
 
-static void doLicense();
+static void doLicense(void);
 
 static struct Option options[] =
 {

--- a/client/src/config.h
+++ b/client/src/config.h
@@ -20,6 +20,6 @@
 
 #include <stdbool.h>
 
-void config_init();
+void config_init(void);
 bool config_load(int argc, char * argv[]);
-void config_free();
+void config_free(void);

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -981,7 +981,7 @@ static bool tryRenderer(const int index, const LG_RendererParams lgrParams,
   return true;
 }
 
-static void reportBadVersion()
+static void reportBadVersion(void)
 {
   DEBUG_BREAK();
   DEBUG_ERROR("The host application is not compatible with this client");

--- a/client/src/overlays.h
+++ b/client/src/overlays.h
@@ -44,7 +44,7 @@ void overlayAlert_show(LG_MsgAlert type, const char * fmt, va_list args);
 
 GraphHandle overlayGraph_register(const char * name, RingBuffer buffer,
     float min, float max, GraphFormatFn formatFn);
-void overlayGraph_unregister();
+void overlayGraph_unregister(GraphHandle handle);
 void overlayGraph_iterate(void (*callback)(GraphHandle handle, const char * name,
     bool * enabled, void * udata), void * udata);
 void overlayGraph_invalidate(GraphHandle handle);

--- a/common/include/common/ivshmem.h
+++ b/common/include/common/ivshmem.h
@@ -33,7 +33,7 @@ struct IVSHMEM
   void * opaque;
 };
 
-void ivshmemOptionsInit();
+void ivshmemOptionsInit(void);
 bool ivshmemInit(struct IVSHMEM * dev);
 bool ivshmemOpen(struct IVSHMEM * dev);
 bool ivshmemOpenDev(struct IVSHMEM * dev, const char * shmDev);

--- a/common/include/common/ll.h
+++ b/common/include/common/ll.h
@@ -40,7 +40,7 @@ struct ll
   LG_Lock lock;
 };
 
-struct ll *  ll_new();
+struct ll *  ll_new(void);
 void         ll_free     (struct ll * list);
 void         ll_push     (struct ll * list, void * data);
 bool         ll_shift    (struct ll * list, void ** data);

--- a/common/include/common/sysinfo.h
+++ b/common/include/common/sysinfo.h
@@ -22,6 +22,6 @@
 #define _H_LG_COMMON_SYSUTILS
 
 // returns the page size
-long sysinfo_getPageSize();
+long sysinfo_getPageSize(void);
 
 #endif

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -39,6 +39,7 @@ add_compile_options(
   "-Wall"
   "-Werror"
   "-Wfatal-errors"
+  "$<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>"
   "-ffast-math"
   "-fdata-sections"
   "-ffunction-sections"

--- a/host/include/interface/capture.h
+++ b/host/include/interface/capture.h
@@ -96,21 +96,21 @@ typedef struct CaptureInterface
 {
   const char * shortName;
   const bool   asyncCapture;
-  const char * (*getName        )();
-  void         (*initOptions    )();
+  const char * (*getName        )(void);
+  void         (*initOptions    )(void);
 
   bool(*create)(
     CaptureGetPointerBuffer  getPointerBufferFn,
     CapturePostPointerBuffer postPointerBufferFn
   );
 
-  bool          (*init         )();
-  bool          (*start        )();
-  void          (*stop         )();
-  bool          (*deinit       )();
-  void          (*free         )();
+  bool          (*init         )(void);
+  bool          (*start        )(void);
+  void          (*stop         )(void);
+  bool          (*deinit       )(void);
+  void          (*free         )(void);
 
-  CaptureResult (*capture   )();
+  CaptureResult (*capture   )(void);
   CaptureResult (*waitFrame )(CaptureFrame * frame, const size_t maxFrameSize);
   CaptureResult (*getFrame  )(FrameBuffer  * frame, const unsigned int height, int frameIndex);
 }

--- a/host/platform/Linux/capture/XCB/src/xcb.c
+++ b/host/platform/Linux/capture/XCB/src/xcb.c
@@ -64,7 +64,7 @@ static int pointerThread(void * unused);
 
 // forwards
 
-static bool xcb_deinit();
+static bool xcb_deinit(void);
 
 // implementation
 

--- a/host/platform/Linux/capture/pipewire/src/pipewire.c
+++ b/host/platform/Linux/capture/pipewire/src/pipewire.c
@@ -56,7 +56,7 @@ static struct pipewire * this = NULL;
 
 // forwards
 
-static bool pipewire_deinit();
+static bool pipewire_deinit(void);
 
 // implementation
 

--- a/host/platform/Windows/capture/DXGI/src/d3d12.c
+++ b/host/platform/Windows/capture/DXGI/src/d3d12.c
@@ -79,7 +79,7 @@ typedef HRESULT (*D3D12GetDebugInterface_t)(
   void   **ppvDebug
 );
 
-static void d3d12_free();
+static void d3d12_free(void);
 
 static bool d3d12_create(struct DXGIInterface * intf)
 {

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -57,8 +57,8 @@ static struct DXGICopyBackend * backends[] = {
 
 // forwards
 
-static bool          dxgi_deinit();
-static CaptureResult dxgi_releaseFrame();
+static bool          dxgi_deinit(void);
+static CaptureResult dxgi_releaseFrame(void);
 
 // implementation
 

--- a/host/platform/Windows/capture/NVFBC/src/wrapper.h
+++ b/host/platform/Windows/capture/NVFBC/src/wrapper.h
@@ -48,8 +48,8 @@ enum DiffMapBlockSize
   DIFFMAP_BLOCKSIZE_64X64
 };
 
-bool NvFBCInit();
-void NvFBCFree();
+bool NvFBCInit(void);
+void NvFBCFree(void);
 
 bool NvFBCToSysCreate(
   int            adapterIndex,

--- a/host/platform/Windows/include/windows/mousehook.h
+++ b/host/platform/Windows/include/windows/mousehook.h
@@ -21,4 +21,4 @@
 typedef void (*MouseHookFn)(int x, int y);
 
 void mouseHook_install(MouseHookFn callback);
-void mouseHook_remove();
+void mouseHook_remove(void);


### PR DESCRIPTION
`-Wstrict-prototypes` is not yet enforced for the client because it depends on cimgui, whose code generation scripts don't currently generate compatible code.