### PR TITLE
[client] keybind: add ScrollLock+C to toggle microphone defaults

### DIFF
--- a/client/src/audio.c
+++ b/client/src/audio.c
@@ -814,9 +814,9 @@ void audio_recordStart(int channels, int sampleRate, PSAudioFormat format)
 
   if (audio.record.started)
     realRecordStart(channels, sampleRate, format);
-  else if (g_params.micDefaultState == MIC_DEFAULT_DENY)
+  else if (g_state.micDefaultState == MIC_DEFAULT_DENY)
     DEBUG_INFO("Microphone access denied by default");
-  else if (g_params.micDefaultState == MIC_DEFAULT_ALLOW)
+  else if (g_state.micDefaultState == MIC_DEFAULT_ALLOW)
   {
     DEBUG_INFO("Microphone access granted by default");
     realRecordStart(channels, sampleRate, format);

--- a/client/src/keybind.c
+++ b/client/src/keybind.c
@@ -139,6 +139,27 @@ void keybind_commonRegister(void)
       "Toggle overlay");
 }
 
+#if ENABLE_AUDIO
+static void bind_toggleMicDefault(int sc, void * opaque)
+{
+  g_state.micDefaultState = (g_state.micDefaultState + 1) % MIC_DEFAULT_MAX;
+
+  switch (g_state.micDefaultState)
+  {
+    case MIC_DEFAULT_PROMPT:
+      app_alert(LG_ALERT_INFO, "Microphone access will prompt");
+      break;
+
+    case MIC_DEFAULT_ALLOW:
+      app_alert(LG_ALERT_INFO, "Microphone access allowed by default");
+      break;
+
+    case MIC_DEFAULT_DENY:
+      app_alert(LG_ALERT_INFO, "Microphone access denied by default");
+  }
+}
+#endif
+
 void keybind_spiceRegister(void)
 {
   /* register the common keybinds for spice */
@@ -170,6 +191,8 @@ void keybind_spiceRegister(void)
     {
       app_registerKeybind(0, 'E', audio_recordToggleKeybind, NULL,
           "Toggle audio recording");
+      app_registerKeybind(0, 'C', bind_toggleMicDefault, NULL,
+          "Cycle audio recording default");
     }
 #endif
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1227,6 +1227,8 @@ static int lg_run(void)
   };
   purespice_init(&psInit);
 
+  g_state.micDefaultState = g_params.micDefaultState;
+
   if (g_params.useSpiceInput     ||
       g_params.useSpiceClipboard ||
       g_params.useSpiceAudio)

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -147,6 +147,8 @@ struct AppState
   bool     resizeDone;
 
   bool     autoIdleInhibitState;
+
+  enum MicDefaultState micDefaultState;
 };
 
 struct AppParams

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -50,6 +50,7 @@ enum MicDefaultState {
   MIC_DEFAULT_ALLOW,
   MIC_DEFAULT_DENY
 };
+#define MIC_DEFAULT_MAX (MIC_DEFAULT_DENY + 1)
 
 struct AppState
 {


### PR DESCRIPTION
This makes it possible to change the default action taken the next time an application tries to open the microphone without restarting the client.