### PR TITLE
[github] CODEOWERS: Fix typo stopping JJRcop owning /doc/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Jonathan Rubenstein (JJRcop)
 # - Primary documentation manager. Does not require direct approval for every
 # - change, but should be consulted for large additions and changes.
-docs/ jrubcop@gmail.com
+/doc/ jrubcop@gmail.com


### PR DESCRIPTION
Made an embarassing typo.

It's doc not docs