### PR TITLE
[host] D12: fix ACCESS_VIOLATION crash in d12_enumerateDevices with NVIDIA driver 32.x

### DIFF
--- a/host/platform/Windows/capture/D12/d12.c
+++ b/host/platform/Windows/capture/D12/d12.c
@@ -989,9 +989,10 @@ static bool d12_enumerateDevices(
 
     for(
       int n = 0;
-      IDXGIAdapter1_EnumOutputs(*adapter, n, output) != DXGI_ERROR_NOT_FOUND;
+      IDXGIAdapter1_EnumOutputs(*adapter, n, output) == S_OK;
       ++n, comRef_release(output))
     {
+      if (!*output) break;
       IDXGIOutput_GetDesc(*output, &outputDesc);
 
       if (optOutput)


### PR DESCRIPTION
With NVIDIA driver 32.0.15.9636 (and likely other 32.x releases),
IDXGIAdapter1_EnumOutputs() returns an error code that is neither S_OK
nor DXGI_ERROR_NOT_FOUND. The original loop condition
`!= DXGI_ERROR_NOT_FOUND` treated any such error as "keep iterating",
executing the loop body with *output == NULL. This caused an
ACCESS_VIOLATION crash at IDXGIOutput_GetDesc(*output, ...) since
*output is NULL.

Fix:
- Change the loop condition from `!= DXGI_ERROR_NOT_FOUND` to `== S_OK`
  so iteration only continues on full success.
- Add a defensive null guard `if (!*output) break;` before
  IDXGIOutput_GetDesc to prevent the crash even if the condition is
  ever bypassed.

Tested on:
- GPU: NVIDIA T550 Laptop GPU (10de:1fb7)
- Driver: 32.0.15.9636
- OS: Windows 11 24H2
- LG: B7