### PR TITLE
[client] audio: avoid prompting when changing record format

### DIFF
--- a/client/src/audio.c
+++ b/client/src/audio.c
@@ -803,7 +803,9 @@ void audio_recordStart(int channels, int sampleRate, PSAudioFormat format)
   lastChannels   = channels;
   lastSampleRate = sampleRate;
 
-  if (g_params.micAlwaysAllow)
+  if (audio.record.started)
+    realRecordStart(channels, sampleRate, format);
+  else if (g_params.micAlwaysAllow)
   {
     DEBUG_INFO("Microphone access granted by default");
     realRecordStart(channels, sampleRate, format);


### PR DESCRIPTION
If a recording is already in progress, we should not prompt again.