### PR TITLE
[module] fix compile on 5.18

### DIFF
--- a/module/kvmfr.c
+++ b/module/kvmfr.c
@@ -28,6 +28,7 @@
 #include <linux/fs.h>
 #include <linux/dma-buf.h>
 #include <linux/highmem.h>
+#include <linux/memremap.h>
 #include <linux/version.h>
 
 #include <asm/io.h>


### PR DESCRIPTION
module compilation fails on kernel 5.18 because dev_pagemap, devm_memremap_pages and devm_memunmap_pages are not included anymore. memremap.h must be explicitly included to fix this.

Tested on Arch kernel: 5.18.0-arch1-1