### PR TITLE
[common] option: rtrim boolean parser

### DIFF
--- a/common/src/option.c
+++ b/common/src/option.c
@@ -63,11 +63,20 @@ static bool int_parser(struct Option * opt, const char * str)
 
 static bool bool_parser(struct Option * opt, const char * str)
 {
-  opt->value.x_bool =
-    strcasecmp(str, "1"   ) == 0 ||
-    strcasecmp(str, "on"  ) == 0 ||
-    strcasecmp(str, "yes" ) == 0 ||
-    strcasecmp(str, "true") == 0;
+  char val[5];
+  size_t len = strlen(str);
+  while (len > 1 && isspace(str[len-1]))
+    --len;
+  if (len <= 5)
+  {
+    memcpy(val, str, len);
+    val[len] = '\0';
+    opt->value.x_bool =
+      strcasecmp(val, "1"   ) == 0 ||
+      strcasecmp(val, "on"  ) == 0 ||
+      strcasecmp(val, "yes" ) == 0 ||
+      strcasecmp(val, "true") == 0;
+  }
   return true;
 }
 


### PR DESCRIPTION
User on Discord complained that they are getting different results from LG when specifying `egl:vsync=yes` on the command-line and in the config file. Doing cut-and-paste from their posted config, showed that they had a trailing space after the option, which caused the parser to fail.
This PR adds rtrim the value received by the options boolean parser so trailing white space in the config file will not fail the comparison. The rtrim code shamelessly copied from another section of options.c