### PR TITLE
[host] ci/windows: use explicit windows-2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         makensis -DIVSHMEM platform/Windows/installer.nsi
 
   host-windows-native:
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This allows forks for whom windows-latest doesn't point to `windows-2025` to build successfully.