### PR TITLE
[client] wayland: support back/forward buttons on some mouses

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -110,8 +110,10 @@ static int mapWaylandToSpiceButton(uint32_t button)
     case BTN_RIGHT:
       return 3;  // SPICE_MOUSE_BUTTON_RIGHT
     case BTN_SIDE:
+    case BTN_BACK:
       return 6;  // SPICE_MOUSE_BUTTON_SIDE
     case BTN_EXTRA:
+    case BTN_FORWARD:
       return 7;  // SPICE_MOUSE_BUTTON_EXTRA
   }
 


### PR DESCRIPTION
Despite their names, SPICE_MOUSE_BUTTON_SIDE and SPICE_MOUSE_BUTTON_EXTRA are actually treated by Windows as BTN_BACK and BTN_FORWARD, with Edge browser and Heroes of the Storm both recognize them and label them correctly.

Add the missing mapping for BTN_BACK and BTN_FORWARD.

This is hinted by [1].

1: https://github.com/rust-windowing/winit/issues/1914#issuecomment-826087457