### PR TITLE
[idd] helper: load default mode list with default refresh rate

### DIFF
--- a/idd/LGIddHelper/CRegistrySettings.cpp
+++ b/idd/LGIddHelper/CRegistrySettings.cpp
@@ -78,6 +78,24 @@ static std::optional<DisplayMode> parseDisplayMode(const std::wstring &str)
   return mode;
 }
 
+std::vector<DisplayMode> CRegistrySettings::getDefaultModes()
+{
+  auto defaultRefresh = getDefaultRefresh();
+  int refresh = defaultRefresh ? *defaultRefresh : DEFAULT_REFRESH;
+
+  std::vector<DisplayMode> result;
+  for (int i = 0; i < ARRAYSIZE(DefaultDisplayModes); ++i)
+  {
+    DisplayMode mode;
+    mode.width = DefaultDisplayModes[i][0];
+    mode.height = DefaultDisplayModes[i][1];
+    mode.refresh = refresh;
+    mode.preferred = i == DefaultPreferredDisplayMode;
+    result.emplace_back(mode);
+  }
+  return result;
+}
+
 std::optional<std::vector<DisplayMode>> CRegistrySettings::getModes()
 {
   LSTATUS status;
@@ -89,19 +107,7 @@ std::optional<std::vector<DisplayMode>> CRegistrySettings::getModes()
   case ERROR_SUCCESS:
     break;
   case ERROR_FILE_NOT_FOUND:
-  {
-    std::vector<DisplayMode> result;
-    for (int i = 0; i < ARRAYSIZE(DefaultDisplayModes); ++i)
-    {
-      DisplayMode mode;
-      mode.width = DefaultDisplayModes[i][0];
-      mode.height = DefaultDisplayModes[i][1];
-      mode.refresh = DefaultDisplayModes[i][2];
-      mode.preferred = i == DefaultPreferredDisplayMode;
-      result.emplace_back(mode);
-    }
-    return result;
-  }
+    return getDefaultModes();
   default:
     DEBUG_ERROR_HR(status, "RegGetValue(Modes) length computation");
     return {};

--- a/idd/LGIddHelper/CRegistrySettings.h
+++ b/idd/LGIddHelper/CRegistrySettings.h
@@ -44,6 +44,7 @@ public:
   LSTATUS open();
   bool isOpen() { return !!hKey; }
 
+  std::vector<DisplayMode> getDefaultModes();
   std::optional<std::vector<DisplayMode>> getModes();
   LSTATUS setModes(const std::vector<DisplayMode> &modes);
 


### PR DESCRIPTION
After 882d53179287a216dafa1a573a0b6dc32ef05768, the existing code in the helper reads past the end of the array for refresh rate, which is broken.

This PR also refactors the default modes into a `getDefaultModes` method so that it can be used for a reset feature later.