### PR TITLE
Remove non-prototype function declarations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,7 +9,7 @@ arcnmx <arcnmx@users.noreply.github.com> (arcnmx)
 TheCakeIsNaOH <TheCakeIsNaOH@gmail.com> (TheCakeIsNaOH)
 NamoDev <namodev@users.noreply.github.com> (NamoDev)
 feltcat <58396817+feltcat@users.noreply.github.com> (feltcat)
-Ali Abdel-Qader <abdelqaderali@protonmail.com>
+Ali Abdel-Qader <abdelqaderali@protonmail.com> (thrifty-txt)
 Jack Karamanian <karamanian.jack@gmail.com>
 Mikko Rasa <tdb@tdb.fi> (DataBeaver)
 Omar Pakker <Omar007@users.noreply.github.com> (Omar007)

--- a/client/displayservers/X11/clipboard.c
+++ b/client/displayservers/X11/clipboard.c
@@ -103,7 +103,7 @@ bool x11CBEventThread(const XEvent xe)
   return false;
 }
 
-bool x11CBInit()
+bool x11CBInit(void)
 {
   x11cb.aCurSelection = BadValue;
   for(int i = 0; i < LG_CLIPBOARD_DATA_NONE; ++i)

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -458,7 +458,7 @@ void app_handleMouseRelative(double normx, double normy,
 // cursor warp support. Instead, we attempt a best-effort emulation which works
 // with a 1:1 mouse movement patch applied in the guest. For anything fancy, use
 // capture mode.
-void app_handleMouseBasic()
+void app_handleMouseBasic(void)
 {
   /* do not pass mouse events to the guest if we do not have focus */
   if (!g_cursor.guest.valid || !g_state.haveSrcSize || !g_state.focused ||
@@ -495,7 +495,7 @@ void app_handleMouseBasic()
     DEBUG_ERROR("failed to send mouse motion message");
 }
 
-void app_resyncMouseBasic()
+void app_resyncMouseBasic(void)
 {
   if (!g_cursor.guest.valid)
     return;


### PR DESCRIPTION
With -Wstrict-prototypes on non-protyped functions are deprecated and functions must include a void parameter if they do not take parameters.