### PR TITLE
[common] options: Fix regression in option parsing logic

### DIFF
--- a/common/src/option.c
+++ b/common/src/option.c
@@ -346,6 +346,7 @@ bool option_parse(int argc, char * argv[])
           o = state.options[i];
           if (o->type != OPTION_TYPE_BOOL && a < argc - 1)
           {
+            ++a;
             char * v = argv[a];
 
             //ltrim


### PR DESCRIPTION
Oops on command line parser logic argv counter