### PR TITLE
 [client] wayland: use fractional-scale-v1 now that it's available

### DIFF
--- a/client/displayservers/Wayland/protocol/CMakeLists.txt
+++ b/client/displayservers/Wayland/protocol/CMakeLists.txt
@@ -60,6 +60,9 @@ wayland_generate(
 wayland_generate(
   "${WAYLAND_PROTOCOLS_BASE}/staging/xdg-activation/xdg-activation-v1.xml"
   "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-activation-v1-client-protocol")
+wayland_generate(
+  "${WAYLAND_PROTOCOLS_BASE}/staging/fractional-scale/fractional-scale-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-fractional-scale-v1-client-protocol")
 
 target_link_libraries(wayland_protocol
   PkgConfig::WAYLAND

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -46,6 +46,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, wp_viewporter_interface.name))
     wlWm.viewporter = wl_registry_bind(wlWm.registry, name,
         &wp_viewporter_interface, 1);
+  else if (!strcmp(interface, wp_fractional_scale_manager_v1_interface.name))
+    wlWm.fractionalScaleManager = wl_registry_bind(wlWm.registry, name,
+        &wp_fractional_scale_manager_v1_interface, 1);
   else if (!strcmp(interface, zwp_relative_pointer_manager_v1_interface.name))
     wlWm.relativePointerManager = wl_registry_bind(wlWm.registry, name,
         &zwp_relative_pointer_manager_v1_interface, 1);

--- a/client/displayservers/Wayland/scale.h
+++ b/client/displayservers/Wayland/scale.h
@@ -71,7 +71,7 @@ static inline int waylandScaleCeil(struct WaylandScale scale)
 
 static inline int waylandScaleMulInt(struct WaylandScale scale, int value)
 {
-  return (int)(((int64_t)value * scale.num) / scale.den);
+  return (int)(((int64_t)value * scale.num + scale.den / 2) / scale.den);
 }
 
 static inline double waylandScaleToDouble(struct WaylandScale scale)

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -47,6 +47,7 @@
 #include "wayland-idle-inhibit-unstable-v1-client-protocol.h"
 #include "wayland-xdg-output-unstable-v1-client-protocol.h"
 #include "wayland-xdg-activation-v1-client-protocol.h"
+#include "wayland-fractional-scale-v1-client-protocol.h"
 
 #include "scale.h"
 
@@ -175,6 +176,8 @@ struct WaylandDSState
 
   struct wp_viewporter * viewporter;
   struct wp_viewport * viewport;
+  struct wp_fractional_scale_manager_v1 * fractionalScaleManager;
+  struct wp_fractional_scale_v1 * fractionalScaleInterface;
   struct zxdg_output_manager_v1 * xdgOutputManager;
   struct wl_list outputs; // WaylandOutput::link
   struct wl_list surfaceOutputs; // SurfaceOutput::link

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -31,8 +31,21 @@
 
 // Surface-handling listeners.
 
+static void setScale(struct WaylandScale newScale)
+{
+  wlWm.scale = newScale;
+  wlWm.fractionalScale = waylandScaleIsFractional(newScale);
+  wlWm.needsResize = true;
+  waylandCursorScaleChange();
+  app_invalidateWindow(true);
+  waylandStopWaitFrame();
+}
+
 void waylandWindowUpdateScale(void)
 {
+  if (wlWm.fractionalScaleInterface)
+    return;
+
   struct WaylandScale maxScale = waylandScaleFromInt(0);
   struct SurfaceOutput * node;
 
@@ -44,14 +57,7 @@ void waylandWindowUpdateScale(void)
   }
 
   if (waylandScaleValid(maxScale))
-  {
-    wlWm.scale = maxScale;
-    wlWm.fractionalScale = waylandScaleIsFractional(maxScale);
-    wlWm.needsResize = true;
-    waylandCursorScaleChange();
-    app_invalidateWindow(true);
-    waylandStopWaitFrame();
-  }
+    setScale(maxScale);
 }
 
 static void wlSurfaceEnterHandler(void * data, struct wl_surface * surface, struct wl_output * output)
@@ -85,6 +91,16 @@ static const struct wl_surface_listener wlSurfaceListener = {
   .leave = wlSurfaceLeaveHandler,
 };
 
+static void fractionalScalePreferredScale(void * data,
+    struct wp_fractional_scale_v1 * fractionalScale, uint32_t scale)
+{
+  setScale(waylandScaleFromRatio(scale, 120));
+}
+
+static const struct wp_fractional_scale_v1_listener fractionalScaleListener = {
+  .preferred_scale = fractionalScalePreferredScale,
+};
+
 bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
   wlWm.scale = waylandScaleFromInt(1);
@@ -110,7 +126,15 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
     return false;
   }
 
-  wl_surface_add_listener(wlWm.surface, &wlSurfaceListener, NULL);
+  if (wlWm.fractionalScaleManager)
+  {
+    wlWm.fractionalScaleInterface = wp_fractional_scale_manager_v1_get_fractional_scale(
+        wlWm.fractionalScaleManager, wlWm.surface);
+    wp_fractional_scale_v1_add_listener(wlWm.fractionalScaleInterface,
+        &fractionalScaleListener, NULL);
+  }
+  else
+    wl_surface_add_listener(wlWm.surface, &wlSurfaceListener, NULL);
 
   if (!wlWm.desktop->shellInit(wlWm.display, wlWm.surface,
         title, appId, fullscreen, maximize, borderless, resizable))
@@ -122,6 +146,8 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
 
 void waylandWindowFree(void)
 {
+  if (wlWm.fractionalScaleInterface)
+    wp_fractional_scale_v1_destroy(wlWm.fractionalScaleInterface);
   wl_surface_destroy(wlWm.surface);
   lgFreeEvent(wlWm.frameEvent);
 }


### PR DESCRIPTION
We had a hack to implement fractional scaling from before `fractional-scale-v1` is available that computed the scale by guessing from the `wl_output` size. Now that `fractional-scale-v1` is available, we can just get the scale from the protocol instead.