### PR TITLE
Fixed minor spelling error in logger ("complient" should be spelled as "compliant").

### DIFF
--- a/client/displayservers/X11/x11.c
+++ b/client/displayservers/X11/x11.c
@@ -229,7 +229,7 @@ static void x11CheckEWMHSupport(void)
       x11.ewmhHasFocusEvent = true;
   }
 
-  DEBUG_INFO("EWMH-complient window manager detected: %s", wmName);
+  DEBUG_INFO("EWMH-compliant window manager detected: %s", wmName);
   x11.ewmhSupport = true;
 
   if (strcmp(wmName, "i3") == 0)


### PR DESCRIPTION
I noticed when running Looking Glass Client that the logger spells the word "compliant" incorrectly. I amended the spelling from "complient" to "compliant".