### PR TITLE
[doc] build: Move NvFBC note into don't build warning

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -207,15 +207,20 @@ These instructions help you build the host yourself from the
 :ref:`downloaded source code <download_source>`.
 
 .. warning::
+   :name: dont-build-the-host
+
    Building the host from source code is not recommended for most purposes,
    and should only be attempted by users who are prepared to handle issues
    on their own. Please download the pre-built binary installers from
    https://looking-glass.io/downloads for stability, and increased support.
 
-.. note::
-   The pre-built binaries also include NvFBC support built in, which is
-   only available to current Nvidia SDK license holders, and cannot
-   be enabled when building the host without also having a license.
+   .. note::
+
+      The pre-built binaries also include NvFBC support built in, which is
+      only available to current Nvidia SDK license holders, and cannot
+      be enabled when building the host without also having a license.
+
+   (`link <#dont-build-the-host>`_)
 
 .. _host_win_on_win:
 


### PR DESCRIPTION
Also:
   - Add link to warning (#dont-build-the-host)

![Screenshot_20231102_165251](https://github.com/gnif/LookingGlass/assets/5211576/0965828d-1d9c-4366-8896-c15476cd8f43)

![Screenshot_20231102_164817](https://github.com/gnif/LookingGlass/assets/5211576/9291839c-9c9e-4657-855e-fb4e71fd6804)
