### PR TITLE
Add myself to CODEOWNERS for docs/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Jonathan Rubenstein (JJRcop)
+# - Primary documentation manager. Does not require direct approval for every
+# - change, but should be consulted for large additions and changes.
+docs/ jrubcop@gmail.com


### PR DESCRIPTION
This way I should be notified for changes that interact with this directory.

I would need to be added as a collaborator, which would give me [some inseparable rights and access](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-personal-account-settings/permission-levels-for-a-personal-account-repository#collaborator-access-for-a-repository-owned-by-a-personal-account) outside of the scope of just code owner.