### PR TITLE
[client] wayland: handle wl_data_source.target action

### DIFF
--- a/client/displayservers/Wayland/clipboard.c
+++ b/client/displayservers/Wayland/clipboard.c
@@ -512,6 +512,13 @@ error:
   free(data);
 }
 
+static void dataSourceHandleTarget(void * data, struct wl_data_source * source,
+    const char * mimetype)
+{
+  // Certain Wayland clients send this for copy-paste operations even though
+  // it only makes sense for drag-and-drop. We just do nothing.
+}
+
 static void dataSourceHandleSend(void * data, struct wl_data_source * source,
     const char * mimetype, int fd)
 {
@@ -547,7 +554,8 @@ static void dataSourceHandleCancelled(void * data,
 }
 
 static const struct wl_data_source_listener dataSourceListener = {
-  .send = dataSourceHandleSend,
+  .target    = dataSourceHandleTarget,
+  .send      = dataSourceHandleSend,
   .cancelled = dataSourceHandleCancelled,
 };
 


### PR DESCRIPTION
There is no action to be taken by the Looking Glass client, but a handler needs to exist as certain other Wayland clients chooses to
send this message for copy-paste operations despite the fact it's supposed to be used for drag-and-drop negotiation.