### PR TITLE
[module] Fix build on Linux 6.10

### DIFF
--- a/module/kvmfr.c
+++ b/module/kvmfr.c
@@ -30,6 +30,7 @@
 #include <linux/highmem.h>
 #include <linux/memremap.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include <asm/io.h>
 


### PR DESCRIPTION
Directly include a previously implicitly included header