### PR TITLE
[host] dxgi: add microsecond-scale sleep capability to d3d12

### DIFF
--- a/host/platform/Windows/capture/DXGI/src/d3d12.c
+++ b/host/platform/Windows/capture/DXGI/src/d3d12.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <d3d12.h>
 #include <d3d12sdklayers.h>
+#include "common/time.h"
 #include "common/debug.h"
 #include "common/option.h"
 #include "common/windebug.h"
@@ -44,7 +45,7 @@ struct D3D12Texture
 
 struct D3D12Backend
 {
-  int                   copySleep;
+  float                 copySleep;
   ID3D12Device        * device;
   ID3D12InfoQueue1    * debugInfoQueue;
   ID3D12CommandQueue  * commandQueue;
@@ -120,8 +121,8 @@ static bool d3d12_create(struct DXGIInterface * intf)
     return false;
   }
 
-  this->copySleep = option_get_int("dxgi", "d3d12CopySleep");
-  DEBUG_INFO("Sleep before copy : %d ms", this->copySleep);
+  this->copySleep = option_get_float("dxgi", "d3d12CopySleep");
+  DEBUG_INFO("Sleep before copy : %f ms", this->copySleep);
 
   status = D3D12CreateDevice((IUnknown *) dxgi->adapter, D3D_FEATURE_LEVEL_11_0,
     &IID_ID3D12Device, (void **)&this->device);
@@ -346,7 +347,7 @@ static bool d3d12_copyFrame(Texture * parent, ID3D11Texture2D * src)
   HRESULT status;
 
   if (this->copySleep > 0)
-    Sleep(this->copySleep);
+    nsleep((uint64_t)(this->copySleep * 1000000));
 
   HANDLE handle = INVALID_HANDLE_VALUE;
 

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -130,7 +130,7 @@ static void dxgi_initOptions(void)
       .module         = "dxgi",
       .name           = "d3d12CopySleep",
       .description    = "Milliseconds to sleep before copying frame with d3d12",
-      .type           = OPTION_TYPE_INT,
+      .type           = OPTION_TYPE_FLOAT,
       .value.x_int    = 5
     },
     {


### PR DESCRIPTION
The usleep() call lets d3d12 match the sleep calls of d3d11 while
maintaining the current millisecond-scale sleep interface in the
configuration file.