### PR TITLE
Both Wayland desktops support win:allowResize and win:borderless

### DIFF
--- a/client/displayservers/Wayland/desktops/libdecor/libdecor.c
+++ b/client/displayservers/Wayland/desktops/libdecor/libdecor.c
@@ -46,6 +46,7 @@ typedef struct LibDecorState
   int32_t width, height;
   bool     needsResize;
   bool     fullscreen;
+  bool     borderless;
   uint32_t resizeSerial;
 }
 LibDecorState;
@@ -147,6 +148,10 @@ static bool libdecor_shellInit(
   if (maximize)
     libdecor_frame_set_maximized(state.libdecorFrame);
 
+  if (borderless)
+    libdecor_frame_set_visibility(state.libdecorFrame, false);
+  state.borderless = borderless;
+
   if (resizable)
     libdecor_frame_set_capabilities(state.libdecorFrame,
         LIBDECOR_ACTION_RESIZE);
@@ -183,7 +188,8 @@ static void libdecor_setFullscreen(bool fs)
   else
     libdecor_frame_unset_fullscreen(state.libdecorFrame);
 
-  libdecor_frame_set_visibility(state.libdecorFrame, !fs);
+  if (!state.borderless)
+    libdecor_frame_set_visibility(state.libdecorFrame, !fs);
 }
 
 static bool libdecor_getFullscreen(void)

--- a/client/displayservers/Wayland/desktops/xdg/xdg.c
+++ b/client/displayservers/Wayland/desktops/xdg/xdg.c
@@ -49,6 +49,7 @@ typedef struct XDGState
   uint32_t resizeSerial;
   bool fullscreen;
   bool floating;
+  bool resizable;
   int displayFd;
 }
 XDGState;
@@ -155,6 +156,13 @@ bool xdg_shellInit(struct wl_display * display, struct wl_surface * surface,
   if (maximize)
     xdg_toplevel_set_maximized(state.toplevel);
 
+  if (!resizable)
+  {
+    xdg_toplevel_set_min_size(state.toplevel, state.width, state.height);
+    xdg_toplevel_set_max_size(state.toplevel, state.width, state.height);
+  }
+  state.resizable = resizable;
+
   if (state.decorationManager)
   {
     state.toplevelDecoration = zxdg_decoration_manager_v1_get_toplevel_decoration(
@@ -200,7 +208,7 @@ static void xdg_minimize(void)
 
 static void xdg_shellResize(int w, int h)
 {
-  if (!state.floating)
+  if (!state.floating || !state.resizable)
     return;
 
   state.width  = w;


### PR DESCRIPTION
`libdecor_shellInit` was handling `win:allowResize`but ignoring `win:borderless`, so it did nothing on compositors using libdecor, for example GNOME/Mutter

Conversely, `xdg_shellInit` was handling `win:borderless` but ignoring `win:allowResize`, so it did nothing on compositors using the XDG shell protocol, for example KDE/Kwin, and many others


This Pull Request fixes both issues and now both options work fine on different Wayland compositors.