### PR TITLE
[doc] usage: fix command name bolding

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -3,7 +3,9 @@
 Client usage
 ------------
 
-**``looking-glass-client``** ``[--help] [-f] [-F] [-s] [-S] [options...]``
+.. raw:: html
+
+   <p><code class="literal"><b>looking-glass-client</b> [--help] [-f] [-F] [-s] [-S] [options...]</code></p>
 
 
 .. _client_cli_options:


### PR DESCRIPTION
Note that ```**``looking-glass-client``**``` is not valid syntax.