### PR TITLE
[idd] helper: update icon to reflect GPU state and defer if needed

### DIFF
--- a/idd/LGIddHelper/CNotifyWindow.cpp
+++ b/idd/LGIddHelper/CNotifyWindow.cpp
@@ -49,7 +49,7 @@ bool CNotifyWindow::registerClass()
 }
 
 CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_iconRegistered(false),
-  m_noGPUQueued(false), m_menu(CreatePopupMenu()), closeRequested(false)
+  m_menu(CreatePopupMenu()), closeRequested(false)
 {
   CreateWindowEx(0, MAKEINTATOM(s_atom), NULL,
     0, 0, 0, 0, 0, NULL, NULL, hInstance, this);
@@ -82,7 +82,7 @@ LRESULT CNotifyWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
     return 0;
 
   case WM_NO_GPU:
-    handleNoGPUNotification();
+    handleGPUNotification((bool)wParam);
     return 0;
 
   default:
@@ -152,7 +152,7 @@ void CNotifyWindow::registerIcon()
 {
   m_iconData.cbSize = sizeof m_iconData;
   m_iconData.hWnd = m_hwnd;
-  m_iconData.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+  m_iconData.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP | NIF_SHOWTIP;
   m_iconData.uCallbackMessage = WM_NOTIFY_ICON;
   m_iconData.hIcon = LoadIcon(hInstance, IDI_APPLICATION);
   m_iconData.uVersion = NOTIFYICON_VERSION_4;
@@ -168,23 +168,36 @@ void CNotifyWindow::registerIcon()
   if (!Shell_NotifyIcon(NIM_SETVERSION, &m_iconData))
     DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_SETVERSION)");
 
-  if (m_noGPUQueued)
+  if (m_gpuQueue)
   {
-    m_noGPUQueued = false;
-    handleNoGPUNotification();
+    handleGPUNotification(*m_gpuQueue);
+    m_gpuQueue.reset();
   }
 }
 
-void CNotifyWindow::noGPUNotification()
+void CNotifyWindow::setGPU(bool hasGPU)
 {
   if (m_iconRegistered)
-    PostMessage(m_hwnd, WM_NO_GPU, 0, 0);
+    PostMessage(m_hwnd, WM_NO_GPU, hasGPU, 0);
   else
-    m_noGPUQueued = true;
+    m_gpuQueue.emplace(hasGPU);
 }
 
-void CNotifyWindow::handleNoGPUNotification()
+void CNotifyWindow::handleGPUNotification(bool hasGPU)
 {
+  StringCbCopy(m_iconData.szTip, sizeof m_iconData.szTip, hasGPU ?
+    L"Looking Glass (IDD) with GPU acceleration" :
+    L"Looking Glass (IDD) with software rendering");
+
+  if (!Shell_NotifyIcon(NIM_MODIFY, &m_iconData))
+  {
+    DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_ADD)");
+    return;
+  }
+
+  if (hasGPU)
+    return;
+
   CRegistrySettings settings;
   LSTATUS error = settings.open();
   if (error != ERROR_SUCCESS)
@@ -197,7 +210,7 @@ void CNotifyWindow::handleNoGPUNotification()
   NOTIFYICONDATA nid;
   memcpy(&nid, &m_iconData, sizeof nid);
 
-  nid.uFlags = NIF_INFO;
+  nid.uFlags = NIF_INFO | NIF_SHOWTIP;
   nid.dwInfoFlags = NIIF_WARNING;
   StringCbCopy(nid.szInfoTitle, sizeof nid.szInfoTitle, L"No GPU found!");
   StringCbCopy(nid.szInfo, sizeof nid.szInfo,

--- a/idd/LGIddHelper/CNotifyWindow.cpp
+++ b/idd/LGIddHelper/CNotifyWindow.cpp
@@ -48,8 +48,8 @@ bool CNotifyWindow::registerClass()
   return s_atom;
 }
 
-CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_menu(CreatePopupMenu()),
-  closeRequested(false)
+CNotifyWindow::CNotifyWindow() : m_iconData({ 0 }), m_iconRegistered(false),
+  m_noGPUQueued(false), m_menu(CreatePopupMenu()), closeRequested(false)
 {
   CreateWindowEx(0, MAKEINTATOM(s_atom), NULL,
     0, 0, 0, 0, 0, NULL, NULL, hInstance, this);
@@ -164,13 +164,23 @@ void CNotifyWindow::registerIcon()
     return;
   }
 
+  m_iconRegistered = true;
   if (!Shell_NotifyIcon(NIM_SETVERSION, &m_iconData))
     DEBUG_ERROR_HR(GetLastError(), "Shell_NotifyIcon(NIM_SETVERSION)");
+
+  if (m_noGPUQueued)
+  {
+    m_noGPUQueued = false;
+    handleNoGPUNotification();
+  }
 }
 
 void CNotifyWindow::noGPUNotification()
 {
-  PostMessage(m_hwnd, WM_NO_GPU, 0, 0);
+  if (m_iconRegistered)
+    PostMessage(m_hwnd, WM_NO_GPU, 0, 0);
+  else
+    m_noGPUQueued = true;
 }
 
 void CNotifyWindow::handleNoGPUNotification()

--- a/idd/LGIddHelper/CNotifyWindow.h
+++ b/idd/LGIddHelper/CNotifyWindow.h
@@ -30,6 +30,8 @@ class CNotifyWindow : public CWindow
   static ATOM s_atom;
 
   NOTIFYICONDATA m_iconData;
+  bool m_iconRegistered;
+  bool m_noGPUQueued;
   HMENU m_menu;
   bool closeRequested;
   std::unique_ptr<CConfigWindow> m_config;

--- a/idd/LGIddHelper/CNotifyWindow.h
+++ b/idd/LGIddHelper/CNotifyWindow.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "CWindow.h"
 #include <memory>
+#include <optional>
 
 class CConfigWindow;
 
@@ -31,14 +32,14 @@ class CNotifyWindow : public CWindow
 
   NOTIFYICONDATA m_iconData;
   bool m_iconRegistered;
-  bool m_noGPUQueued;
+  std::optional<bool> m_gpuQueue;
   HMENU m_menu;
   bool closeRequested;
   std::unique_ptr<CConfigWindow> m_config;
 
   LRESULT onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y);
   void registerIcon();
-  void handleNoGPUNotification();
+  void handleGPUNotification(bool hasGPU);
 
   virtual LRESULT handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
   virtual LRESULT onCreate() override;
@@ -64,7 +65,7 @@ public:
 
   static bool registerClass();
 
-  void noGPUNotification();
+  void setGPU(bool hasGPU);
 
   HWND hwndDialog();
   void close();

--- a/idd/LGIddHelper/CPipeClient.cpp
+++ b/idd/LGIddHelper/CPipeClient.cpp
@@ -308,6 +308,5 @@ void CPipeClient::HandleSetDisplayMode(const LGPipeMsg& msg)
 
 void CPipeClient::HandleGPUStatus(const LGPipeMsg& msg)
 {
-  if (msg.gpuStatus.software)
-    CNotifyWindow::instance().noGPUNotification();
+  CNotifyWindow::instance().setGPU(!msg.gpuStatus.software);
 }


### PR DESCRIPTION
No GPU notifications are not possible before the notification icon is created. Since the helper could start before explorer.exe (and often does on reboot), the notification would fail.

This PR adds logic to refer the notification and we send it immediately when successfully creating the notification icon. It also updates the tooltip to reflect the presence or absence of a GPU.
