### PR TITLE
[repos] wayland-protocols: swith to anongit.freedesktop.org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/cimgui/cimgui.git
 [submodule "repos/wayland-protocols"]
 	path = repos/wayland-protocols
-	url = https://gitlab.freedesktop.org/wayland/wayland-protocols.git
+	url = https://anongit.freedesktop.org/git/wayland/wayland-protocols
 [submodule "repos/nanosvg"]
 	path = repos/nanosvg
 	url = https://github.com/memononen/nanosvg.git


### PR DESCRIPTION
gitlab.freedesktop.org has become unreliable over the last year, to prevent the ci pipeline from failing, fall back to the more stable and trusted anongit.