### PR TITLE
 [client] pipewire: Stop loading properties from client-rt.conf

### DIFF
--- a/client/audiodevs/PipeWire/pipewire.c
+++ b/client/audiodevs/PipeWire/pipewire.c
@@ -168,6 +168,12 @@ static bool pipewire_init(void)
   pw_init(NULL, NULL);
 
   pw.loop = pw_loop_new(NULL);
+#if PW_CHECK_VERSION(1, 3, 81)
+  pw.context = pw_context_new(
+    pw.loop,
+    NULL,
+    0);
+#else
   pw.context = pw_context_new(
     pw.loop,
     pw_properties_new(
@@ -176,6 +182,7 @@ static bool pipewire_init(void)
       NULL
     ),
     0);
+#endif
   if (!pw.context)
   {
     DEBUG_ERROR("Failed to create a context");


### PR DESCRIPTION
Pipewire now automatically moves non-rt clients into non-rt threads so client-rt.conf is obsolete.
Pipewire will now emit a deprecation warning if a client tries to load RT config properties which LG does.
Stop loading RT properties during context initialization for Pipewire 1.3.81 and newer.
See: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/24bcacc6195ffbf8e40c9ea1374eb6666252eadc

Reference branch was accidentally removed so this is a re-submit. Please see discussion in https://github.com/gnif/LookingGlass/pull/1174