### PR TITLE
[client] egl: recalculate mouse position when toggling spice

### DIFF
--- a/client/renderers/EGL/egl.c
+++ b/client/renderers/EGL/egl.c
@@ -1242,6 +1242,7 @@ static void egl_spiceShow(LG_Renderer * renderer, bool show)
 {
   struct Inst * this = UPCAST(struct Inst, renderer);
   this->showSpice = show;
+  egl_calc_mouse_size(this);
   egl_desktopSpiceShow(this->desktop, show);
 }
 


### PR DESCRIPTION
Without this step, the cursor with be transformed for rendering the spice cursor, not the IVSHMEM cursor.