### PR TITLE
[idd] debug: full Unicode handling and log as UTF-8

### DIFF
--- a/idd/LGCommon/CDebug.h
+++ b/idd/LGCommon/CDebug.h
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Looking Glass
  * Copyright © 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
@@ -27,7 +27,7 @@ class CDebug
 {
   private:
     std::ofstream m_stream;
-    void Write(const char * line);
+    void Write(const wchar_t *line);
 
   public:
 
@@ -44,22 +44,18 @@ class CDebug
       LEVEL_MAX
     };
 
-    void Init(const char * name);
-    void Log_va(CDebug::Level level, const char* function, int line, const char* fmt, va_list args);
-    void Log(CDebug::Level level, const char * function, int line, const char * fmt, ...);
-    void LogHR(CDebug::Level level, HRESULT hr, const char* function, int line, const char* fmt, ...);
+    void Init(const wchar_t * name);
+    void Log_va(CDebug::Level level, const char *function, int line, const wchar_t *fmt, va_list args);
+    void Log(CDebug::Level level, const char *function, int line, const wchar_t *fmt, ...);
+    void Log_va(CDebug::Level level, const char *function, int line, const char *fmt, va_list args);
+    void Log(CDebug::Level level, const char *function, int line, const char *fmt, ...);
+    void LogHR(CDebug::Level level, HRESULT hr, const char *function, int line, const char *fmt, ...);
+    void LogHR(CDebug::Level level, HRESULT hr, const char *function, int line, const wchar_t *fmt, ...);
 
   private:
-    const char* m_levelStr[LEVEL_MAX] =
-    {
-      " ",
-      "I",
-      "W",
-      "E",
-      "T",
-      "!",
-      "F"
-    };
+    void LogStr(CDebug::Level level, const char *function, int line, bool wide, const void *str);
+    void LogStrHR(CDebug::Level level, HRESULT hr, const char *function, int line, bool wide, const void *str);
+    static const char *s_levelStr[LEVEL_MAX];
 };
 
 extern CDebug g_debug;

--- a/idd/LGIdd/Driver.cpp
+++ b/idd/LGIdd/Driver.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Looking Glass
  * Copyright © 2017-2025 The Looking Glass Authors
  * https://looking-glass.io
@@ -28,7 +28,7 @@
 
 NTSTATUS DriverEntry(_In_ PDRIVER_OBJECT  DriverObject, _In_ PUNICODE_STRING RegistryPath)
 {
-  g_debug.Init("looking-glass-idd");
+  g_debug.Init(L"looking-glass-idd");
   DEBUG_INFO("Looking Glass IDD Driver (" LG_VERSION_STR ")");
 
   NTSTATUS status = STATUS_SUCCESS;

--- a/idd/LGIddHelper/main.cpp
+++ b/idd/LGIddHelper/main.cpp
@@ -52,7 +52,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 
   if (argc == 1)
   {
-    g_debug.Init("looking-glass-idd-service");
+    g_debug.Init(L"looking-glass-idd-service");
     DEBUG_INFO("Looking Glass IDD Helper Service (" LG_VERSION_STR ")");
     if (!HandleService())
       return EXIT_FAILURE;
@@ -63,7 +63,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     return EXIT_FAILURE;
 
   // child process
-  g_debug.Init("looking-glass-idd-helper");
+  g_debug.Init(L"looking-glass-idd-helper");
   DEBUG_INFO("Looking Glass IDD Helper Process (" LG_VERSION_STR ")");
 
   HandleT<HANDLENullTraits> hParent(OpenProcess(SYNCHRONIZE, FALSE, std::stoul(args[1])));


### PR DESCRIPTION
This commit makes `CDebug` use Unicode internally instead of whatever random code page is in use. It also gets rid of the horrible character counting and replaces that with `vasprintf` and `vaswprintf` helpers (partially inspired by Linux) which allocates a buffer.

For `HRESULT` logging, the error code in both hex and decimal are included.

The output is now guaranteed to be UTF-8.