### PR TITLE
[client] wayland: implement window size setting for xdg-shell

### DIFF
--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -112,6 +112,7 @@ struct WaylandDSState
   bool fractionalScale;
   bool needsResize;
   bool fullscreen;
+  bool floating;
   uint32_t resizeSerial;
   bool configured;
   bool warpSupport;


### PR DESCRIPTION
This should allow `win:autoResize` to work on Wayland when the compositor supports such an operation.