### PR TITLE
[client] overlay/graphs: allow unregistering after shutdown

### DIFF
--- a/client/src/overlay/graphs.c
+++ b/client/src/overlay/graphs.c
@@ -89,6 +89,7 @@ static void graphs_free(void * udata)
   while(ll_shift(gs.graphs, (void **)&graph))
     free(graph);
   ll_free(gs.graphs);
+  gs.graphs = NULL;
 }
 
 struct BufferMetrics
@@ -239,6 +240,9 @@ GraphHandle overlayGraph_register(const char * name, RingBuffer buffer,
 
 void overlayGraph_unregister(GraphHandle handle)
 {
+  if (!gs.graphs)
+    return;
+
   ll_removeData(gs.graphs, handle);
   free(handle);
 


### PR DESCRIPTION
The Wayland display server has a graph for presentation times, but the backend shuts down after the overlays, so calling `overlayGraph_unregister` causes memory corruption. We can avoid this problem by making unregister a noop after all graphs have been freed.

This is safe because updating the graph doesn't use the graph handle: instead you update the `ringbuffer` which is owned by the user.