### PR TITLE
[doc] troubleshooting: Rewrite missing desktop

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -1,9 +1,9 @@
-.. _requrements:
+.. _requirements:
 
 Requirements
 ############
 
-.. _minimum_:
+.. _minimum:
 
 Minimum
 -------
@@ -29,6 +29,11 @@ Hyper-threading (>= 12 threads).
 PCIe bandwidth can also be a limiting factor, as such both GPUs should have a
 minimum of 8 lanes (x8) at PCIe3 speeds, or 4 lanes (x4) at PCIe4 speeds.
 
+.. _connected_display:
+
+Connected Display
+^^^^^^^^^^^^^^^^^
+
 The GPU used for the guest virtual machine must have either a physical monitor
 attached to it, or a cheap dummy plug. The guest operating system (most notably
 Windows) will disable the GPU output if there is nothing attached to it and
@@ -36,7 +41,7 @@ Looking Glass will not be able to function. If you are using a vGPU the virtual
 device should already have a virtual monitor attached to it negating this
 requirement.
 
-.. _recommended_:
+.. _recommended:
 
 Recommended
 -----------

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -9,15 +9,9 @@ Glass. Below is a list of known issues with potential solutions:
 When launching Looking Glass the desktop doesn't appear
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  **Using an AMD GPU?**
-
-   -  After the end of the Radeon HD Series, new AMD GPUs go to sleep when no
-      display is connected. For this reason, one of two conditions must be met.
-
-#. The GPU needs to remain plugged into a monitor (this is good for
-   testing & troubleshooting).
-#. The GPU needs to have a dummy plug installed which presents itself as a
-   monitor.
+Make sure you meet the :ref:`minimum requirements<minimum>` for using
+Looking Glass, especially regarding your guest GPU. See
+:ref:`connected_display` for more details.
 
 .. _the_clipboard_is_not_working:
 


### PR DESCRIPTION
Added Connected Display subsection to requirements.rst to so we can link to it easier, and link to it from the questionably troubled troubleshooting question.

Actually, rewrites that question to redirect back to the requirements.