### PR TITLE
[client] wayland: fix attempt to confine when pointer is locked

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -465,7 +465,7 @@ void waylandGrabPointer(void)
 
   INTERLOCKED_SECTION(wlWm.confineLock,
   {
-    if (!wlWm.confinedPointer)
+    if (!wlWm.confinedPointer && !wlWm.lockedPointer)
     {
       wlWm.confinedPointer = zwp_pointer_constraints_v1_confine_pointer(
           wlWm.pointerConstraints, wlWm.surface, wlWm.pointer, NULL,


### PR DESCRIPTION
This fixes the following crash when attempt to toggle capture at the right after closing the overlay:

    zwp_pointer_constraints_v1@12: error 1: a pointer constraint with a wl_pointer of the same wl_seat is already on this surface