### PR TITLE
[client] wayland: fix infinite resize loop

### DIFF
--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -128,7 +128,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
         (struct Border) {0, 0, 0, 0});
     app_invalidateWindow(true);
     waylandStopWaitFrame();
-    wlWm.needsResize = !skipResize;
+    wlWm.needsResize = skipResize;
   }
 
   waylandShellAckConfigureIfNeeded();


### PR DESCRIPTION
The intention has been to keep `wlWm.needsResize` true when skipping resize, but I accidentally negated the value.