### PR TITLE
[client] x11: Fix clipboard selection notify

### DIFF
--- a/client/displayservers/X11/clipboard.c
+++ b/client/displayservers/X11/clipboard.c
@@ -93,7 +93,7 @@ bool x11CBEventThread(const XEvent * xe)
     default:
       if (xe->type == x11.eventBase + XFixesSelectionNotify)
       {
-        XFixesSelectionNotifyEvent * sne = (XFixesSelectionNotifyEvent *)&xe;
+        XFixesSelectionNotifyEvent * sne = (XFixesSelectionNotifyEvent *)xe;
         x11CBXFixesSelectionNotify(*sne);
         return true;
       }


### PR DESCRIPTION
Was expecting a pointer but getting a pointer-to-pointer

This was causing clipboard sync from host to guest to break on KDE X11