### PR TITLE
[all] Update to new issue template workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Report bugs in Looking Glass (only confirmed bugs and feature requests please)
+
+---
+
 ### Issues are for Bug Reports and Feature Requests Only!
 
 If you are looking for help or support please use one of the following methods
@@ -64,3 +70,4 @@ https://www.youtube.com/watch?v=EqxxJK9Yo64
 ```
 PASTE FULL BACKTRACE HERE
 ```
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Looking Glass on Level1Tech's Forum
+    url: https://forum.level1techs.com/c/software/lookingGlass/142
+    about: Ask for help by creating a New Topic on the Level1Tech's forum
+  - name: Looking Glass Discord Server
+    url: https://discord.gg/52SMupxkvt
+    about: Ask for help in the Looking Glass discord server
+


### PR DESCRIPTION
GitHub switched its issue template to a new workflow. This PR moves the current template to comply with the new structure and also adds a pre-selector that offers links to the forum and discord.