### PR TITLE
[all] cmake: standardize indentation and remove warnings

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -66,7 +66,7 @@ add_compile_options(
   "-Wextra"
   "-Wno-sign-compare"
   "-Wno-unused-parameter"
-  "-Wstrict-prototypes"
+  "$<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>"
   "$<$<C_COMPILER_ID:GNU>:-Wimplicit-fallthrough=2>"
   "-Werror"
   "-Wfatal-errors"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -4,13 +4,13 @@ project(looking-glass-client C CXX)
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
-	message(FATAL_ERROR
-		"\n"
-		"In-source builds are not supported\n"
-		"See build instructions provided in: "
-		"${PROJECT_TOP}/doc/build.rst\n"
-		"Refusing to continue"
-	)
+  message(FATAL_ERROR
+    "\n"
+    "In-source builds are not supported\n"
+    "See build instructions provided in: "
+    "${PROJECT_TOP}/doc/build.rst\n"
+    "Refusing to continue"
+  )
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_TOP}/cmake/" "${PROJECT_SOURCE_DIR}/cmake/")
@@ -101,52 +101,51 @@ add_definitions(-D ATOMIC_LOCKING)
 add_definitions(-D GL_GLEXT_PROTOTYPES)
 
 add_custom_command(
-	OUTPUT	${CMAKE_BINARY_DIR}/version.c
-		${CMAKE_BINARY_DIR}/_version.c
-	COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
-		${PROJECT_TOP}/version.cmake
+  OUTPUT  ${CMAKE_BINARY_DIR}/version.c
+    ${CMAKE_BINARY_DIR}/_version.c
+  COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
+    ${PROJECT_TOP}/version.cmake
 )
 
 include_directories(
-	${PROJECT_TOP}
-	${PROJECT_SOURCE_DIR}/include
-	${CMAKE_BINARY_DIR}
-	${CMAKE_BINARY_DIR}/include
-
-        ${PROJECT_TOP}/repos/nanosvg/src
+  ${PROJECT_TOP}
+  ${PROJECT_SOURCE_DIR}/include
+  ${CMAKE_BINARY_DIR}
+  ${CMAKE_BINARY_DIR}/include
+  ${PROJECT_TOP}/repos/nanosvg/src
 )
 
 link_libraries(
-	${CMAKE_DL_LIBS}
-	rt
-	m
+  ${CMAKE_DL_LIBS}
+  rt
+  m
 )
 
 set(SOURCES
-	${CMAKE_BINARY_DIR}/version.c
-	src/main.c
-	src/core.c
-	src/app.c
-	src/audio.c
-	src/config.c
-	src/keybind.c
-	src/util.c
-	src/clipboard.c
-	src/kb.c
-	src/gl_dynprocs.c
-	src/egl_dynprocs.c
-	src/eglutil.c
-	src/overlay_utils.c
-	src/render_queue.c
+  ${CMAKE_BINARY_DIR}/version.c
+  src/main.c
+  src/core.c
+  src/app.c
+  src/audio.c
+  src/config.c
+  src/keybind.c
+  src/util.c
+  src/clipboard.c
+  src/kb.c
+  src/gl_dynprocs.c
+  src/egl_dynprocs.c
+  src/eglutil.c
+  src/overlay_utils.c
+  src/render_queue.c
 
-	src/overlay/splash.c
-	src/overlay/alert.c
-	src/overlay/fps.c
-	src/overlay/graphs.c
-	src/overlay/help.c
-	src/overlay/config.c
-	src/overlay/msg.c
-	src/overlay/status.c
+  src/overlay/splash.c
+  src/overlay/alert.c
+  src/overlay/fps.c
+  src/overlay/graphs.c
+  src/overlay/help.c
+  src/overlay/config.c
+  src/overlay/msg.c
+  src/overlay/status.c
 )
 
 # Force cimgui to build as a static library.
@@ -166,29 +165,29 @@ add_executable(looking-glass-client ${SOURCES})
 target_compile_definitions(looking-glass-client PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1)
 
 target_link_libraries(looking-glass-client
-	${EXE_FLAGS}
-	PkgConfig::FONTCONFIG
-	lg_resources
-	lg_common
-	displayservers
-	lgmp
-	purespice
-	renderers
-	cimgui
+  ${EXE_FLAGS}
+  PkgConfig::FONTCONFIG
+  lg_resources
+  lg_common
+  displayservers
+  lgmp
+  purespice
+  renderers
+  cimgui
 )
 
 if (ENABLE_PIPEWIRE OR ENABLE_PULSEAUDIO)
-	add_definitions(-D ENABLE_AUDIO)
-	add_subdirectory(audiodevs)
-	pkg_check_modules(SAMPLERATE REQUIRED IMPORTED_TARGET samplerate)
-	target_link_libraries(looking-glass-client
-		PkgConfig::SAMPLERATE
-		audiodevs
-	)
+  add_definitions(-D ENABLE_AUDIO)
+  add_subdirectory(audiodevs)
+  pkg_check_modules(SAMPLERATE REQUIRED IMPORTED_TARGET samplerate)
+  target_link_libraries(looking-glass-client
+    PkgConfig::SAMPLERATE
+    audiodevs
+  )
 endif()
 
 install(TARGETS looking-glass-client
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	COMPONENT binary)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT binary)
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/client/audiodevs/PipeWire/CMakeLists.txt
+++ b/client/audiodevs/PipeWire/CMakeLists.txt
@@ -3,19 +3,19 @@ project(audiodev_PipeWire LANGUAGES C)
 
 find_package(PkgConfig)
 pkg_check_modules(AUDIODEV_PipeWire REQUIRED IMPORTED_TARGET
-	libpipewire-0.3
+  libpipewire-0.3
 )
 
 add_library(audiodev_PipeWire STATIC
-	pipewire.c
+  pipewire.c
 )
 
 target_link_libraries(audiodev_PipeWire
-	PkgConfig::AUDIODEV_PipeWire
-	lg_common
+  PkgConfig::AUDIODEV_PipeWire
+  lg_common
 )
 
 target_include_directories(audiodev_PipeWire
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/client/audiodevs/PulseAudio/CMakeLists.txt
+++ b/client/audiodevs/PulseAudio/CMakeLists.txt
@@ -3,19 +3,19 @@ project(audiodev_PulseAudio LANGUAGES C)
 
 find_package(PkgConfig)
 pkg_check_modules(AUDIODEV_PulseAudio REQUIRED IMPORTED_TARGET
-	libpulse
+  libpulse
 )
 
 add_library(audiodev_PulseAudio STATIC
-	pulseaudio.c
+  pulseaudio.c
 )
 
 target_link_libraries(audiodev_PulseAudio
-	PkgConfig::AUDIODEV_PulseAudio
-	lg_common
+  PkgConfig::AUDIODEV_PulseAudio
+  lg_common
 )
 
 target_include_directories(audiodev_PulseAudio
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/client/displayservers/Wayland/CMakeLists.txt
+++ b/client/displayservers/Wayland/CMakeLists.txt
@@ -3,99 +3,99 @@ project(displayserver_Wayland LANGUAGES C)
 
 find_package(PkgConfig)
 pkg_check_modules(DISPLAYSERVER_Wayland REQUIRED IMPORTED_TARGET
-	wayland-client
-	wayland-cursor
-	xkbcommon
+  wayland-client
+  wayland-cursor
+  xkbcommon
 )
 
 set(DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES "")
 set(displayserver_Wayland_SHELL_SRC "")
 
 if (ENABLE_LIBDECOR)
-	pkg_check_modules(DISPLAYSERVER_Wayland_LIBDECOR REQUIRED IMPORTED_TARGET
-		libdecor-0
-	)
-	list(APPEND DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES PkgConfig::DISPLAYSERVER_Wayland_LIBDECOR)
-	list(APPEND displayserver_Wayland_SHELL_SRC shell_libdecor.c)
-	add_compile_definitions(ENABLE_LIBDECOR)
+  pkg_check_modules(DISPLAYSERVER_Wayland_LIBDECOR REQUIRED IMPORTED_TARGET
+    libdecor-0
+  )
+  list(APPEND DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES PkgConfig::DISPLAYSERVER_Wayland_LIBDECOR)
+  list(APPEND displayserver_Wayland_SHELL_SRC shell_libdecor.c)
+  add_compile_definitions(ENABLE_LIBDECOR)
 else()
-	list(APPEND displayserver_Wayland_SHELL_SRC shell_xdg.c)
+  list(APPEND displayserver_Wayland_SHELL_SRC shell_xdg.c)
 endif()
 
 add_library(displayserver_Wayland STATIC
-	activation.c
-	clipboard.c
-	cursor.c
-	gl.c
-	idle.c
-	input.c
-	output.c
-	poll.c
-	presentation.c
-	state.c
-	registry.c
-	wayland.c
-	window.c
-	${displayserver_Wayland_SHELL_SRC}
+  activation.c
+  clipboard.c
+  cursor.c
+  gl.c
+  idle.c
+  input.c
+  output.c
+  poll.c
+  presentation.c
+  state.c
+  registry.c
+  wayland.c
+  window.c
+  ${displayserver_Wayland_SHELL_SRC}
 )
 
 target_link_libraries(displayserver_Wayland
-	PkgConfig::DISPLAYSERVER_Wayland
-	${DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES}
-	lg_common
+  PkgConfig::DISPLAYSERVER_Wayland
+  ${DISPLAYSERVER_Wayland_OPT_PKGCONFIG_LIBRARIES}
+  lg_common
 )
 
 target_include_directories(displayserver_Wayland
-	PRIVATE
-		src
+  PRIVATE
+    src
 )
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 
 macro(wayland_generate protocol_file output_file)
-    add_custom_command(OUTPUT "${output_file}.h"
-        COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" client-header "${protocol_file}" "${output_file}.h"
-        DEPENDS "${protocol_file}"
-        VERBATIM)
+  add_custom_command(OUTPUT "${output_file}.h"
+    COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" client-header "${protocol_file}" "${output_file}.h"
+    DEPENDS "${protocol_file}"
+    VERBATIM)
 
-    add_custom_command(OUTPUT "${output_file}.c"
-        COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_file}" "${output_file}.c"
-        DEPENDS "${protocol_file}"
-        VERBATIM)
+  add_custom_command(OUTPUT "${output_file}.c"
+    COMMAND "${WAYLAND_SCANNER_EXECUTABLE}" private-code "${protocol_file}" "${output_file}.c"
+    DEPENDS "${protocol_file}"
+    VERBATIM)
 
-    target_sources(displayserver_Wayland PRIVATE "${output_file}.h" "${output_file}.c")
+  target_sources(displayserver_Wayland PRIVATE "${output_file}.h" "${output_file}.c")
 endmacro()
 
 set(WAYLAND_PROTOCOLS_BASE "${PROJECT_TOP}/repos/wayland-protocols")
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/wayland")
 include_directories("${CMAKE_BINARY_DIR}/wayland")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-shell-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-shell-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/stable/presentation-time/presentation-time.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-presentation-time-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/stable/presentation-time/presentation-time.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-presentation-time-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-viewporter-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-viewporter-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-decoration-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-decoration-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-relative-pointer-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/relative-pointer/relative-pointer-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-relative-pointer-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-pointer-constraints-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-pointer-constraints-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-keyboard-shortcuts-inhibit-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-keyboard-shortcuts-inhibit-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-idle-inhibit-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-idle-inhibit-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-output/xdg-output-unstable-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-output-unstable-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-output/xdg-output-unstable-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-output-unstable-v1-client-protocol")
 wayland_generate(
-    "${WAYLAND_PROTOCOLS_BASE}/staging/xdg-activation/xdg-activation-v1.xml"
-    "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-activation-v1-client-protocol")
+  "${WAYLAND_PROTOCOLS_BASE}/staging/xdg-activation/xdg-activation-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-activation-v1-client-protocol")

--- a/client/displayservers/X11/CMakeLists.txt
+++ b/client/displayservers/X11/CMakeLists.txt
@@ -3,29 +3,29 @@ project(displayserver_X11 LANGUAGES C)
 
 find_package(PkgConfig)
 pkg_check_modules(DISPLAYSERVER_X11 REQUIRED IMPORTED_TARGET
-	x11
-	xi
-	xfixes
-	xscrnsaver
-	xinerama
-	xcursor
-	xpresent
+  x11
+  xi
+  xfixes
+  xscrnsaver
+  xinerama
+  xcursor
+  xpresent
 )
 
 add_library(displayserver_X11 STATIC
-	x11.c
-	atoms.c
-	clipboard.c
+  x11.c
+  atoms.c
+  clipboard.c
 )
 
 add_definitions(-D GLX_GLXEXT_PROTOTYPES)
 
 target_link_libraries(displayserver_X11
-	PkgConfig::DISPLAYSERVER_X11
-	lg_common
+  PkgConfig::DISPLAYSERVER_X11
+  lg_common
 )
 
 target_include_directories(displayserver_X11
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/client/renderers/EGL/CMakeLists.txt
+++ b/client/renderers/EGL/CMakeLists.txt
@@ -3,114 +3,114 @@ project(renderer_EGL LANGUAGES C CXX)
 
 find_package(PkgConfig)
 pkg_check_modules(RENDERER_EGL REQUIRED IMPORTED_TARGET
-	egl
-	gl
+  egl
+  gl
 )
 
 pkg_check_modules(RENDERER_EGL_OPT IMPORTED_TARGET
-	wayland-egl
+  wayland-egl
 )
 
 find_program(AWK NAMES gawk mawk original-awk awk)
 
 if(AWK MATCHES ".+-NOTFOUND")
-	message(FATAL_ERROR "FATAL: some known version of awk couldn't be found (${AWK}).")
+  message(FATAL_ERROR "FATAL: some known version of awk couldn't be found (${AWK}).")
 else()
-	message(STATUS "Using awk: ${AWK}")
+  message(STATUS "Using awk: ${AWK}")
 endif()
 
 include(MakeObject)
 function(build_shaders header_dir)
-	file(GLOB headers "${header_dir}/*.h")
-	set(EGL_SHADER_PROCESSED)
-	foreach(shader ${ARGN})
-		set(out_f "${CMAKE_CURRENT_BINARY_DIR}/${shader}")
-		add_custom_command(OUTPUT "${out_f}"
-			COMMAND "${AWK}" -f "${CMAKE_CURRENT_SOURCE_DIR}/glsl.include.awk"
-					"${CMAKE_CURRENT_SOURCE_DIR}/${shader}" > "${out_f}"
-			MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${shader}"
-			DEPENDS ${headers}
-			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/shader"
-			COMMENT "Preprocessing shader ${shader}"
-			VERBATIM
-		)
-	endforeach()
+  file(GLOB headers "${header_dir}/*.h")
+  set(EGL_SHADER_PROCESSED)
+  foreach(shader ${ARGN})
+    set(out_f "${CMAKE_CURRENT_BINARY_DIR}/${shader}")
+    add_custom_command(OUTPUT "${out_f}"
+      COMMAND "${AWK}" -f "${CMAKE_CURRENT_SOURCE_DIR}/glsl.include.awk"
+              "${CMAKE_CURRENT_SOURCE_DIR}/${shader}" > "${out_f}"
+      MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${shader}"
+      DEPENDS ${headers}
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/shader"
+      COMMENT "Preprocessing shader ${shader}"
+      VERBATIM
+    )
+  endforeach()
 
-	set(CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-	make_object(
-		EGL_SHADER
-		${ARGN}
-	)
+  set(CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  make_object(
+    EGL_SHADER
+    ${ARGN}
+  )
 
-	set(EGL_SHADER_OBJS "${EGL_SHADER_OBJS}" PARENT_SCOPE)
-	set(EGL_SHADER_INCS "${EGL_SHADER_INCS}" PARENT_SCOPE)
+  set(EGL_SHADER_OBJS "${EGL_SHADER_OBJS}" PARENT_SCOPE)
+  set(EGL_SHADER_INCS "${EGL_SHADER_INCS}" PARENT_SCOPE)
 endfunction()
 
 build_shaders(
-	shader
-	shader/desktop.vert
-	shader/desktop_rgb.frag
-	shader/cursor.vert
-	shader/cursor_rgb.frag
-	shader/cursor_mono.frag
-	shader/damage.vert
-	shader/damage.frag
-	shader/basic.vert
-	shader/ffx_cas.frag
-	shader/ffx_fsr1_easu.frag
-	shader/ffx_fsr1_rcas.frag
-	shader/downscale.frag
-	shader/downscale_lanczos2.frag
-	shader/downscale_linear.frag
+  shader
+  shader/desktop.vert
+  shader/desktop_rgb.frag
+  shader/cursor.vert
+  shader/cursor_rgb.frag
+  shader/cursor_mono.frag
+  shader/damage.vert
+  shader/damage.frag
+  shader/basic.vert
+  shader/ffx_cas.frag
+  shader/ffx_fsr1_easu.frag
+  shader/ffx_fsr1_rcas.frag
+  shader/downscale.frag
+  shader/downscale_lanczos2.frag
+  shader/downscale_linear.frag
 )
 
 make_defines(
-	"${CMAKE_CURRENT_SOURCE_DIR}/shader/desktop_rgb.frag"
-	"${CMAKE_CURRENT_BINARY_DIR}/shader/desktop_rgb.def.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/shader/desktop_rgb.frag"
+  "${CMAKE_CURRENT_BINARY_DIR}/shader/desktop_rgb.def.h"
 )
 
 add_library(renderer_EGL STATIC
-	egl.c
-	egldebug.c
-	shader.c
-	texture_util.c
-	texture.c
-	texture_buffer.c
-	texture_framebuffer.c
-	texture_dmabuf.c
-	model.c
-	desktop.c
-	desktop_rects.c
-	cursor.c
-	damage.c
-	framebuffer.c
-	postprocess.c
-	ffx.c
-	filter.c
-	filter_ffx_cas.c
-	filter_ffx_fsr1.c
-	filter_downscale.c
-	${EGL_SHADER_OBJS}
-	"${CMAKE_CURRENT_BINARY_DIR}/shader/desktop_rgb.def.h"
-	${PROJECT_TOP}/repos/cimgui/imgui/backends/imgui_impl_opengl3.cpp
+  egl.c
+  egldebug.c
+  shader.c
+  texture_util.c
+  texture.c
+  texture_buffer.c
+  texture_framebuffer.c
+  texture_dmabuf.c
+  model.c
+  desktop.c
+  desktop_rects.c
+  cursor.c
+  damage.c
+  framebuffer.c
+  postprocess.c
+  ffx.c
+  filter.c
+  filter_ffx_cas.c
+  filter_ffx_fsr1.c
+  filter_downscale.c
+  ${EGL_SHADER_OBJS}
+  "${CMAKE_CURRENT_BINARY_DIR}/shader/desktop_rgb.def.h"
+  ${PROJECT_TOP}/repos/cimgui/imgui/backends/imgui_impl_opengl3.cpp
 )
 
 target_compile_definitions(renderer_EGL PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1 IMGUI_IMPL_OPENGL_ES3)
 
 target_link_libraries(renderer_EGL
-	PkgConfig::RENDERER_EGL
-	lg_common
+  PkgConfig::RENDERER_EGL
+  lg_common
 
-	cimgui
+  cimgui
 )
 if(RENDERER_EGL_OPT_FOUND)
-	target_link_libraries(renderer_EGL
-		PkgConfig::RENDERER_EGL_OPT
-	)
+  target_link_libraries(renderer_EGL
+    PkgConfig::RENDERER_EGL_OPT
+  )
 endif()
 
 target_include_directories(renderer_EGL
-	PRIVATE
-		src
-		${EGL_SHADER_INCS}
+  PRIVATE
+    src
+    ${EGL_SHADER_INCS}
 )

--- a/client/renderers/OpenGL/CMakeLists.txt
+++ b/client/renderers/OpenGL/CMakeLists.txt
@@ -3,24 +3,24 @@ project(renderer_Opengl LANGUAGES C CXX)
 
 find_package(PkgConfig)
 pkg_check_modules(RENDERER_OPENGL REQUIRED IMPORTED_TARGET
-	gl
+  gl
 )
 
 add_library(renderer_OpenGL STATIC
-	opengl.c
-	${PROJECT_TOP}/repos/cimgui/imgui/backends/imgui_impl_opengl2.cpp
+  opengl.c
+  ${PROJECT_TOP}/repos/cimgui/imgui/backends/imgui_impl_opengl2.cpp
 )
 
 target_compile_definitions(renderer_OpenGL PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1)
 
 target_link_libraries(renderer_OpenGL
-	PkgConfig::RENDERER_OPENGL
-	lg_common
+  PkgConfig::RENDERER_OPENGL
+  lg_common
 
-	cimgui
+  cimgui
 )
 
 target_include_directories(renderer_OpenGL
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -4,7 +4,7 @@ project(lg_common LANGUAGES C)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
 )
 
 add_definitions(-D_GNU_SOURCE)
@@ -42,8 +42,8 @@ add_library(lg_common STATIC ${COMMON_SOURCES})
 target_link_libraries(lg_common lg_common_platform)
 
 target_include_directories(lg_common
-	INTERFACE
-		include
-	PRIVATE
-		src
+  INTERFACE
+    include
+  PRIVATE
+    src
 )

--- a/common/src/platform/linux/CMakeLists.txt
+++ b/common/src/platform/linux/CMakeLists.txt
@@ -2,21 +2,21 @@ cmake_minimum_required(VERSION 3.0)
 project(lg_common_platform_code LANGUAGES C)
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
-	${PROJECT_TOP}
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_TOP}
 )
 
 add_library(lg_common_platform_code STATIC
-    debug.c
-    crash.c
-    sysinfo.c
-    thread.c
-    event.c
-    ivshmem.c
-    time.c
-    paths.c
-    open.c
-    cpuinfo.c
+  debug.c
+  crash.c
+  sysinfo.c
+  thread.c
+  event.c
+  ivshmem.c
+  time.c
+  paths.c
+  open.c
+  cpuinfo.c
 )
 
 if(ENABLE_BACKTRACE)
@@ -25,7 +25,7 @@ if(ENABLE_BACKTRACE)
 endif()
 
 target_link_libraries(lg_common_platform_code
-	lg_common
-	pthread
-	rt
+  lg_common
+  pthread
+  rt
 )

--- a/common/src/platform/windows/CMakeLists.txt
+++ b/common/src/platform/windows/CMakeLists.txt
@@ -2,49 +2,49 @@ cmake_minimum_required(VERSION 3.0)
 project(lg_common_platform_code LANGUAGES C)
 
 include_directories(
-        ${PROJECT_TOP}/vendor/ivshmem
+  ${PROJECT_TOP}/vendor/ivshmem
 )
 
 # allow use of functions for Windows 7 or later
 add_compile_definitions(WINVER=0x0601 _WIN32_WINNT=0x0601)
 
 if (MINGW)
-	# Build our own ntdll.dll import library
-	# This tricks MinGW into not linking stuff like memcpy from ntdll.dll instead of mscvrt.dll
-	if(NOT CMAKE_DLLTOOL)
-		# cmake older than 3.16 doesn't know how to find dlltool
-		find_program(CMAKE_DLLTOOL NAMES "x86_64-w64-mingw32-dlltool" "dlltool.exe" DOC "dlltool executable")
-	endif()
-	add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/ntdll.a"
-		COMMAND "${CMAKE_DLLTOOL}" -d "${PROJECT_SOURCE_DIR}/ntdll.def" -l "${PROJECT_BINARY_DIR}/ntdll.a"
-		MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/ntdll.def"
-		COMMENT "Building import library ntdll.a"
-		VERBATIM
-	)
-	add_custom_target(ntdll_target DEPENDS "${PROJECT_BINARY_DIR}/ntdll.a")
-	add_library(ntdll STATIC IMPORTED GLOBAL)
-	add_dependencies(ntdll ntdll_target)
-	set_target_properties(ntdll PROPERTIES IMPORTED_LOCATION "${PROJECT_BINARY_DIR}/ntdll.a")
+  # Build our own ntdll.dll import library
+  # This tricks MinGW into not linking stuff like memcpy from ntdll.dll instead of mscvrt.dll
+  if(NOT CMAKE_DLLTOOL)
+    # cmake older than 3.16 doesn't know how to find dlltool
+    find_program(CMAKE_DLLTOOL NAMES "x86_64-w64-mingw32-dlltool" "dlltool.exe" DOC "dlltool executable")
+  endif()
+  add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/ntdll.a"
+    COMMAND "${CMAKE_DLLTOOL}" -d "${PROJECT_SOURCE_DIR}/ntdll.def" -l "${PROJECT_BINARY_DIR}/ntdll.a"
+    MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/ntdll.def"
+    COMMENT "Building import library ntdll.a"
+    VERBATIM
+  )
+  add_custom_target(ntdll_target DEPENDS "${PROJECT_BINARY_DIR}/ntdll.a")
+  add_library(ntdll STATIC IMPORTED GLOBAL)
+  add_dependencies(ntdll ntdll_target)
+  set_target_properties(ntdll PROPERTIES IMPORTED_LOCATION "${PROJECT_BINARY_DIR}/ntdll.a")
 endif()
 
 add_library(lg_common_platform_code STATIC
-    debug.c
-    crash.c
-    sysinfo.c
-    thread.c
-    event.c
-    windebug.c
-    ivshmem.c
-    time.c
-    cpuinfo.c
+  debug.c
+  crash.c
+  sysinfo.c
+  thread.c
+  event.c
+  windebug.c
+  ivshmem.c
+  time.c
+  cpuinfo.c
 )
 
 target_link_libraries(lg_common_platform_code
-	lg_common
-	setupapi
-	ntdll
+  lg_common
+  setupapi
+  ntdll
 )
 
 if (ENABLE_BACKTRACE)
-    target_link_libraries(lg_common_platform_code dbghelp)
+  target_link_libraries(lg_common_platform_code dbghelp)
 endif()

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -4,13 +4,13 @@ project(looking-glass-host C)
 get_filename_component(PROJECT_TOP "${PROJECT_SOURCE_DIR}/.." ABSOLUTE)
 
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
-	message(FATAL_ERROR
-		"\n"
-		"In-source builds are not supported\n"
-		"See build instructions provided in: "
-		"${PROJECT_TOP}/doc/build.rst\n"
-		"Refusing to continue"
-	)
+  message(FATAL_ERROR
+    "\n"
+    "In-source builds are not supported\n"
+    "See build instructions provided in: "
+    "${PROJECT_TOP}/doc/build.rst\n"
+    "Refusing to continue"
+  )
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_TOP}/cmake/" "${PROJECT_SOURCE_DIR}/cmake/")
@@ -62,16 +62,16 @@ if(ENABLE_UBSAN)
 endif()
 
 add_custom_command(
-	OUTPUT	${CMAKE_BINARY_DIR}/version.c
+  OUTPUT  ${CMAKE_BINARY_DIR}/version.c
     ${CMAKE_BINARY_DIR}/include/version.h
-		${CMAKE_BINARY_DIR}/_version.c
-	COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
-		${PROJECT_TOP}/version.cmake
+    ${CMAKE_BINARY_DIR}/_version.c
+  COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
+    ${PROJECT_TOP}/version.cmake
 )
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
-	${CMAKE_BINARY_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
+  ${CMAKE_BINARY_DIR}/include
 )
 
 #link_libraries(
@@ -84,8 +84,8 @@ endif()
 
 
 set(SOURCES
-	${CMAKE_BINARY_DIR}/version.c
-	src/app.c
+  ${CMAKE_BINARY_DIR}/version.c
+  src/app.c
 )
 
 add_subdirectory("${PROJECT_TOP}/common"          "${CMAKE_BINARY_DIR}/common")
@@ -104,9 +104,9 @@ else()
   add_executable(looking-glass-host ${SOURCES})
 endif()
 target_link_libraries(looking-glass-host
-	lg_common
-	platform
-	lgmp
+  lg_common
+  platform
+  lgmp
 )
 
 if(WIN32)
@@ -116,7 +116,7 @@ else()
 endif()
 
 install(TARGETS looking-glass-host
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	COMPONENT binary)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  COMPONENT binary)
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/host/platform/Linux/CMakeLists.txt
+++ b/host/platform/Linux/CMakeLists.txt
@@ -2,22 +2,22 @@ cmake_minimum_required(VERSION 3.0)
 project(platform_Linux LANGUAGES C)
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
 )
 
 add_library(platform_Linux STATIC
-	src/platform.c
+  src/platform.c
 )
 
 add_subdirectory("capture")
 
 target_link_libraries(platform_Linux
-	m
-	capture
-	pthread
+  m
+  capture
+  pthread
 )
 
 target_include_directories(platform_Linux
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/host/platform/Linux/capture/XCB/CMakeLists.txt
+++ b/host/platform/Linux/capture/XCB/CMakeLists.txt
@@ -2,17 +2,17 @@ cmake_minimum_required(VERSION 3.0)
 project(capture_XCB LANGUAGES C)
 
 add_library(capture_XCB STATIC
-	src/xcb.c
+  src/xcb.c
 )
 
 target_link_libraries(capture_XCB
-	lg_common
-	xcb
-	xcb-shm
-	xcb-xfixes
+  lg_common
+  xcb
+  xcb-shm
+  xcb-xfixes
 )
 
 target_include_directories(capture_XCB
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/host/platform/Linux/capture/pipewire/CMakeLists.txt
+++ b/host/platform/Linux/capture/pipewire/CMakeLists.txt
@@ -3,23 +3,23 @@ project(capture_pipewire LANGUAGES C)
 
 find_package(PkgConfig)
 pkg_check_modules(CAPTURE_PIPEWIRE REQUIRED IMPORTED_TARGET
-	gio-2.0
-	gio-unix-2.0
-	libpipewire-0.3
-	libspa-0.2
+  gio-2.0
+  gio-unix-2.0
+  libpipewire-0.3
+  libspa-0.2
 )
 
 add_library(capture_pipewire STATIC
-	src/pipewire.c
-	src/portal.c
+  src/pipewire.c
+  src/portal.c
 )
 
 target_link_libraries(capture_pipewire
-	PkgConfig::CAPTURE_PIPEWIRE
-	lg_common
+  PkgConfig::CAPTURE_PIPEWIRE
+  lg_common
 )
 
 target_include_directories(capture_pipewire
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/host/platform/Windows/CMakeLists.txt
+++ b/host/platform/Windows/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.0)
 project(platform_Windows LANGUAGES C)
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
 )
 
 add_library(platform_Windows STATIC
-	src/platform.c
-	src/service.c
-	src/mousehook.c
-	src/force_compose.c
+  src/platform.c
+  src/service.c
+  src/mousehook.c
+  src/force_compose.c
 )
 
 # allow use of functions for Windows 7 or later
@@ -18,21 +18,21 @@ add_compile_definitions(WINVER=0x0601 _WIN32_WINNT=0x0601)
 add_subdirectory("capture")
 
 target_link_libraries(platform_Windows
-	lg_common
-	capture
+  lg_common
+  capture
 
-	userenv
-	wtsapi32
-	psapi
-	shlwapi
-	powrprof
-	rpcrt4
-	avrt
+  userenv
+  wtsapi32
+  psapi
+  shlwapi
+  powrprof
+  rpcrt4
+  avrt
 )
 
 target_include_directories(platform_Windows
-	PRIVATE
-		src
+  PRIVATE
+    src
 )
 
 # these are for the nsis installer generator

--- a/host/platform/Windows/capture/DXGI/CMakeLists.txt
+++ b/host/platform/Windows/capture/DXGI/CMakeLists.txt
@@ -2,24 +2,24 @@ cmake_minimum_required(VERSION 3.0)
 project(capture_DXGI LANGUAGES C)
 
 add_library(capture_DXGI STATIC
-	src/dxgi.c
-	src/d3d11.c
-	src/d3d12.c
-	src/ods_capture.c
-	src/util.c
+  src/dxgi.c
+  src/d3d11.c
+  src/d3d12.c
+  src/ods_capture.c
+  src/util.c
 )
 
 add_definitions("-DCOBJMACROS -DINITGUID")
 
 target_link_libraries(capture_DXGI
-	lg_common
-	d3d11
-	dxgi
-	dwmapi
+  lg_common
+  d3d11
+  dxgi
+  dwmapi
 )
 
 target_include_directories(capture_DXGI
-	PRIVATE
-		src
-		"${PROJECT_TOP}/vendor/directx"
+  PRIVATE
+    src
+    "${PROJECT_TOP}/vendor/directx"
 )

--- a/host/platform/Windows/capture/NVFBC/CMakeLists.txt
+++ b/host/platform/Windows/capture/NVFBC/CMakeLists.txt
@@ -2,20 +2,20 @@ cmake_minimum_required(VERSION 3.0)
 project(capture_NVFBC LANGUAGES C CXX)
 
 add_library(capture_NVFBC STATIC
-	src/nvfbc.c
-	src/wrapper.cpp
+  src/nvfbc.c
+  src/wrapper.cpp
 )
 
 file(TO_CMAKE_PATH "${NVFBC_SDK}" nvfbc_sdk)
 include_directories(file, "${nvfbc_sdk}/inc")
 
 target_link_libraries(capture_NVFBC
-	platform_Windows
-	dwmapi
-	d3d9
+  platform_Windows
+  dwmapi
+  d3d9
 )
 
 target_include_directories(capture_NVFBC
-	PRIVATE
-		src
+  PRIVATE
+    src
 )

--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -31,46 +31,46 @@ set(EXE_FLAGS "-Wl,--gc-sections")
 set(CMAKE_C_STANDARD 11)
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(OBS_PLUGIN_DIR 64bit)
+  set(OBS_PLUGIN_DIR 64bit)
 else()
-	set(OBS_PLUGIN_DIR 32bit)
+  set(OBS_PLUGIN_DIR 32bit)
 endif()
 
 if(USER_INSTALL)
-	if(DEFINED ENV{XDG_CONFIG_HOME})
-		set(OBS_PLUGIN_PREFIX $ENV{XDG_CONFIG_HOME})
-	else()
-		set(OBS_PLUGIN_PREFIX $ENV{HOME}/.config)
-	endif()
-	set(OBS_PLUGIN_PREFIX ${OBS_PLUGIN_PREFIX}/obs-studio/plugins)
+  if(DEFINED ENV{XDG_CONFIG_HOME})
+    set(OBS_PLUGIN_PREFIX $ENV{XDG_CONFIG_HOME})
+  else()
+    set(OBS_PLUGIN_PREFIX $ENV{HOME}/.config)
+  endif()
+  set(OBS_PLUGIN_PREFIX ${OBS_PLUGIN_PREFIX}/obs-studio/plugins)
 else()
-	set(OBS_PLUGIN_PREFIX ${CMAKE_INSTALL_DATADIR}/obs/obs-plugins)
+  set(OBS_PLUGIN_PREFIX ${CMAKE_INSTALL_DATADIR}/obs/obs-plugins)
 endif()
 
 add_definitions(-D ATOMIC_LOCKING)
 
 add_custom_command(
-	OUTPUT	${CMAKE_BINARY_DIR}/version.c
-		${CMAKE_BINARY_DIR}/_version.c
-	COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
-		${PROJECT_TOP}/version.cmake
+  OUTPUT  ${CMAKE_BINARY_DIR}/version.c
+    ${CMAKE_BINARY_DIR}/_version.c
+  COMMAND ${CMAKE_COMMAND} -D PROJECT_TOP=${PROJECT_TOP} -P
+    ${PROJECT_TOP}/version.cmake
 )
 
 include_directories(
-	${PROJECT_SOURCE_DIR}/include
-	${CMAKE_BINARY_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include
+  ${CMAKE_BINARY_DIR}/include
 )
 
 link_libraries(
-	${CMAKE_DL_LIBS}
-	rt
-	m
+  ${CMAKE_DL_LIBS}
+  rt
+  m
 )
 
 set(SOURCES
-	${CMAKE_BINARY_DIR}/version.c
-	main.c
-	lg.c
+  ${CMAKE_BINARY_DIR}/version.c
+  main.c
+  lg.c
 )
 
 add_subdirectory("${PROJECT_TOP}/common"          "${CMAKE_BINARY_DIR}/common")
@@ -78,13 +78,13 @@ add_subdirectory("${PROJECT_TOP}/repos/LGMP/lgmp" "${CMAKE_BINARY_DIR}/lgmp"  )
 
 add_library(looking-glass-obs SHARED ${SOURCES})
 target_link_libraries(looking-glass-obs
-	${EXE_FLAGS}
-	lg_common
-	lgmp
+  ${EXE_FLAGS}
+  lg_common
+  lgmp
 )
 
 install(TARGETS looking-glass-obs
-	LIBRARY DESTINATION ${OBS_PLUGIN_PREFIX}/${CMAKE_PROJECT_NAME}/bin/${OBS_PLUGIN_DIR}
+  LIBRARY DESTINATION ${OBS_PLUGIN_PREFIX}/${CMAKE_PROJECT_NAME}/bin/${OBS_PLUGIN_DIR}
 )
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)


### PR DESCRIPTION
This PR standardizes cmake indentation to 2 spaces.

It also makes it so that `-Wstrict-prototypes` is passed for C only to avoid this warning:

```
cc1plus: warning: command-line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
```