### PR TITLE
[idd] helper: add mode list reset button

### DIFF
--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -88,7 +88,7 @@ void CConfigWindow::updateFont()
 
   for (HWND child : std::initializer_list<HWND>({
     *m_version, *m_modeGroup, *m_modeBox, *m_widthLabel, *m_heightLabel, *m_refreshLabel,
-    *m_modeWidth, *m_modeHeight, *m_modeRefresh, *m_modeUpdate, *m_modeDelete,
+    *m_modeWidth, *m_modeHeight, *m_modeRefresh, *m_modeUpdate, *m_modeDelete, *m_modeReset,
     *m_autosizeGroup, *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz,
   }))
     SendMessage(child, WM_SETFONT, (WPARAM)m_font.Get(), 1);
@@ -154,6 +154,7 @@ LRESULT CConfigWindow::onCreate()
 
   m_modeUpdate.reset(new CButton(L"Save", WS_CHILD | WS_VISIBLE | WS_TABSTOP, m_hwnd));
   m_modeDelete.reset(new CButton(L"Delete", WS_CHILD | WS_VISIBLE | WS_TABSTOP, m_hwnd));
+  m_modeReset.reset(new CButton(L"Reset", WS_CHILD | WS_VISIBLE | WS_TABSTOP, m_hwnd));
   EnableWindow(*m_modeUpdate, FALSE);
   EnableWindow(*m_modeDelete, FALSE);
 
@@ -198,6 +199,7 @@ LRESULT CConfigWindow::onResize(DWORD width, DWORD height)
   pos.pinBottomLeft(*m_modeRefresh, 75, 48, 50, 20);
   pos.pinBottomLeft(*m_modeUpdate, 24, 20, 50, 24);
   pos.pinBottomLeft(*m_modeDelete, 75, 20, 50, 24);
+  pos.pinBottomLeft(*m_modeReset, 126, 20, 50, 24);
 
   pos.pinTopLeft(*m_autosizeGroup, 224, 40, 200, 52);
   pos.pinTopLeft(*m_defRefreshLabel, 236, 64, 95, 20);
@@ -278,6 +280,14 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
     if (result != ERROR_SUCCESS)
       DEBUG_ERROR_HR((HRESULT) result, "Failed to save modes");
 
+    updateModeList();
+    onModeListSelectChange();
+  }
+  else if (m_modeReset && hwnd == *m_modeReset && code == BN_CLICKED && m_modes)
+  {
+    *m_modes = m_settings.getDefaultModes();
+    m_settings.setModes(*m_modes);
+    m_modeBox->clear();
     updateModeList();
     onModeListSelectChange();
   }

--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -231,11 +231,11 @@ void CConfigWindow::onModeListSelectChange()
 
 LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
 {
-  if (hwnd == *m_modeBox && code == LBN_SELCHANGE && m_modes)
+  if (m_modeBox && hwnd == *m_modeBox && code == LBN_SELCHANGE && m_modes)
   {
     onModeListSelectChange();
   }
-  else if (hwnd == *m_modeUpdate && code == BN_CLICKED && m_modes)
+  else if (m_modeUpdate && hwnd == *m_modeUpdate && code == BN_CLICKED && m_modes)
   {
     int sel = m_modeBox->getSel();
     if (sel == LB_ERR)
@@ -264,7 +264,7 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
     if (result != ERROR_SUCCESS)
       DEBUG_ERROR_HR((HRESULT) result, "Failed to save modes");
   }
-  else if (hwnd == *m_modeDelete && code == BN_CLICKED && m_modes)
+  else if (m_modeDelete && hwnd == *m_modeDelete && code == BN_CLICKED && m_modes)
   {
     int sel = m_modeBox->getSel();
     if (sel == LB_ERR)
@@ -281,7 +281,7 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
     updateModeList();
     onModeListSelectChange();
   }
-  else if (hwnd == *m_defRefresh && code == EN_CHANGE && m_defaultRefresh)
+  else if (m_defRefresh && hwnd == *m_defRefresh && code == EN_CHANGE && m_defaultRefresh)
   {
     int value;
     try

--- a/idd/LGIddHelper/CConfigWindow.h
+++ b/idd/LGIddHelper/CConfigWindow.h
@@ -51,6 +51,7 @@ class CConfigWindow : public CWindow
 
   std::unique_ptr<CButton> m_modeUpdate;
   std::unique_ptr<CButton> m_modeDelete;
+  std::unique_ptr<CButton> m_modeReset;
 
   std::unique_ptr<CGroupBox> m_autosizeGroup;
   std::unique_ptr<CStaticWidget> m_defRefreshLabel;


### PR DESCRIPTION
This PR adds a button to reset the mode list to the default.

There's a separate commit to avoid empty optional dereference that's pulled out of #1277 to avoid conflict.