### PR TITLE
[idd] helper: some clean up improvements

### DIFF
--- a/idd/LGIddHelper/CWindow.cpp
+++ b/idd/LGIddHelper/CWindow.cpp
@@ -60,6 +60,9 @@ LRESULT CWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
   case WM_CREATE:
     onCreate();
     return 0;
+  case WM_NCDESTROY:
+    PostQuitMessage(0);
+    return 0;
   default:
     if (s_taskbarCreated && uMsg == s_taskbarCreated)
     {
@@ -89,8 +92,18 @@ void CWindow::registerIcon()
     DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_ADD)");
 }
 
-CWindow::~CWindow()
+
+void CWindow::destroy()
 {
   if (m_hwnd)
+  {
     DestroyWindow(m_hwnd);
+    m_hwnd = NULL;
+  }
+}
+
+
+CWindow::~CWindow()
+{
+  destroy();
 }

--- a/idd/LGIddHelper/CWindow.h
+++ b/idd/LGIddHelper/CWindow.h
@@ -21,6 +21,7 @@ public:
   static bool registerClass();
   CWindow();
   ~CWindow();
+  void destroy();
 
   HWND hwnd() { return m_hwnd; }
 };

--- a/idd/LGIddHelper/main.cpp
+++ b/idd/LGIddHelper/main.cpp
@@ -34,9 +34,6 @@ static void Launch();
 
 int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nShowCmd)
 {
-  g_debug.Init("looking-glass-iddhelper");
-  DEBUG_INFO("Looking Glass IDD Helper (" LG_VERSION_STR ")");
-
   wchar_t buffer[MAX_PATH];
   DWORD result = GetModuleFileName(NULL, buffer, MAX_PATH);
   if (result == 0)
@@ -56,18 +53,19 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
   if (argc == 1)
   {
+    g_debug.Init("looking-glass-idd-service");
+    DEBUG_INFO("Looking Glass IDD Helper Service (" LG_VERSION_STR ")");
     if (!HandleService())
       return EXIT_FAILURE;
     return EXIT_SUCCESS;
   }
 
-  // child process
   if (argc != 2)
-  {
-    // the one and only value we should see is the exit event name
-    DEBUG_ERROR("Invalid invocation");
     return EXIT_FAILURE;
-  }
+
+  // child process
+  g_debug.Init("looking-glass-idd-helper");
+  DEBUG_INFO("Looking Glass IDD Helper Process (" LG_VERSION_STR ")");
 
   l_exitEvent.Attach(OpenEvent(SYNCHRONIZE, FALSE, args[1].c_str()));
   if (!l_exitEvent.IsValid())
@@ -117,8 +115,9 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
       case WAIT_FAILED:
         DEBUG_ERROR_HR(GetLastError(), "MsgWaitForMultipleObjects Failed");
-        goto exit;
-    }    
+        g_pipe.DeInit();
+        return EXIT_FAILURE;
+    }
   }
 
 exit:


### PR DESCRIPTION
This PR improves the window cleanup for the IDD helper and gets rid of the event object, instead just opening the parent process (whose PID is specified as an argument) with `SYNCHRONIZE`.

It also opens separate log files for the IDD helper service and the actual child process to avoid writing to the same file.