### PR TITLE
Implement damage-aware copies for RGB24-packed data

### DIFF
--- a/client/renderers/EGL/shader/convert_bgr_bgra.frag
+++ b/client/renderers/EGL/shader/convert_bgr_bgra.frag
@@ -11,25 +11,22 @@ uniform vec2      outputSize;
 
 void main()
 {
-  uvec2 inputSize   = uvec2(textureSize(sampler1, 0));
-  uvec2 pos         = uvec2(fragCoord * outputSize);
-  uint  outputWidth = uint(outputSize.x);
+  uvec2 inputSize = uvec2(textureSize(sampler1, 0));
+  uvec2 outputPos = uvec2(fragCoord * outputSize);
 
-  uint output_idx = pos.y * outputWidth + pos.x;
+  uint fst = outputPos.x * 3u / 4u;
+  vec4 color_0 = texelFetch(sampler1, ivec2(fst, outputPos.y), 0);
 
-  uint fst = output_idx * 3u / 4u;
-  vec4 color_0 = texelFetch(sampler1, ivec2(fst % inputSize.x, fst / inputSize.x), 0);
+  uint snd = (outputPos.x * 3u + 1u) / 4u;
+  vec4 color_1 = texelFetch(sampler1, ivec2(snd, outputPos.y), 0);
 
-  uint snd = (output_idx * 3u + 1u) / 4u;
-  vec4 color_1 = texelFetch(sampler1, ivec2(snd % inputSize.x, snd / inputSize.x), 0);
-
-  uint trd = (output_idx * 3u + 2u) / 4u;
-  vec4 color_2 = texelFetch(sampler1, ivec2(trd % inputSize.x, trd / inputSize.x), 0);
+  uint trd = (outputPos.x * 3u + 2u) / 4u;
+  vec4 color_2 = texelFetch(sampler1, ivec2(trd, outputPos.y), 0);
 
   fragColor.bgra = vec4(
-    color_0.barg[output_idx % 4u],
-    color_1.gbar[output_idx % 4u],
-    color_2.rgba[output_idx % 4u],
+    color_0.barg[outputPos.x % 4u],
+    color_1.gbar[outputPos.x % 4u],
+    color_2.rgba[outputPos.x % 4u],
     1.0
   );
 }

--- a/host/platform/Windows/capture/DXGI/src/d3d11.c
+++ b/host/platform/Windows/capture/DXGI/src/d3d11.c
@@ -140,6 +140,11 @@ static void d3d11_free(void)
   this = NULL;
 }
 
+static int scaleForBGR(int x)
+{
+  return x * 3 / 4;
+}
+
 static void copyFrameFull(Texture * tex, ID3D11Texture2D * src)
 {
   struct D3D11TexImpl * teximpl = TEXIMPL(*tex);
@@ -155,11 +160,11 @@ static void copyFrameFull(Texture * tex, ID3D11Texture2D * src)
       FrameDamageRect * rect = tex->texDamageRects + i;
       D3D11_BOX box =
       {
-        .left   = rect->x,
+        .left   = scaleForBGR(rect->x),
         .top    = rect->y,
         .front  = 0,
         .back   = 1,
-        .right  = rect->x + rect->width ,
+        .right  = scaleForBGR(rect->x + rect->width),
         .bottom = rect->y + rect->height,
       };
       ID3D11DeviceContext_CopySubresourceRegion(*dxgi->deviceContext,

--- a/host/platform/Windows/capture/DXGI/src/dxgi.c
+++ b/host/platform/Windows/capture/DXGI/src/dxgi.c
@@ -95,7 +95,7 @@ static CaptureResult dxgi_releaseFrame(void);
 static bool ppInit(const DXGIPostProcess * pp, bool shareable);
 static ID3D11Texture2D * ppRun(Texture * tex, ID3D11Texture2D * src,
   int * width, int * height,
-  int * rows , int * cols,
+  int * cols , int * rows,
   CaptureFormat * format);
 static void ppFreeAll(void);
 
@@ -1468,7 +1468,7 @@ static bool ppInit(const DXGIPostProcess * pp, bool shareable)
 
 static ID3D11Texture2D * ppRun(Texture * tex, ID3D11Texture2D * src,
   int * width, int * height,
-  int * rows, int * cols,
+  int * cols , int * rows,
   CaptureFormat * format)
 {
   PostProcessInstance * inst;

--- a/host/platform/Windows/capture/DXGI/src/pp/rgb24.c
+++ b/host/platform/Windows/capture/DXGI/src/pp/rgb24.c
@@ -78,7 +78,7 @@ static bool rgb24_configure(void * opaque,
 
   if (!this.pshader)
   {
-    this.width  = *cols;
+    this.width  = *cols * 3 / 4;
     this.height = *rows;
 
     char sOutputWidth[6], sOutputHeight[6];


### PR DESCRIPTION
Copying my comments motivating this approach from Discord for posterity:

> we can make a slight modification to the HLSL conversion shader to never consider data from row (i+1) when converting row i

> (this can only happen for the alpha channel of the rightmost pixel on a row anyway)

> so this would have the effect of making the height of the output texture be the same as the input, but the width be round(inputWidth * 3 / 4, 4) / 4 

> and we could perform a single CopySubResource per damage rect as we have before

> and should not have any implications for the guest, they're still seeing the packed data they expected to see

> we only need to do the 1 CopySubResource per row of damage rect thing if we allow the alpha channel of the last pixel on row i to encode the red channel of the first pixel on row (i+1)

> by not allowing that we waste like 2 KiB per frame, but win the ability to use damage rects so seems worth it