### PR TITLE
[client] corrected mistaken constant name

### DIFF
--- a/client/audiodevs/PipeWire/pipewire.c
+++ b/client/audiodevs/PipeWire/pipewire.c
@@ -138,7 +138,7 @@ static bool pipewire_init(void)
     pw.loop,
     pw_properties_new(
       // Request real-time priority on the PipeWire threads
-      PW_KEY_CONFIG_NAME, "client-rt.conf",
+      PW_KEY_CORE_NAME, "client-rt.conf",
       NULL
     ),
     0);


### PR DESCRIPTION
I was building the client in my Debian system, and this error came up; I think that the name of the constant was wrong. This change worked for me. I hope it helps.