### PR TITLE
[client] core: resize guest to actual surface size

### DIFF
--- a/client/src/core.c
+++ b/client/src/core.c
@@ -221,8 +221,8 @@ void core_updatePositionInfo(void)
       .type = LG_MSG_WINDOWSIZE,
       .windowSize =
       {
-        .width  = g_state.windowW,
-        .height = g_state.windowH
+        .width  = round(g_state.windowW * g_state.windowScale),
+        .height = round(g_state.windowH * g_state.windowScale)
       }
     };
     lgMessage_post(&msg);


### PR DESCRIPTION
This ensures that the guest renders with the actual screen size when the client surface is scaled when using automatic scaling.