### PR TITLE
[doc] build: Add tip for 32-bit installer

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -300,6 +300,11 @@ Building the Windows installer
 This will build ``looking-glass-host-setup.exe`` under
 ``host/build/platform/Windows/looking-glass-host-setup.exe``
 
+.. tip::
+
+   If you want to build a 32-bit installer, add the ``-DBUILD_32BIT`` flag to
+   ``makensis``
+
 .. seealso::
 
    :ref:`Installing the Host <host_install>`


### PR DESCRIPTION
This may help people who really need a 32-bit installer so they can make one for themselves.

There is an argument to be made that those who really need this can find it by reading the `installer.nsi` file and the `makensis` man page, and that may act as a desirable filter; but I figure we are giving them build instructions that they are already following against our warnings, so might as well give them a hand.

![Screenshot_20231102_171440](https://github.com/gnif/LookingGlass/assets/5211576/c592d0dd-83e3-4038-917d-49f2e4417814)
