### PR TITLE
Fix for downward scroll wheel misbehaviour when using the Wayland client

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -91,11 +91,15 @@ static void pointerAxisHandler(void * data, struct wl_pointer * pointer,
   if (axis != WL_POINTER_AXIS_VERTICAL_SCROLL)
     return;
 
-  int button = value > 0 ?
-    5 /* SPICE_MOUSE_BUTTON_DOWN */ :
-    4 /* SPICE_MOUSE_BUTTON_UP */;
-  app_handleButtonPress(button);
-  app_handleButtonRelease(button);
+  if (value != 0)
+  {
+    int button = value > 0 ?
+      5 /* SPICE_MOUSE_BUTTON_DOWN */ :
+      4 /* SPICE_MOUSE_BUTTON_UP */;
+    app_handleButtonPress(button);
+    app_handleButtonRelease(button);
+  }
+
   app_handleWheelMotion(wl_fixed_to_double(value) / 15.0);
 }
 


### PR DESCRIPTION
When using the Wayland client, scrolling down with the mouse wheel resulted in 1x scroll down command being sent to the VM, followed by 3x scroll up commands. Scrolling up on the mouse wheel worked as expected.

I tracked this down to the ``pointerAxisHandler`` function inadvertently sending ``SPICE_MOUSE_BUTTON_UP`` events when the input ``value`` was 0. 

This fix wraps the ``int button = value > 0 ?`` test with a ``value != 0`` test.