### PR TITLE
[idd] installer: dont make the reg key owned by USER MODE DRIVERS

### DIFF
--- a/idd/LGIddInstall/LGIddInstall.c
+++ b/idd/LGIddInstall/LGIddInstall.c
@@ -132,8 +132,8 @@ DWORD ensureKeyWithAce()
   }
 
   ec = SetSecurityInfo(hKey, SE_REGISTRY_KEY,
-    OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
-    sid, NULL, newDacl, NULL);
+    DACL_SECURITY_INFORMATION,
+    NULL, NULL, newDacl, NULL);
 
   if (newDacl) LocalFree(newDacl);
   if (sid)     LocalFree(sid);


### PR DESCRIPTION
Windows 11 does not allow the key to be owned by USER MODE DRIVERS granting the user control via the ACL should resolve this