### PR TITLE
Add an option to not show the warning popup if the host application is not detected

### DIFF
--- a/client/src/config.c
+++ b/client/src/config.c
@@ -309,6 +309,13 @@ static struct Option options[] =
     .type           = OPTION_TYPE_BOOL,
     .value.x_bool   = true
   },
+  {
+    .module         = "win",
+    .name           = "noHostAppWarning",
+    .description    = "Don't show a warning message if the host application is not detected",
+    .type           = OPTION_TYPE_BOOL,
+    .value.x_bool   = false
+  },
 
   // input options
   {
@@ -678,6 +685,7 @@ bool config_load(int argc, char * argv[])
   g_params.uiSize            = option_get_int   ("win", "uiSize"            );
   g_params.jitRender         = option_get_bool  ("win", "jitRender"         );
   g_params.requestActivation = option_get_bool  ("win", "requestActivation" );
+  g_params.noHostAppWarning  = option_get_bool  ("win", "noHostAppWarning"  );
 
   if (g_params.noScreensaver && g_params.autoScreensaver)
   {

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1494,7 +1494,7 @@ restart:
           DEBUG_INFO("Waiting for the host application to start...");
         }
 
-        if (waitCount == 30)
+        if (waitCount == 30 && !g_params.noHostAppWarning)
         {
           DEBUG_BREAK();
           msgs[msgsCount++] = app_msgBox(

--- a/client/src/main.h
+++ b/client/src/main.h
@@ -202,6 +202,7 @@ struct AppParams
   int                  uiSize;
   bool                 jitRender;
   bool                 requestActivation;
+  bool                 noHostAppWarning;
 
   unsigned int         cursorPollInterval;
   unsigned int         framePollInterval;


### PR DESCRIPTION
I added this option as a small quality-of-life improvement (since this warning steals focus away from the client and often appears at the worst time), especially when troubleshooting any issue with a non-booting VM or broken GPU, since you can already tell when the host app is not running because of the Spice warning on the top right and the client log.