### PR TITLE
[idd] all: use UTF-8 source code

### DIFF
--- a/idd/LGCommon/PipeMsg.h
+++ b/idd/LGCommon/PipeMsg.h
@@ -1,6 +1,6 @@
 /**
  * Looking Glass
- * Copyright © 2017-2025 The Looking Glass Authors
+ * Copyright Â© 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/idd/LGIdd/CPipeServer.cpp
+++ b/idd/LGIdd/CPipeServer.cpp
@@ -1,6 +1,6 @@
 /**
  * Looking Glass
- * Copyright © 2017-2025 The Looking Glass Authors
+ * Copyright Â© 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/idd/LGIdd/CPipeServer.h
+++ b/idd/LGIdd/CPipeServer.h
@@ -1,6 +1,6 @@
 /**
  * Looking Glass
- * Copyright © 2017-2025 The Looking Glass Authors
+ * Copyright Â© 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/idd/LGIddHelper/CPipeClient.cpp
+++ b/idd/LGIddHelper/CPipeClient.cpp
@@ -1,6 +1,6 @@
 /**
  * Looking Glass
- * Copyright © 2017-2025 The Looking Glass Authors
+ * Copyright Â© 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/idd/LGIddHelper/CPipeClient.h
+++ b/idd/LGIddHelper/CPipeClient.h
@@ -1,6 +1,6 @@
 /**
  * Looking Glass
- * Copyright © 2017-2025 The Looking Glass Authors
+ * Copyright Â© 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
  *
  * This program is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A bunch of files were encoding the copyright sign as Windows-1252 and causing problems when building.