### PR TITLE
[client] main: better error when no display server is available

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -154,6 +154,7 @@ static bool waylandGetProp(LG_DSProperty prop, void * ret)
 
 struct LG_DisplayServerOps LGDS_Wayland =
 {
+  .name                = "Wayland",
   .setup               = waylandSetup,
   .probe               = waylandProbe,
   .earlyInit           = waylandEarlyInit,

--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -1922,6 +1922,7 @@ static void x11Minimize(void)
 
 struct LG_DisplayServerOps LGDS_X11 =
 {
+  .name               = "X11",
   .setup              = x11Setup,
   .probe              = x11Probe,
   .earlyInit          = x11EarlyInit,

--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -110,6 +110,8 @@ typedef struct LGEvent LGEvent;
 
 struct LG_DisplayServerOps
 {
+  const char * name;
+
   /* called before options are parsed, useful for registering options */
   void (*setup)(void);
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1162,7 +1162,14 @@ static int lg_run(void)
       break;
     }
 
-  DEBUG_ASSERT(g_state.ds);
+  if (!g_state.ds)
+  {
+    DEBUG_ERROR("No display servers available, tried:");
+    for (int i = 0; i < LG_DISPLAYSERVER_COUNT; ++i)
+      DEBUG_ERROR("* %s", LG_DisplayServers[i]->name);
+    return -1;
+  }
+
   ASSERT_LG_DS_VALID(g_state.ds);
 
   if (g_params.jitRender)


### PR DESCRIPTION
This commit makes it show a prettier error message when no display server is available, including the display servers compiled. This replaces the old assert.

Example output:

```
[E] 572277145932              main.c:1167 | lg_run                         | No display servers available, tried:
[E] 572277145934              main.c:1169 | lg_run                         | * Wayland
[E] 572277145935              main.c:1169 | lg_run                         | * X11
```