### PR TITLE
[doc] usage: improve ini syntax documentation

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -110,13 +110,17 @@ the system-wide configuration.
 When first launched, the Looking-Glass client will create the folder
 ``$XDG_CONFIG_HOME/looking-glass/`` if it does not yet exist.
 
-The format of config files is the commonly known INI format, for example::
+The format of config files is the commonly known INI format, for example:
+
+.. code-block:: ini
 
    [win]
    fullScreen=yes
 
    [egl]
    nvGain=1
+
+   ; this is a comment
 
 Command line arguments will override any options loaded from config
 files.


### PR DESCRIPTION
This uses syntax highlighting for the config file and also documents the ; comment character.