### PR TITLE
[idd] helper: refactor window handling

### DIFF
--- a/idd/LGIddHelper/CNotifyWindow.cpp
+++ b/idd/LGIddHelper/CNotifyWindow.cpp
@@ -1,0 +1,97 @@
+﻿#include "CNotifyWindow.h"
+#include <CDebug.h>
+#include <windowsx.h>
+#include <strsafe.h>
+
+#define ID_MENU_SHOW_LOG 3000
+
+ATOM CNotifyWindow::s_atom = 0;
+UINT CNotifyWindow::s_taskbarCreated = 0;
+
+bool CNotifyWindow::registerClass()
+{
+  s_taskbarCreated = RegisterWindowMessage(L"TaskbarCreated");
+  if (!s_taskbarCreated)
+    DEBUG_WARN_HR(GetLastError(), "RegisterWindowMessage(TaskbarCreated)");
+
+  WNDCLASSEX wx = {};
+  populateWindowClass(wx);
+  wx.lpszClassName = L"LookingGlassIddHelper";
+
+  s_atom = RegisterClassEx(&wx);
+  return s_atom;
+}
+
+CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_menu(CreatePopupMenu())
+{
+  CreateWindowEx(0, MAKEINTATOM(s_atom), NULL,
+    0, 0, 0, 0, 0, NULL, NULL, hInstance, this);
+
+  if (m_menu)
+  {
+    AppendMenu(m_menu, MF_STRING, ID_MENU_SHOW_LOG, L"Open log directory");
+  }
+}
+
+CNotifyWindow::~CNotifyWindow()
+{
+  DestroyMenu(m_menu);
+}
+
+LRESULT CNotifyWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+  switch (uMsg)
+  {
+  case WM_NCDESTROY:
+    PostQuitMessage(0);
+    return 0;
+  case WM_NOTIFY_ICON:
+    return onNotifyIcon(LOWORD(lParam), HIWORD(lParam), GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam));
+  default:
+    if (s_taskbarCreated && uMsg == s_taskbarCreated)
+    {
+      registerIcon();
+      return 0;
+    }
+    return CWindow::handleMessage(uMsg, wParam, lParam);
+  }
+}
+
+LRESULT CNotifyWindow::onCreate()
+{
+  registerIcon();
+  return 0;
+}
+
+LRESULT CNotifyWindow::onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y)
+{
+  switch (uEvent)
+  {
+  case WM_CONTEXTMENU:
+    switch (TrackPopupMenu(m_menu, TPM_RETURNCMD | TPM_NONOTIFY, x, y, 0, m_hwnd, NULL))
+    {
+    case ID_MENU_SHOW_LOG:
+      ShellExecute(m_hwnd, L"open", g_debug.logDir(), NULL, NULL, SW_NORMAL);
+      break;
+    }
+    break;
+  }
+  return 0;
+}
+
+void CNotifyWindow::registerIcon()
+{
+  m_iconData.cbSize = sizeof m_iconData;
+  m_iconData.hWnd = m_hwnd;
+  m_iconData.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  m_iconData.uCallbackMessage = WM_NOTIFY_ICON;
+  m_iconData.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
+  m_iconData.uVersion = NOTIFYICON_VERSION_4;
+  StringCbCopy(m_iconData.szTip, sizeof m_iconData.szTip, L"Looking Glass (IDD)");
+
+  if (!Shell_NotifyIcon(NIM_ADD, &m_iconData))
+    DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_ADD)");
+
+  if (!Shell_NotifyIcon(NIM_SETVERSION, &m_iconData))
+    DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_SETVERSION)");
+}

--- a/idd/LGIddHelper/CNotifyWindow.cpp
+++ b/idd/LGIddHelper/CNotifyWindow.cpp
@@ -22,7 +22,8 @@ bool CNotifyWindow::registerClass()
   return s_atom;
 }
 
-CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_menu(CreatePopupMenu())
+CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_menu(CreatePopupMenu()),
+  closeRequested(false)
 {
   CreateWindowEx(0, MAKEINTATOM(s_atom), NULL,
     0, 0, 0, 0, 0, NULL, NULL, hInstance, this);
@@ -63,6 +64,13 @@ LRESULT CNotifyWindow::onCreate()
   return 0;
 }
 
+LRESULT CNotifyWindow::onClose()
+{
+  if (closeRequested)
+    destroy();
+  return 0;
+}
+
 LRESULT CNotifyWindow::onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y)
 {
   switch (uEvent)
@@ -94,4 +102,10 @@ void CNotifyWindow::registerIcon()
 
   if (!Shell_NotifyIcon(NIM_SETVERSION, &m_iconData))
     DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_SETVERSION)");
+}
+
+void CNotifyWindow::close()
+{
+  closeRequested = true;
+  PostMessage(m_hwnd, WM_CLOSE, 0, 0);
 }

--- a/idd/LGIddHelper/CNotifyWindow.h
+++ b/idd/LGIddHelper/CNotifyWindow.h
@@ -10,15 +10,19 @@ class CNotifyWindow : public CWindow
 
   NOTIFYICONDATA m_iconData;
   HMENU m_menu;
+  bool closeRequested;
 
   LRESULT onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y);
   void registerIcon();
 
   virtual LRESULT handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
   virtual LRESULT onCreate() override;
+  virtual LRESULT onClose() override;
 
 public:
   CNotifyWindow();
   ~CNotifyWindow() override;
   static bool registerClass();
+
+  void close();
 };

--- a/idd/LGIddHelper/CNotifyWindow.h
+++ b/idd/LGIddHelper/CNotifyWindow.h
@@ -1,0 +1,24 @@
+﻿#pragma once
+#include "CWindow.h"
+
+#define WM_NOTIFY_ICON (WM_USER)
+
+class CNotifyWindow : public CWindow
+{
+  static UINT s_taskbarCreated;
+  static ATOM s_atom;
+
+  NOTIFYICONDATA m_iconData;
+  HMENU m_menu;
+
+  LRESULT onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y);
+  void registerIcon();
+
+  virtual LRESULT handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
+  virtual LRESULT onCreate() override;
+
+public:
+  CNotifyWindow();
+  ~CNotifyWindow() override;
+  static bool registerClass();
+};

--- a/idd/LGIddHelper/CWindow.cpp
+++ b/idd/LGIddHelper/CWindow.cpp
@@ -43,12 +43,26 @@ LRESULT CWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
   {
   case WM_CREATE:
     return onCreate();
+  case WM_CLOSE:
+    return onClose();
+  case WM_DESTROY:
+    return onDestroy();
   default:
     return DefWindowProc(m_hwnd, uMsg, wParam, lParam);
   }
 }
 
 LRESULT CWindow::onCreate()
+{
+  return 0;
+}
+
+LRESULT CWindow::onClose()
+{
+  return DefWindowProc(m_hwnd, WM_CLOSE, 0, 0);
+}
+
+LRESULT CWindow::onDestroy()
 {
   return 0;
 }

--- a/idd/LGIddHelper/CWindow.cpp
+++ b/idd/LGIddHelper/CWindow.cpp
@@ -3,41 +3,17 @@
 #include <strsafe.h>
 #include <CDebug.h>
 
-#define ID_MENU_SHOW_LOG 3000
+HINSTANCE CWindow::hInstance = (HINSTANCE)GetModuleHandle(NULL);
 
-ATOM CWindow::s_atom = 0;
-UINT CWindow::s_taskbarCreated = 0;
-static HINSTANCE hInstance = (HINSTANCE)GetModuleHandle(NULL);
-
-bool CWindow::registerClass()
+void CWindow::populateWindowClass(WNDCLASSEX &wx)
 {
-  s_taskbarCreated = RegisterWindowMessage(L"TaskbarCreated");
-  if (!s_taskbarCreated)
-    DEBUG_WARN_HR(GetLastError(), "RegisterWindowMessage(TaskbarCreated)");
-
-  WNDCLASSEX wx = {};
   wx.cbSize = sizeof(WNDCLASSEX);
   wx.lpfnWndProc = wndProc;
   wx.hInstance = hInstance;
-  wx.lpszClassName = L"LookingGlassIddHelper";
   wx.hIcon = LoadIcon(NULL, IDI_APPLICATION);
   wx.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
   wx.hCursor = LoadCursor(NULL, IDC_ARROW);
   wx.hbrBackground = (HBRUSH)COLOR_APPWORKSPACE;
-
-  s_atom = RegisterClassEx(&wx);
-  return s_atom;
-}
-
-CWindow::CWindow() : m_iconData({ 0 }), m_menu(CreatePopupMenu())
-{
-  CreateWindowEx(0, MAKEINTATOM(s_atom), NULL,
-    0, 0, 0, 0, 0, NULL, NULL, hInstance, this);
-
-  if (m_menu)
-  {
-    AppendMenu(m_menu, MF_STRING, ID_MENU_SHOW_LOG, L"Open log directory");
-  }
 }
 
 LRESULT CWindow::wndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -67,58 +43,14 @@ LRESULT CWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
   {
   case WM_CREATE:
     return onCreate();
-  case WM_NCDESTROY:
-    PostQuitMessage(0);
-    return 0;
-  case WM_NOTIFY_ICON:
-    return onNotifyIcon(LOWORD(lParam), HIWORD(lParam), GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam));
   default:
-    if (s_taskbarCreated && uMsg == s_taskbarCreated)
-    {
-      registerIcon();
-      return 0;
-    }
     return DefWindowProc(m_hwnd, uMsg, wParam, lParam);
   }
 }
 
 LRESULT CWindow::onCreate()
 {
-  registerIcon();
   return 0;
-}
-
-LRESULT CWindow::onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y)
-{
-  switch (uEvent)
-  {
-  case WM_CONTEXTMENU:
-    switch (TrackPopupMenu(m_menu, TPM_RETURNCMD | TPM_NONOTIFY, x, y, 0, m_hwnd, NULL))
-    {
-    case ID_MENU_SHOW_LOG:
-      ShellExecute(m_hwnd, L"open", g_debug.logDir(), NULL, NULL, SW_NORMAL);
-      break;
-    }
-    break;
-  }
-  return 0;
-}
-
-void CWindow::registerIcon()
-{
-  m_iconData.cbSize = sizeof m_iconData;
-  m_iconData.hWnd = m_hwnd;
-  m_iconData.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
-  m_iconData.uCallbackMessage = WM_NOTIFY_ICON;
-  m_iconData.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
-  m_iconData.uVersion = NOTIFYICON_VERSION_4;
-  StringCbCopy(m_iconData.szTip, sizeof m_iconData.szTip, L"Looking Glass (IDD)");
-
-  if (!Shell_NotifyIcon(NIM_ADD, &m_iconData))
-    DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_ADD)");
-
-  if (!Shell_NotifyIcon(NIM_SETVERSION, &m_iconData))
-    DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_SETVERSION)");
 }
 
 void CWindow::destroy()
@@ -133,5 +65,4 @@ void CWindow::destroy()
 CWindow::~CWindow()
 {
   destroy();
-  DestroyMenu(m_menu);
 }

--- a/idd/LGIddHelper/CWindow.h
+++ b/idd/LGIddHelper/CWindow.h
@@ -4,26 +4,21 @@
 #include <windows.h>
 #include <shellapi.h>
 
-#define WM_NOTIFY_ICON (WM_USER)
-
 class CWindow {
-  static ATOM s_atom;
-  static UINT s_taskbarCreated;
   static LRESULT CALLBACK wndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-  HWND m_hwnd = NULL;
-  NOTIFYICONDATA m_iconData;
-  HMENU m_menu;
+  virtual LRESULT onCreate();
 
-  LRESULT handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
-  LRESULT onCreate();
-  LRESULT onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y);
-  void registerIcon();
+protected:
+  static HINSTANCE hInstance;
+  static void populateWindowClass(WNDCLASSEX &wx);
+
+  virtual LRESULT handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+  HWND m_hwnd = NULL;
 
 public:
-  static bool registerClass();
-  CWindow();
-  ~CWindow();
+  virtual ~CWindow();
   void destroy();
 
   HWND hwnd() { return m_hwnd; }

--- a/idd/LGIddHelper/CWindow.h
+++ b/idd/LGIddHelper/CWindow.h
@@ -8,6 +8,8 @@ class CWindow {
   static LRESULT CALLBACK wndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
   virtual LRESULT onCreate();
+  virtual LRESULT onClose();
+  virtual LRESULT onDestroy();
 
 protected:
   static HINSTANCE hInstance;

--- a/idd/LGIddHelper/LGIddHelper.vcxproj
+++ b/idd/LGIddHelper/LGIddHelper.vcxproj
@@ -177,12 +177,14 @@ copy /Y "$(ProjectDir)VERSION" "$(SolutionDir)$(Platform)\$(Configuration)\LGIdd
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="$(SolutionDir)LGCommon\*.cpp" />
+    <ClCompile Include="CNotifyWindow.cpp" />
     <ClCompile Include="CPipeClient.cpp" />
     <ClCompile Include="CWindow.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="$(SolutionDir)LGCommon\*.h" />
+    <ClInclude Include="CNotifyWindow.h" />
     <ClInclude Include="CPipeClient.h" />
     <ClInclude Include="CWindow.h" />
   </ItemGroup>

--- a/idd/LGIddHelper/LGIddHelper.vcxproj.filters
+++ b/idd/LGIddHelper/LGIddHelper.vcxproj.filters
@@ -22,10 +22,25 @@
     <ClCompile Include="CPipeClient.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(SolutionDir)LGCommon\*.cpp" />
+    <ClCompile Include="CWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CNotifyWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <CLInclude Include="$(SolutionDir)LGCommon\*.h" />
     <ClInclude Include="CPipeClient.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <CLInclude Include="$(SolutionDir)LGCommon\*.h" />
+    <CLInclude Include="$(SolutionDir)LGCommon\*.h" />
+    <ClInclude Include="CWindow.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CNotifyWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/idd/LGIddHelper/main.cpp
+++ b/idd/LGIddHelper/main.cpp
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL::Wrappers::HandleTraits;
 #include "CDebug.h"
 #include "VersionInfo.h"
 #include "CPipeClient.h"
-#include "CWindow.h"
+#include "CNotifyWindow.h"
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof*(x))
 #define SVCNAME L"Looking Glass (IDD Helper)"
@@ -73,13 +73,13 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     return EXIT_FAILURE;
   }
 
-  if (!CWindow::registerClass())
+  if (!CNotifyWindow::registerClass())
   {
     DEBUG_ERROR("Failed to register message window class");
     return EXIT_FAILURE;
   }
 
-  CWindow window;
+  CNotifyWindow window;
 
   if (!g_pipe.Init())
   {


### PR DESCRIPTION
This PR does two main things:
* Split out the application logic from `CWindow` to `CNotifyWindow` in preparation for `CConfigWindow` subclass of `CWindow`.
* Use `RegisterWaitForSingleObject` instead of `MsgWaitForMultipleObjects` to handle inner message pumps that aren't aware of the wait, e.g. in `TrackPopupMenu`, allowing the process to still exit.