### PR TITLE
Use double type for storing the display scaling factor in Wayland

### DIFF
--- a/client/displayservers/Wayland/cursor.c
+++ b/client/displayservers/Wayland/cursor.c
@@ -183,7 +183,7 @@ void waylandCursorFree(void)
 
 void waylandCursorScaleChange(void)
 {
-  int newScale = ceil(wl_fixed_to_double(wlWm.scale));
+  int newScale = ceil(wlWm.scale);
   if (newScale == wlWm.cursorScale)
     return;
 

--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -92,8 +92,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
 
     int width, height;
     wlWm.desktop->getSize(&width, &height);
-    wl_egl_window_resize(wlWm.eglWindow, wl_fixed_to_int(width * wlWm.scale),
-        wl_fixed_to_int(height * wlWm.scale), 0, 0);
+    wl_egl_window_resize(wlWm.eglWindow, width * wlWm.scale, height * wlWm.scale, 0, 0);
 
     if (width == 0 || height == 0)
       skipResize = true;
@@ -123,7 +122,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
         wp_viewport_destroy(wlWm.viewport);
         wlWm.viewport = NULL;
       }
-      wl_surface_set_buffer_scale(wlWm.surface, wl_fixed_to_int(wlWm.scale));
+      wl_surface_set_buffer_scale(wlWm.surface, floor(wlWm.scale));
     }
 
     struct wl_region * region = wl_compositor_create_region(wlWm.compositor);
@@ -131,7 +130,7 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
     wl_surface_set_opaque_region(wlWm.surface, region);
     wl_region_destroy(region);
 
-    app_handleResizeEvent(width, height, wl_fixed_to_double(wlWm.scale),
+    app_handleResizeEvent(width, height, wlWm.scale,
         (struct Border) {0, 0, 0, 0});
     app_invalidateWindow(true);
     waylandStopWaitFrame();

--- a/client/displayservers/Wayland/output.c
+++ b/client/displayservers/Wayland/output.c
@@ -29,14 +29,14 @@
 
 static void outputUpdateScale(struct WaylandOutput * node)
 {
-  wl_fixed_t original = node->scale;
+  double original = node->scale;
 
   if (!wlWm.useFractionalScale || !wlWm.viewporter || !node->logicalWidth)
-    node->scale = wl_fixed_from_int(node->scaleInt);
+    node->scale = node->scaleInt;
   else
   {
     int32_t modeWidth = node->modeRotate ? node->modeHeight : node->modeWidth;
-    node->scale = wl_fixed_from_double(1.0 * modeWidth / node->logicalWidth);
+    node->scale = 1.0 * modeWidth / node->logicalWidth;
   }
 
   if (original != node->scale)
@@ -209,12 +209,12 @@ void waylandOutputTryUnbind(uint32_t name)
   }
 }
 
-wl_fixed_t waylandOutputGetScale(struct wl_output * output)
+double waylandOutputGetScale(struct wl_output * output)
 {
   struct WaylandOutput * node;
 
   wl_list_for_each(node, &wlWm.outputs, link)
     if (node->output == output)
       return node->scale;
-  return 0;
+  return 0.0;
 }

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -62,7 +62,7 @@ struct WaylandPoll
 struct WaylandOutput
 {
   uint32_t name;
-  wl_fixed_t scale;
+  double scale;
   int32_t scaleInt;
   int32_t logicalWidth;
   int32_t logicalHeight;
@@ -108,7 +108,7 @@ struct WaylandDSState
   struct wl_shm * shm;
   struct wl_compositor * compositor;
 
-  wl_fixed_t scale;
+  double scale;
   bool fractionalScale;
   bool needsResize;
   bool configured;
@@ -285,7 +285,7 @@ bool waylandOutputInit(void);
 void waylandOutputFree(void);
 void waylandOutputBind(uint32_t name, uint32_t version);
 void waylandOutputTryUnbind(uint32_t name);
-wl_fixed_t waylandOutputGetScale(struct wl_output * output);
+double waylandOutputGetScale(struct wl_output * output);
 
 // poll module
 bool waylandPollInit(void);

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -33,12 +33,12 @@
 
 void waylandWindowUpdateScale(void)
 {
-  wl_fixed_t maxScale = 0;
+  double maxScale = 0;
   struct SurfaceOutput * node;
 
   wl_list_for_each(node, &wlWm.surfaceOutputs, link)
   {
-    wl_fixed_t scale = waylandOutputGetScale(node->output);
+    double scale = waylandOutputGetScale(node->output);
     if (scale > maxScale)
       maxScale = scale;
   }
@@ -46,7 +46,7 @@ void waylandWindowUpdateScale(void)
   if (maxScale)
   {
     wlWm.scale = maxScale;
-    wlWm.fractionalScale = wl_fixed_from_int(wl_fixed_to_int(maxScale)) != maxScale;
+    wlWm.fractionalScale = floor(maxScale) != maxScale;
     wlWm.needsResize = true;
     waylandCursorScaleChange();
     app_invalidateWindow(true);
@@ -87,7 +87,7 @@ static const struct wl_surface_listener wlSurfaceListener = {
 
 bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
-  wlWm.scale = wl_fixed_from_int(1);
+  wlWm.scale = 1.0;
 
   wlWm.frameEvent = lgCreateEvent(true, 0);
   if (!wlWm.frameEvent)


### PR DESCRIPTION
One of my monitors has a resolution of 3840 x 2560. I have this set up with a scaling factor of 1.6x to achieve a comfortable widget size akin to that of a 30" 4k display at 1.5x scale. Unfortunately the ``wl_fixed`` type stores 1.6 as 1.6034somethingsomething (I can't remember the exact number). This results in an inaccurate scaled resolution (an additional 3 or so pixels in each dimension) on my funky monitor. 

The fix is to replace the ``wl_fixed`` typed with ``double`` in the wayland display server.

I'm not sure if there's a better solution to this problem. Please advise if there is one - I'd be happy to implement it if so.