### PR TITLE
rgb24_configure() fix -Werror=format-truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ idd/*/Debug
 idd/*/VersionInfo.h
 idd/*/VERSION
 idd/packages
+/build/

--- a/host/platform/Windows/capture/DXGI/src/pp/rgb24.c
+++ b/host/platform/Windows/capture/DXGI/src/pp/rgb24.c
@@ -94,7 +94,7 @@ static bool rgb24_configure(void * opaque,
     /* adjust for the aligned width */
     this.height = (*cols * *rows) / (packedPitch / 3);
 
-    char sOutputWidth[6], sOutputHeight[6];
+    char sOutputWidth[11], sOutputHeight[11];
     snprintf(sOutputWidth , sizeof(sOutputWidth) , "%d", this.width );
     snprintf(sOutputHeight, sizeof(sOutputHeight), "%d", this.height);
 


### PR DESCRIPTION
```gcc-error
error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 6 [-Werror=format-truncation=]
   98 |     snprintf(sOutputWidth , sizeof(sOutputWidth) , %d, this.width );
      |                                                     ^~
```