### PR TITLE
[client] opengl: initialize scale to 1.0

### DIFF
--- a/client/renderers/OpenGL/opengl.c
+++ b/client/renderers/OpenGL/opengl.c
@@ -205,6 +205,9 @@ bool opengl_create(LG_Renderer ** renderer, const LG_RendererParams params,
   this->opt.preventBuffer = option_get_bool("opengl", "preventBuffer");
   this->opt.amdPinnedMem  = option_get_bool("opengl", "amdPinnedMem" );
 
+  this->scaleX = 1.0f;
+  this->scaleY = 1.0f;
+
   LG_LOCK_INIT(this->formatLock);
   LG_LOCK_INIT(this->frameLock );
   LG_LOCK_INIT(this->mouseLock );


### PR DESCRIPTION
Fixes SPICE cursor rendering unconditionally at (0, 0) prior to KVMFR frame format configuration (using OpenGL renderer).

Presently cursor coordinates are multiplied by `scale = 0` in `opengl_onMouseEvent` until `opengl_onFrameFormat`.

I observe this problem with a Win 10 VM using QXL video by running `looking-glass-client app:renderer=OpenGL` .

Note that some video devices / configurations embed the cursor in the video stream rather than sending SPICE cursor messages:
- QXL apparently defaults to a hardware cursor which is forwarded via SPICE (thus the issue manifests)
- Virtio currently disables hardware cursor support unless [overridden via the registry](https://github.com/virtio-win/kvm-guest-drivers-windows/blob/eff7b43073b95c563d2e5c6b0d7b6dd954f1232a/viogpu/viogpudo/viogpudo.cpp#L1895) (thus no issue for now)
- VGA seems unaffected