### PR TITLE
[repos] wayland-protocols: switch to a mirror on GitHub

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/cimgui/cimgui.git
 [submodule "repos/wayland-protocols"]
 	path = repos/wayland-protocols
-	url = https://anongit.freedesktop.org/git/wayland/wayland-protocols
+	url = https://github.com/quantum5/wayland-protocols.git
 [submodule "repos/nanosvg"]
 	path = repos/nanosvg
 	url = https://github.com/memononen/nanosvg.git


### PR DESCRIPTION
anongit.freedesktop.org has unfortunately been very flaky in our CI pipelines and causing builds to fail. I am running my own mirror which syncs from the official FreeDesktop GitLab instance to GitHub, which should allow CI pipelines to continue working on the last available release should the GitLab sync fail.