### PR TITLE
[host] improve logging to avoid confusion

### DIFF
--- a/host/platform/Windows/src/platform.c
+++ b/host/platform/Windows/src/platform.c
@@ -526,7 +526,13 @@ bool app_init(void)
 
   // redirect stderr to a file
   if (logFile && strcmp(logFile, "stderr") != 0)
-    freopen(logFile, "a", stderr);
+  {
+    DEBUG_INFO("Logs will be written to: %s", logFile);
+    DEBUG_INFO("Please see there for any further information");
+
+    if (!freopen(logFile, "a", stderr))
+      DEBUG_WARN("Failed to open log file, will log to stderr");
+  }
 
   // always flush stderr
   setbuf(stderr, NULL);

--- a/host/src/app.c
+++ b/host/src/app.c
@@ -748,7 +748,7 @@ int app_main(int argc, char * argv[])
   if (option_load(configFile))
     DEBUG_INFO("Configuration file loaded");
   else
-    DEBUG_INFO("Configuration file not found or invalid");
+    DEBUG_INFO("Configuration file not found or invalid, continuing anyway...");
 
   // parse the command line arguments
   if (!option_parse(argc, argv))


### PR DESCRIPTION
This PR does two things:
* clarify that config file not found is not fatal to prevent users from thinking this is the problem they are facing.
* log to stderr that logs will continue in log file on Windows to prevents users from posting the stderr as if it's the only output.

This should be merged for B6 to reduce support volume.