### PR TITLE
[github] build: Use debian package for sphinxcontrib-spelling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,8 +183,8 @@ jobs:
         sudo apt-get update
     - name: Install docs dependencies
       run: |
-        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme
-        sudo pip3 install sphinxcontrib-spelling
+        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme \
+            python3-sphinxcontrib.spelling
     - name: Build docs
       run: |
         cd doc


### PR DESCRIPTION
Uses the Debian/Ubuntu package for sphinxcontrib-spelling rather than from pip. This fixes the issue by virtue of being an older version. I think we should prefer these packages anyway for stability.

This issue looks to have been caused by sphinxcontrib-spelling needing `docutils >= 0.18.1` but not declaring that as a requirement (see sphinx-contrib/spelling#212). The current `ubuntu-latest` appears to feature 0.17.1:
[![Screenshot_20230404_172738](https://user-images.githubusercontent.com/5211576/229824645-b411a955-a6ba-4b01-8e68-3445d93a4d83.png)](https://github.com/gnif/LookingGlass/actions/runs/4608362713/jobs/8144023739#step:4:36)


[Build test](https://github.com/JJRcop/LookingGlass/actions/runs/4608732839/jobs/8144906062)
![Screenshot 2023-04-04 at 17-11-32 Debianize docs build workflow test · JJRcop_LookingGlass@7bc9578](https://user-images.githubusercontent.com/5211576/229820764-97a43df7-e0be-4db5-b90b-e6f011f0275e.png)
