### PR TITLE
[client] pipewire: Add pipewire application name

### DIFF
--- a/client/audiodevs/PipeWire/pipewire.c
+++ b/client/audiodevs/PipeWire/pipewire.c
@@ -258,6 +258,7 @@ static void pipewire_playbackSetup(int channels, int sampleRate,
 
   struct pw_properties * props =
     pw_properties_new(
+      PW_KEY_APP_NAME      , "Looking Glass",
       PW_KEY_NODE_NAME     , "Looking Glass",
       PW_KEY_MEDIA_TYPE    , "Audio",
       PW_KEY_MEDIA_CATEGORY, "Playback",


### PR DESCRIPTION
Some applications require the setting of pipewire's `application.name` to properly identify the app's audio. Adding the same app name as the node name to the client.