### PR TITLE
Update libdecor source link in FAQ and package name to dev package

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -103,7 +103,7 @@ which will allow you to move the window and resize it.
    alternatives if you require stable operation.
 
 .. _standard protocol: https://wayland.app/protocols/xdg-decoration-unstable-v1
-.. _libdecor: https://gitlab.gnome.org/jadahl/libdecor
+.. _libdecor: https://gitlab.freedesktop.org/libdecor/libdecor
 
 Mouse
 -----

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -87,8 +87,8 @@ for server-side decorations, and Looking Glass doesn't implement its own
 decorations.
 
 The easiest solution is to build Looking Glass with `libdecor`_ support.
-If your distribution lacks a ``libdecor`` package, you must build it from
-`source code <libdecor_>`_.
+Install the ``libdecor-0-dev`` package. If your distribution lacks this package
+or any equivalents, you must build it from `source code <libdecor_>`_.
 
 You can then build the the client with libdecor support by passing
 ``-DENABLE_LIBDECOR=ON`` to ``cmake``.


### PR DESCRIPTION
Update link from https://gitlab.gnome.org/jadahl/libdecor to https://gitlab.freedesktop.org/libdecor/libdecor
Change package name from `libdecor` to `libdecor-0-dev` to help those that may install the non-devel dependency.