### PR TITLE
[obs] Fix function call causing crash on lgUpdate

### DIFF
--- a/obs/lg.c
+++ b/obs/lg.c
@@ -156,7 +156,7 @@ static void deinit(LGPlugin * this)
     case STATE_STOPPING:
     case STATE_RESTARTING:
       this->state = STATE_STOPPING;
-      createThreads(this);
+      waitThreads(this);
       this->state = STATE_STOPPED;
       /* fallthrough */
 


### PR DESCRIPTION
Small oversight from my last PR that was causing a crash on properties save when clicking "Cancel" in the plugin properties window.  Turns out the frame/pointer threads were being mismanaged in deinit() due to calling the incorrect function.