### PR TITLE
[client] wayland: use wp_fractional_scale_v1 for pixel-exact output

### DIFF
--- a/client/displayservers/Wayland/gl.c
+++ b/client/displayservers/Wayland/gl.c
@@ -92,8 +92,14 @@ void waylandEGLSwapBuffers(EGLDisplay display, EGLSurface surface, const struct 
 
     int width, height;
     wlWm.desktop->getSize(&width, &height);
-    wl_egl_window_resize(wlWm.eglWindow, waylandScaleMulInt(wlWm.scale, width),
-        waylandScaleMulInt(wlWm.scale, height), 0, 0);
+
+    // Size the buffer to ceil(logical * scale) so it exactly covers the
+    // viewport destination. Truncating (floor) would leave the buffer up to a
+    // pixel short and force the compositor to stretch (and thus resample) the
+    // image, producing the distortion seen with fractional scale.
+    wl_egl_window_resize(wlWm.eglWindow,
+        waylandScaleMulIntCeil(wlWm.scale, width),
+        waylandScaleMulIntCeil(wlWm.scale, height), 0, 0);
 
     if (width == 0 || height == 0)
       skipResize = true;

--- a/client/displayservers/Wayland/protocol/CMakeLists.txt
+++ b/client/displayservers/Wayland/protocol/CMakeLists.txt
@@ -39,6 +39,11 @@ wayland_generate(
 wayland_generate(
   "${WAYLAND_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
   "${CMAKE_BINARY_DIR}/wayland/wayland-viewporter-client-protocol")
+# fractional-scale-v1 is bundled locally because the pinned wayland-protocols
+# submodule predates it (it was added upstream in wayland-protocols 1.31).
+wayland_generate(
+  "${CMAKE_CURRENT_SOURCE_DIR}/fractional-scale-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-fractional-scale-v1-client-protocol")
 wayland_generate(
   "${WAYLAND_PROTOCOLS_BASE}/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml"
   "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-decoration-unstable-v1-client-protocol")

--- a/client/displayservers/Wayland/protocol/fractional-scale-v1.xml
+++ b/client/displayservers/Wayland/protocol/fractional-scale-v1.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="fractional_scale_v1">
+  <copyright>
+    Copyright © 2022 Kenny Levinsen
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for requesting fractional surface scales">
+    This protocol allows a compositor to suggest for surfaces to render at
+    fractional scales.
+
+    A client can submit scaled content by utilizing wp_viewport. This is done by
+    creating a wp_viewport object for the surface and setting the destination
+    rectangle to the surface size before the scale factor is applied.
+
+    The buffer size is calculated by multiplying the surface size by the
+    intended scale.
+
+    The wl_surface buffer scale should remain set to 1.
+
+    If a surface has a surface-local size of 100 px by 50 px and wishes to
+    submit buffers with a scale of 1.5, then a buffer of 150px by 75 px should
+    be used and the wp_viewport destination rectangle should be 100 px by 50 px.
+
+    For toplevel surfaces, the size is rounded halfway away from zero. The
+    rounding algorithm for subsurface position and size is not defined.
+  </description>
+
+  <interface name="wp_fractional_scale_manager_v1" version="1">
+    <description summary="fractional surface scale information">
+      A global interface for requesting surfaces to use fractional scales.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the fractional surface scale interface">
+        Informs the server that the client will not be using this protocol
+        object anymore. This does not affect any other objects,
+        wp_fractional_scale_v1 objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="fractional_scale_exists" value="0"
+        summary="the surface already has a fractional_scale object associated"/>
+    </enum>
+
+    <request name="get_fractional_scale">
+      <description summary="extend surface interface for scale information">
+        Create an add-on object for the the wl_surface to let the compositor
+        request fractional scales. If the given wl_surface already has a
+        wp_fractional_scale_v1 object associated, the fractional_scale_exists
+        protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_fractional_scale_v1"
+           summary="the new surface scale info interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_fractional_scale_v1" version="1">
+    <description summary="fractional scale interface to a wl_surface">
+      An additional interface to a wl_surface object which allows the compositor
+      to inform the client of the preferred scale.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove surface scale information for surface">
+        Destroy the fractional scale object. When this object is destroyed,
+        preferred_scale events will no longer be sent.
+      </description>
+    </request>
+
+    <event name="preferred_scale">
+      <description summary="notify of new preferred scale">
+        Notification of a new preferred scale for this surface that the
+        compositor suggests that the client should use.
+
+        The sent scale is the numerator of a fraction with a denominator of 120.
+      </description>
+      <arg name="scale" type="uint" summary="the new preferred scale"/>
+    </event>
+  </interface>
+</protocol>

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -46,6 +46,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, wp_viewporter_interface.name))
     wlWm.viewporter = wl_registry_bind(wlWm.registry, name,
         &wp_viewporter_interface, 1);
+  else if (!strcmp(interface, wp_fractional_scale_manager_v1_interface.name))
+    wlWm.fractionalScaleManager = wl_registry_bind(wlWm.registry, name,
+        &wp_fractional_scale_manager_v1_interface, 1);
   else if (!strcmp(interface, zwp_relative_pointer_manager_v1_interface.name))
     wlWm.relativePointerManager = wl_registry_bind(wlWm.registry, name,
         &zwp_relative_pointer_manager_v1_interface, 1);

--- a/client/displayservers/Wayland/scale.h
+++ b/client/displayservers/Wayland/scale.h
@@ -74,6 +74,11 @@ static inline int waylandScaleMulInt(struct WaylandScale scale, int value)
   return (int)(((int64_t)value * scale.num) / scale.den);
 }
 
+static inline int waylandScaleMulIntCeil(struct WaylandScale scale, int value)
+{
+  return (int)(((int64_t)value * scale.num + scale.den - 1) / scale.den);
+}
+
 static inline double waylandScaleToDouble(struct WaylandScale scale)
 {
   return (double)scale.num / (double)scale.den;

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -41,6 +41,7 @@
 
 #include "wayland-presentation-time-client-protocol.h"
 #include "wayland-viewporter-client-protocol.h"
+#include "wayland-fractional-scale-v1-client-protocol.h"
 #include "wayland-keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
 #include "wayland-pointer-constraints-unstable-v1-client-protocol.h"
 #include "wayland-relative-pointer-unstable-v1-client-protocol.h"
@@ -112,6 +113,8 @@ struct WaylandDSState
 
   struct WaylandScale scale;
   bool fractionalScale;
+  // exact per-surface scale reported by wp_fractional_scale_v1 (invalid if unknown)
+  struct WaylandScale preferredScale;
   bool needsResize;
   bool configured;
   bool warpSupport;
@@ -175,6 +178,8 @@ struct WaylandDSState
 
   struct wp_viewporter * viewporter;
   struct wp_viewport * viewport;
+  struct wp_fractional_scale_manager_v1 * fractionalScaleManager;
+  struct wp_fractional_scale_v1 * fractionalScaleHandle;
   struct zxdg_output_manager_v1 * xdgOutputManager;
   struct wl_list outputs; // WaylandOutput::link
   struct wl_list surfaceOutputs; // SurfaceOutput::link

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -34,13 +34,24 @@
 void waylandWindowUpdateScale(void)
 {
   struct WaylandScale maxScale = waylandScaleFromInt(0);
-  struct SurfaceOutput * node;
 
-  wl_list_for_each(node, &wlWm.surfaceOutputs, link)
+  // When the compositor supports wp_fractional_scale_v1 it tells us the exact
+  // scale to use for this surface. This is authoritative and pixel-exact, so
+  // prefer it over deriving the scale from output geometry (which is only an
+  // approximation, since the logical size it is computed from has already been
+  // rounded by the compositor, and leads to a blurry/distorted image after the
+  // resulting buffer is resampled).
+  if (wlWm.fractionalScaleHandle && waylandScaleValid(wlWm.preferredScale))
+    maxScale = wlWm.preferredScale;
+  else
   {
-    struct WaylandScale scale = waylandOutputGetScale(node->output);
-    if (waylandScaleCmp(scale, maxScale) > 0)
-      maxScale = scale;
+    struct SurfaceOutput * node;
+    wl_list_for_each(node, &wlWm.surfaceOutputs, link)
+    {
+      struct WaylandScale scale = waylandOutputGetScale(node->output);
+      if (waylandScaleCmp(scale, maxScale) > 0)
+        maxScale = scale;
+    }
   }
 
   if (waylandScaleValid(maxScale))
@@ -85,6 +96,18 @@ static const struct wl_surface_listener wlSurfaceListener = {
   .leave = wlSurfaceLeaveHandler,
 };
 
+static void fractionalScalePreferredScale(void * data,
+    struct wp_fractional_scale_v1 * fractionalScale, uint32_t scale)
+{
+  // scale is the numerator of a fraction with a denominator of 120.
+  wlWm.preferredScale = waylandScaleFromRatio(scale, 120);
+  waylandWindowUpdateScale();
+}
+
+static const struct wp_fractional_scale_v1_listener fractionalScaleListener = {
+  .preferred_scale = fractionalScalePreferredScale,
+};
+
 bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
   wlWm.scale = waylandScaleFromInt(1);
@@ -112,6 +135,17 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
 
   wl_surface_add_listener(wlWm.surface, &wlSurfaceListener, NULL);
 
+  // Ask the compositor for the exact fractional scale of this surface. This is
+  // only usable together with wp_viewporter; without it we fall back to the
+  // output-geometry heuristic in waylandWindowUpdateScale.
+  if (wlWm.useFractionalScale && wlWm.viewporter && wlWm.fractionalScaleManager)
+  {
+    wlWm.fractionalScaleHandle = wp_fractional_scale_manager_v1_get_fractional_scale(
+        wlWm.fractionalScaleManager, wlWm.surface);
+    wp_fractional_scale_v1_add_listener(wlWm.fractionalScaleHandle,
+        &fractionalScaleListener, NULL);
+  }
+
   if (!wlWm.desktop->shellInit(wlWm.display, wlWm.surface,
         title, appId, fullscreen, maximize, borderless, resizable))
     return false;
@@ -122,6 +156,8 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
 
 void waylandWindowFree(void)
 {
+  if (wlWm.fractionalScaleHandle)
+    wp_fractional_scale_v1_destroy(wlWm.fractionalScaleHandle);
   wl_surface_destroy(wlWm.surface);
   lgFreeEvent(wlWm.frameEvent);
 }


### PR DESCRIPTION
# [client] wayland: use wp_fractional_scale_v1 for pixel-exact output

## Problem

On a fractionally-scaled Wayland session (e.g. GNOME/Mutter at 125 %, 150 %,
175 %) the EGL/OpenGL output is slightly soft and geometrically distorted
instead of producing a crisp 1:1 image. An SDL3-based client such as FreeRDP 3's
SDL frontend (`sdl-freerdp3`) is pixel-perfect on the same setup, which is the
behaviour this PR brings to Looking Glass.

## Root cause

The Wayland EGL backend renders into a `wp_viewport`, but it never asks the
compositor what scale the surface is actually displayed at. Two issues combine:

1. **The scale is guessed from output geometry** (`output.c`):
   ```c
   node->scale = waylandScaleFromRatio(modeWidth, node->logicalWidth);
   ```
   `logical_width` is itself rounded by the compositor (`round(mode / scale)`),
   so reversing the division cannot recover the exact `n/120` fraction the
   compositor uses for the surface. The `WaylandScale` rational type added in
   01b8724c makes this division lossless, but the *input* has already lost
   information, so the result is still an approximation.

   Example — 2560 px mode at 150 %:
   ```
   logical_width = round(2560 / 1.5) = 1707     (2560 / 1.5 = 1706.67)
   derived scale = 2560 / 1707       = 1.50029...   (not 1.5)
   ```

2. **The buffer is sized with a truncating multiply** (`gl.c`):
   ```c
   wl_egl_window_resize(wlWm.eglWindow,
       waylandScaleMulInt(wlWm.scale, width),   // floor
       waylandScaleMulInt(wlWm.scale, height), 0, 0);
   ```
   Combined with `wp_viewport_set_destination(width, height)`, a buffer that is
   even a pixel short of `logical * scale` gets stretched to fill the
   destination — a non-integer resample of the whole frame.

The net effect is that the buffer no longer maps 1:1 to physical pixels and the
compositor resamples it.

## Fix

* Bind **`wp_fractional_scale_v1`** and create a per-surface object. Its
  `preferred_scale` event reports the compositor's exact scale as a numerator
  over 120, which maps directly onto the existing `WaylandScale` type:
  ```c
  wlWm.preferredScale = waylandScaleFromRatio(scale, 120);
  ```
  `waylandWindowUpdateScale()` prefers this authoritative value when available.

* Add **`waylandScaleMulIntCeil()`** (integer-only, mirrors the existing
  `waylandScaleMulInt()`) and size the EGL buffer with it, so
  `ceil(logical * scale)` exactly covers the viewport destination.

With the exact scale and a matching buffer size, Mutter takes its no-resample
path and the image is pixel-exact.

## Compatibility / scope

* Gated behind the existing `wayland:fractionScale` option (default on) and only
  active when both `wp_viewporter` and `wp_fractional_scale_manager_v1` are
  advertised.
* Compositors without `wp_fractional_scale_v1` fall back to the existing
  output-geometry heuristic — **no behavioural change** there.
* Integer scales (`preferred_scale == 120, 240, …`) continue to take the
  `wl_surface_set_buffer_scale()` path.

## Note on the protocol file

`fractional-scale-v1.xml` is bundled locally under
`client/displayservers/Wayland/protocol/` because the pinned
`repos/wayland-protocols` submodule (v1.25) predates the protocol, which was
added upstream in wayland-protocols **1.31**. The CMake generator points at the
local copy.

Alternative, if preferred by maintainers: bump the `repos/wayland-protocols`
submodule to ≥ 1.31 and reference `staging/fractional-scale/fractional-scale-v1.xml`
from `${WAYLAND_PROTOCOLS_BASE}` like the other protocols, dropping the local
copy. Happy to switch the PR to that approach.

## Testing

Builds and links cleanly against current `master` (`b3701992`) with no new
warnings. Verified on GNOME/Mutter under fractional scaling: output is sharp
with no geometric distortion; the `wp_viewport` destination (logical size) and
the `ceil(logical * scale)` buffer size produce a 1:1 mapping to physical pixels.