### PR TITLE
X11 mouse is invisible even if hideCursor is false

### DIFF
--- a/client/include/interface/displayserver.h
+++ b/client/include/interface/displayserver.h
@@ -97,6 +97,8 @@ typedef struct LG_DSInitParams
   // x11 needs to know if this is in use so we can decide to setup for
   // presentation times
   bool jitRender;
+  // x11 needs this early to not override the defaults.
+  bool hideMouse;
 }
 LG_DSInitParams;
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1305,7 +1305,8 @@ static int lg_run(void)
     .borderless          = g_params.borderless,
     .maximize            = g_params.maximize,
     .opengl              = needsOpenGL,
-    .jitRender           = g_params.jitRender
+    .jitRender           = g_params.jitRender,
+    .hideMouse           = g_params.hideMouse
   };
 
   g_state.dsInitialized = g_state.ds->init(params);


### PR DESCRIPTION
x11Init assumes you're going to be hiding the mouse, so defines the cursor unconditionally.

FWIW the 'dot' cursor is always invisible on my system if it works at all.

I don't see a good way to fix this.  The other option is to take the XDefineCursor call out of x11Init() entirely, and leave it up to the rest of the code if .SetPointer() should be used.