### PR TITLE
Install .desktop file and SVG icon on Linux

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -147,6 +147,7 @@ add_subdirectory("${PROJECT_TOP}/repos/cimgui"    "${CMAKE_BINARY_DIR}/cimgui" E
 add_subdirectory(displayservers)
 add_subdirectory(renderers)
 
+configure_file("${PROJECT_TOP}/resources/looking-glass-client.desktop.in" "${CMAKE_BINARY_DIR}/resources/looking-glass-client.desktop" @ONLY)
 add_executable(looking-glass-client ${SOURCES})
 
 target_compile_definitions(looking-glass-client PRIVATE CIMGUI_DEFINE_ENUMS_AND_STRUCTS=1)
@@ -176,5 +177,11 @@ endif()
 install(TARGETS looking-glass-client
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   COMPONENT binary)
+
+install(FILES "${CMAKE_BINARY_DIR}/resources/looking-glass-client.desktop"
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+install(FILES "${PROJECT_TOP}/resources/lg-logo.svg"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps"
+        RENAME "looking-glass.svg")
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/resources/looking-glass-client.desktop.in
+++ b/resources/looking-glass-client.desktop.in
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Looking Glass Client
+Comment=Clent for Looking Glass KVMFR
+Icon=looking-glass
+Exec=@CMAKE_INSTALL_PREFIX@/bin/looking-glass-client
+Terminal=false
+Keywords=KVM
+Categories=System;
+StartupWMClass=looking-glass-client
+SingleMainWindow=true


### PR DESCRIPTION
This PR competes with #1011. That was an attempt to ship a .desktop file and icon on Linux which got stalled.

This resolves the stall by only installing the SVG icon, which have had great support on Linux for about a decade.

Gnome Boxes is examples of another KVM app on Linux that only ships an SVG icon.

Because Looking Glass doesn't ship a desktop or icon on Linux, some people are creating their own and in some cases have wrongly selected the ~2500x2500 PNG logo file as their choice, accidentally slowing down their system as their desktop system works to downscale the huge PNG to a reasonable size.

See: https://codeberg.org/dnkl/fuzzel/issues/306

Shipping a proper icon will resolve that.

This also provides two other improvements over #1011:

 - The spelling of "Client" is corrected in the .desktop file.
 - "Keywords=KVM" was added to the .desktop file. 
