### PR TITLE
[client] audio/pw: pw_stream_get_time() deprecated

### DIFF
--- a/client/audiodevs/PipeWire/pipewire.c
+++ b/client/audiodevs/PipeWire/pipewire.c
@@ -368,7 +368,11 @@ static size_t pipewire_playbackLatency(void)
   struct pw_time time = { 0 };
 
   pw_thread_loop_lock(pw.thread);
+#if PW_CHECK_VERSION(0, 3, 50)
+  if (pw_stream_get_time_n(pw.playback.stream, &time, sizeof(time)) < 0)
+#else
   if (pw_stream_get_time(pw.playback.stream, &time) < 0)
+#endif
     DEBUG_ERROR("pw_stream_get_time failed");
   pw_thread_loop_unlock(pw.thread);
 


### PR DESCRIPTION
pw_stream_get_time() is deprecated in PipeWire 0.3.50. Use pw_stream_get_time_n() instead based on PipeWire
library version.

As of this writing the PipeWire master branch is still at 0.3.49, but the deprecation commit has been merged about a week ago, so this patch will not solve build issues until master is updated to 0.3.50. To build from PW master for now we can turn off Werror for deprecations `CFLAGS='-Wno-error=deprecated-declarations' cmake ..`