### PR TITLE
Add a confirmation dialog before we start recording

### DIFF
--- a/client/audiodevs/PipeWire/pipewire.c
+++ b/client/audiodevs/PipeWire/pipewire.c
@@ -426,7 +426,16 @@ static void pipewire_recordStart(int channels, int sampleRate,
   if (pw.record.stream &&
       pw.record.channels == channels &&
       pw.record.sampleRate == sampleRate)
+  {
+    if (!pw.record.active)
+    {
+      pw_thread_loop_lock(pw.thread);
+      pw_stream_set_active(pw.record.stream, true);
+      pw.record.active = true;
+      pw_thread_loop_unlock(pw.thread);
+    }
     return;
+  }
 
   pipewire_recordStopStream();
 
@@ -474,6 +483,7 @@ static void pipewire_recordStart(int channels, int sampleRate,
       params, 1);
 
   pw_thread_loop_unlock(pw.thread);
+  pw.record.active = true;
 }
 
 static void pipewire_recordStop(void)

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -138,14 +138,14 @@ void app_clipboardRequest(const LG_ClipboardReplyFn replyFn, void * opaque);
  */
 void app_alert(LG_MsgAlert type, const char * fmt, ...);
 
-typedef void * MsgBoxHandle;
+typedef struct MsgBoxHandle * MsgBoxHandle;
 MsgBoxHandle app_msgBox(const char * caption, const char * fmt, ...);
 
 typedef void (*MsgBoxConfirmCallback)(bool yes, void * opaque);
 MsgBoxHandle app_confirmMsgBox(const char * caption,
     MsgBoxConfirmCallback callback, void * opaque, const char * fmt, ...);
 
-void app_msgBoxClose(MsgBoxHandle * handle);
+void app_msgBoxClose(MsgBoxHandle handle);
 
 typedef struct KeybindHandle * KeybindHandle;
 typedef void (*KeybindFn)(int sc, void * opaque);

--- a/client/include/app.h
+++ b/client/include/app.h
@@ -140,6 +140,11 @@ void app_alert(LG_MsgAlert type, const char * fmt, ...);
 
 typedef void * MsgBoxHandle;
 MsgBoxHandle app_msgBox(const char * caption, const char * fmt, ...);
+
+typedef void (*MsgBoxConfirmCallback)(bool yes, void * opaque);
+MsgBoxHandle app_confirmMsgBox(const char * caption,
+    MsgBoxConfirmCallback callback, void * opaque, const char * fmt, ...);
+
 void app_msgBoxClose(MsgBoxHandle * handle);
 
 typedef struct KeybindHandle * KeybindHandle;

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -644,8 +644,20 @@ MsgBoxHandle app_msgBox(const char * caption, const char * fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
-  MsgBoxHandle handle =
-    overlayMsg_show(caption, fmt, args);
+  MsgBoxHandle handle = overlayMsg_show(caption, NULL, NULL, fmt, args);
+  va_end(args);
+
+  core_updateOverlayState();
+
+  return handle;
+}
+
+MsgBoxHandle app_confirmMsgBox(const char * caption,
+    MsgBoxConfirmCallback callback, void * opaque, const char * fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  MsgBoxHandle handle = overlayMsg_show(caption, callback, opaque, fmt, args);
   va_end(args);
 
   core_updateOverlayState();

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -665,7 +665,7 @@ MsgBoxHandle app_confirmMsgBox(const char * caption,
   return handle;
 }
 
-void app_msgBoxClose(MsgBoxHandle * handle)
+void app_msgBoxClose(MsgBoxHandle handle)
 {
   if (!handle)
     return;

--- a/client/src/config.c
+++ b/client/src/config.c
@@ -480,6 +480,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_INT,
     .value.x_int    = 13
   },
+  {
+    .module         = "audio",
+    .name           = "micAlwaysAllow",
+    .description    = "Always allow guest attempts to access the microphone",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false
+  },
   {0}
 };
 
@@ -670,6 +677,7 @@ bool config_load(int argc, char * argv[])
 
   g_params.audioPeriodSize = option_get_int("audio", "periodSize");
   g_params.audioBufferLatency = option_get_int("audio", "bufferLatency");
+  g_params.micAlwaysAllow     = option_get_bool("audio", "micAlwaysAllow");
 
   return true;
 }

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -654,12 +654,6 @@ void core_resetOverlayInputState(void)
 
 void core_updateOverlayState(void)
 {
-  static bool lastState = false;
-  bool currentState = app_isOverlayMode();
-  if (lastState == currentState)
-    return;
-
-  lastState          = currentState;
   g_state.cursorLast = -2;
 
   static bool wasGrabbed = false;

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -202,6 +202,7 @@ struct AppParams
 
   int               audioPeriodSize;
   int               audioBufferLatency;
+  bool              micAlwaysAllow;
 };
 
 struct CBRequest

--- a/client/src/overlay/msg.c
+++ b/client/src/overlay/msg.c
@@ -219,7 +219,7 @@ MsgBoxHandle overlayMsg_show(
   return (MsgBoxHandle)msg;
 }
 
-void overlayMsg_close(MsgBoxHandle * handle)
+void overlayMsg_close(MsgBoxHandle handle)
 {
   if (ll_removeData(l_msg.messages, handle))
     freeMsg((struct Msg *)handle);

--- a/client/src/overlay/msg.h
+++ b/client/src/overlay/msg.h
@@ -32,6 +32,6 @@ MsgBoxHandle overlayMsg_show(
     const char * caption, MsgBoxConfirmCallback confirm, void * opaque,
     const char * fmt, va_list args);
 
-void overlayMsg_close(MsgBoxHandle * handle);
+void overlayMsg_close(MsgBoxHandle handle);
 
 #endif

--- a/client/src/overlay/msg.h
+++ b/client/src/overlay/msg.h
@@ -29,7 +29,8 @@
 bool overlayMsg_modal(void);
 
 MsgBoxHandle overlayMsg_show(
-    const char * caption, const char * fmt, va_list args);
+    const char * caption, MsgBoxConfirmCallback confirm, void * opaque,
+    const char * fmt, va_list args);
 
 void overlayMsg_close(MsgBoxHandle * handle);
 


### PR DESCRIPTION
This prevents rogue Windows applications from spying on you. To disable the prompts and always grant access, use `audio:micAlwaysAllow`.

This PR also includes the following fixes:
* Fix a bug in `core_updateOverlayState` that breaks message boxes when they show up the second time.
* Fix a type issue with `app_msgBoxClose`. It should not be taking a pointer to a handle. This bug was masked because it was declared as an alias of `void *` instead of pointer to a `struct`.
* Fix a bug with PipeWire backend not stopping recording