### PR TITLE
[doc] kvmfr: Update udev rule example

### DIFF
--- a/doc/ivshmem_kvmfr.rst
+++ b/doc/ivshmem_kvmfr.rst
@@ -120,12 +120,17 @@ change its ownership manually, i.e.:
 
    sudo chown user:kvm /dev/kvmfr0
 
-As an example, you can create a new file in ``/etc/udev/rules.d/99-kvmfr.rules``
+(replace ``user`` with your username)
+
+As an example, you can create a new file in ``/etc/udev/rules.d/70-kvmfr.rules``
 with the following contents::
 
-   SUBSYSTEM=="kvmfr", OWNER="user", GROUP="kvm", MODE="0660"
+   SUBSYSTEM=="kvmfr", GROUP="kvm", MODE="0660", TAG+="uaccess"
 
-(replace ``user`` with your username)
+.. note::
+
+   Make sure the udev rule file name ordinal value is below (lexically sorts before) ``73-seat-late.rules``
+   to allow the uaccess tag to be processed properly.
 
 .. _ivshmem_kvmfr_libvirt:
 

--- a/doc/words.txt
+++ b/doc/words.txt
@@ -31,6 +31,7 @@ imgui
 ini
 kvmfr
 laggy
+lexically
 libdecor
 libpipewire
 libpulse
@@ -73,6 +74,7 @@ Threadripper
 toolchain
 tritanope
 tunable
+uaccess
 udev
 UEFI
 uncheck


### PR DESCRIPTION
Starting with version 258 of systemd, OWNER=/GROUP= are ignored for non-system user/group in udev rules files. Modify the example in the documentation to reflect this change.