### PR TITLE
Build client with -Wstrict-prototypes

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -66,6 +66,7 @@ add_compile_options(
   "-Wextra"
   "-Wno-sign-compare"
   "-Wno-unused-parameter"
+  "-Wstrict-prototypes"
   "$<$<C_COMPILER_ID:GNU>:-Wimplicit-fallthrough=2>"
   "-Werror"
   "-Wfatal-errors"

--- a/client/src/kb.c
+++ b/client/src/kb.c
@@ -428,7 +428,7 @@ void initImGuiKeyMap(int * keymap)
   keymap[ImGuiKey_Space      ] = KEY_SPACE;
   keymap[ImGuiKey_Enter      ] = KEY_ENTER;
   keymap[ImGuiKey_Escape     ] = KEY_SPACE;
-  keymap[ImGuiKey_KeyPadEnter] = KEY_KPENTER;
+  keymap[ImGuiKey_KeypadEnter] = KEY_KPENTER;
   keymap[ImGuiKey_A          ] = KEY_A;
   keymap[ImGuiKey_C          ] = KEY_C;
   keymap[ImGuiKey_V          ] = KEY_V;


### PR DESCRIPTION
This should be the last of these PRs.

https://github.com/cimgui/cimgui/pull/197 landed, so pull in the latest cimgui. We were on 1.86, so fix compilation for 1.87.