### PR TITLE
[client] overlay/msg: fix race condition in render

### DIFF
--- a/client/src/overlay/msg.c
+++ b/client/src/overlay/msg.c
@@ -85,9 +85,14 @@ static bool msg_needsOverlay(void * udata)
 static int msg_render(void * udata, bool interactive, struct Rect * windowRects,
     int maxRects)
 {
+  ll_lock(l_msg.messages);
+
   struct Msg * msg;
-  if (!ll_peek_head(l_msg.messages, (void **)&msg))
+  if (!ll_peek_head_nl(l_msg.messages, (void **)&msg))
+  {
+    ll_unlock(l_msg.messages);
     return 0;
+  }
 
   ImVec2 * screen = overlayGetScreenSize();
   igSetNextWindowBgAlpha(0.8f);
@@ -163,7 +168,7 @@ static int msg_render(void * udata, bool interactive, struct Rect * windowRects,
 
   if (destroy)
   {
-    (void)ll_shift(l_msg.messages, NULL);
+    (void)ll_shift_nl(l_msg.messages, NULL);
     freeMsg(msg);
     app_invalidateOverlay(false);
   }
@@ -171,6 +176,7 @@ static int msg_render(void * udata, bool interactive, struct Rect * windowRects,
   overlayGetImGuiRect(windowRects);
   igEnd();
 
+  ll_unlock(l_msg.messages);
   return 1;
 }
 

--- a/common/include/common/ll.h
+++ b/common/include/common/ll.h
@@ -41,11 +41,14 @@ struct ll
 };
 
 struct ll *  ll_new(void);
-void         ll_free     (struct ll * list);
-void         ll_push     (struct ll * list, void * data);
-bool         ll_shift    (struct ll * list, void ** data);
-bool         ll_peek_head(struct ll * list, void ** data);
-bool         ll_peek_tail(struct ll * list, void ** data);
+void         ll_free        (struct ll * list);
+void         ll_push        (struct ll * list, void * data);
+bool         ll_shift       (struct ll * list, void ** data);
+bool         ll_shift_nl    (struct ll * list, void ** data);
+bool         ll_peek_head   (struct ll * list, void ** data);
+bool         ll_peek_head_nl(struct ll * list, void ** data);
+bool         ll_peek_tail   (struct ll * list, void ** data);
+bool         ll_peek_tail_nl(struct ll * list, void ** data);
 
 #define ll_lock(ll) LG_LOCK((ll)->lock)
 #define ll_unlock(ll) LG_UNLOCK((ll)->lock)

--- a/common/src/ll.c
+++ b/common/src/ll.c
@@ -83,15 +83,18 @@ void ll_push(struct ll * list, void * data)
 bool ll_shift(struct ll * list, void ** data)
 {
   LG_LOCK(list->lock);
+  bool result = ll_shift_nl(list, data);
+  LG_UNLOCK(list->lock);
+  return result;
+}
+
+bool ll_shift_nl(struct ll * list, void ** data)
+{
   if (!list->head)
-  {
-    LG_UNLOCK(list->lock);
     return false;
-  }
 
   struct ll_item * item = list->head;
   ll_removeNL(list, item);
-  LG_UNLOCK(list->lock);
 
   if (data)
     *data = item->data;
@@ -103,29 +106,31 @@ bool ll_shift(struct ll * list, void ** data)
 bool ll_peek_head(struct ll * list, void ** data)
 {
   LG_LOCK(list->lock);
-  if (!list->head)
-  {
-    LG_UNLOCK(list->lock);
-    return false;
-  }
-
-  *data = list->head->data;
+  bool result = ll_peek_head_nl(list, data);
   LG_UNLOCK(list->lock);
+  return result;
+}
 
+bool ll_peek_head_nl(struct ll * list, void ** data)
+{
+  if (!list->head)
+    return false;
+  *data = list->head->data;
   return true;
 }
 
 bool ll_peek_tail(struct ll * list, void ** data)
 {
   LG_LOCK(list->lock);
-  if (!list->tail)
-  {
-    LG_UNLOCK(list->lock);
-    return false;
-  }
-
-  *data = list->tail->data;
+  bool result = ll_peek_tail_nl(list, data);
   LG_UNLOCK(list->lock);
+  return result;
+}
 
+bool ll_peek_tail_nl(struct ll * list, void ** data)
+{
+  if (!list->tail)
+    return false;
+  *data = list->tail->data;
   return true;
 }


### PR DESCRIPTION
If an overlay is closed with `overlayMsg_close`, the message can be freed while it is still being used by `msg_render`, resulting in a segfault. Lock the message list for the duration of `msg_render` to fix this.

A semi-reliable way to reproduce this is to put a 20ms sleep after the call to `ll_peek_head` in `msg_render`. Use remote desktop to stop the Looking Glass host service, then start the client. The 'host not running' message should appear. Now start the host service. The client will now probably crash somewhere inside `msg_render` because the message it is rendering has been freed by `overlayMsg_close`.

Not sure this is the cleanest approach, but I've taken after the precedence of `ll_forEachNL` by adding some more `nl` methods. Perhaps it would be better to add a new lock in `msg.c`.