### PR TITLE
Add spice cursor channel support

### DIFF
--- a/client/src/app.c
+++ b/client/src/app.c
@@ -1087,12 +1087,14 @@ bool app_useSpiceDisplay(bool enable)
   if (enable)
   {
     purespice_connectChannel(PS_CHANNEL_DISPLAY);
+    purespice_connectChannel(PS_CHANNEL_CURSOR);
     renderQueue_spiceShow(true);
   }
   else
   {
     renderQueue_spiceShow(false);
     purespice_disconnectChannel(PS_CHANNEL_DISPLAY);
+    purespice_disconnectChannel(PS_CHANNEL_CURSOR);
   }
 
   overlayStatus_set(LG_USER_STATUS_SPICE, enable);

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -150,6 +150,8 @@ struct AppState
   bool     autoIdleInhibitState;
 
   enum MicDefaultState micDefaultState;
+
+  int spiceHotX, spiceHotY;
 };
 
 struct AppParams

--- a/client/src/render_queue.h
+++ b/client/src/render_queue.h
@@ -27,7 +27,9 @@ typedef struct
     SPICE_OP_CONFIGURE,
     SPICE_OP_DRAW_FILL,
     SPICE_OP_DRAW_BITMAP,
-    SPICE_OP_SHOW
+    SPICE_OP_SHOW,
+    CURSOR_OP_STATE,
+    CURSOR_OP_IMAGE,
   }
   op;
 
@@ -62,6 +64,26 @@ typedef struct
       bool show;
     }
     spiceShow;
+
+    struct
+    {
+      bool visible;
+      int  x;
+      int  y;
+      int  hx;
+      int  hy;
+    }
+    cursorState;
+
+    struct
+    {
+      bool      monochrome;
+      int       width;
+      int       height;
+      int       pitch;
+      uint8_t * data;
+    }
+    cursorImage;
   };
 }
 RenderCommand;
@@ -80,3 +102,8 @@ void renderQueue_spiceDrawBitmap(int x, int y, int width, int height, int stride
     void * data, bool topDown);
 
 void renderQueue_spiceShow(bool show);
+
+void renderQueue_cursorState(bool visible, int x, int y, int hx, int hy);
+
+void renderQueue_cursorImage(bool monochrome, int width, int height, int pitch,
+    uint8_t * data);


### PR DESCRIPTION
This PR allows "hardware" cursors on the Spice display to be shown.

Both RGBA and monochrome cursors are tested.