### PR TITLE
Fix host not building on Void Linux

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -74,8 +74,9 @@ include_directories(
   ${CMAKE_BINARY_DIR}/include
 )
 
-#link_libraries(
-#)
+link_libraries(
+	${CMAKE_DL_LIBS}
+)
 
 if (ENABLE_ASAN OR ENABLE_UBSAN)
   link_directories("c:/msys64/clang64/lib/clang/12.0.0/lib/windows")


### PR DESCRIPTION
Explicit linking of `${CMAKE_DL_LIBS}`

Clone of #223 for host.  
Fixes #222 for host.