### PR TITLE
[client] wayland: honour fullscreen and maximize in libdecor

### DIFF
--- a/client/displayservers/Wayland/desktops/libdecor/libdecor.c
+++ b/client/displayservers/Wayland/desktops/libdecor/libdecor.c
@@ -141,6 +141,12 @@ static bool libdecor_shellInit(
   libdecor_frame_set_title(state.libdecorFrame, title);
   libdecor_frame_map(state.libdecorFrame);
 
+  if (fullscreen)
+    libdecor_frame_set_fullscreen(state.libdecorFrame, NULL);
+
+  if (maximize)
+    libdecor_frame_set_minimized(state.libdecorFrame);
+
   if (resizable)
     libdecor_frame_set_capabilities(state.libdecorFrame,
         LIBDECOR_ACTION_RESIZE);


### PR DESCRIPTION
This likely fixes an issue surrounding full screen not being honoured when creating the window when using the libdecor code, but I have received no confirmation on Discord.