### PR TITLE
[module] Fix build on Linux 6.4 (fixes #1075)

### DIFF
--- a/module/dkms.conf
+++ b/module/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="kvmfr"
-PACKAGE_VERSION="0.0.8"
+PACKAGE_VERSION="0.0.9"
 BUILT_MODULE_NAME[0]="${PACKAGE_NAME}"
 MAKE[0]="make KDIR=${kernel_source_dir}"
 CLEAN="make KDIR=${kernel_source_dir} clean"

--- a/module/kvmfr.c
+++ b/module/kvmfr.c
@@ -569,7 +569,11 @@ static int __init kvmfr_module_init(void)
     goto out_free;
   }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
   kvmfr->pClass = class_create(THIS_MODULE, KVMFR_DEV_NAME);
+#else
+  kvmfr->pClass = class_create(KVMFR_DEV_NAME);
+#endif
   if (IS_ERR(kvmfr->pClass)) {
     printk(KERN_INFO "kvmfr: kvmfr_module_init: failed to create class!\n");
     goto out_unreg;


### PR DESCRIPTION
Remove second parameter from class_create since Linux >= 6.4 uses data from struct instead supplied from previous calls.  Draft PR until I can get this tested properly.