### PR TITLE
[client] wayland: improve fractional scale protocol compatibility

### DIFF
--- a/client/displayservers/Wayland/desktops/libdecor/libdecor.c
+++ b/client/displayservers/Wayland/desktops/libdecor/libdecor.c
@@ -263,6 +263,11 @@ void libdecor_pollWait(struct wl_display * display, int epollFd,
   }
 }
 
+bool libdecor_configured(void)
+{
+  return state.configured;
+}
+
 WL_DesktopOps WLD_libdecor =
 {
   .name                      = "libdecor",
@@ -277,5 +282,6 @@ WL_DesktopOps WLD_libdecor =
   .getSize                   = libdecor_getSize,
   .registryGlobalHandler     = libdecor_registryGlobalHandler,
   .pollInit                  = libdecor_pollInit,
-  .pollWait                  = libdecor_pollWait
+  .pollWait                  = libdecor_pollWait,
+  .configured                = libdecor_configured
 };

--- a/client/displayservers/Wayland/desktops/xdg/xdg.c
+++ b/client/displayservers/Wayland/desktops/xdg/xdg.c
@@ -304,6 +304,11 @@ void xdg_pollWait(struct wl_display * display, int epollFd,
     wl_display_cancel_read(display);
 }
 
+bool xdg_configured(void)
+{
+  return state.configured;
+}
+
 WL_DesktopOps WLD_xdg =
 {
   .name                      = "xdg",
@@ -318,5 +323,6 @@ WL_DesktopOps WLD_xdg =
   .getSize                   = xdg_getSize,
   .registryGlobalHandler     = xdg_registryGlobalHandler,
   .pollInit                  = xdg_pollInit,
-  .pollWait                  = xdg_pollWait
+  .pollWait                  = xdg_pollWait,
+  .configured                = xdg_configured
 };

--- a/client/displayservers/Wayland/interface/desktop.h
+++ b/client/displayservers/Wayland/interface/desktop.h
@@ -58,6 +58,8 @@ typedef struct WL_DesktopOps
   bool (*pollInit)(struct wl_display * display);
 
   void (*pollWait)(struct wl_display * display, int epollFd, unsigned int time);
+
+  bool (*configured)(void);
 }
 WL_DesktopOps;
 

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -36,9 +36,13 @@ static void setScale(struct WaylandScale newScale)
   wlWm.scale = newScale;
   wlWm.fractionalScale = waylandScaleIsFractional(newScale);
   wlWm.needsResize = true;
-  waylandCursorScaleChange();
-  app_invalidateWindow(true);
-  waylandStopWaitFrame();
+
+  if (wlWm.desktop->configured())
+  {
+    waylandCursorScaleChange();
+    app_invalidateWindow(true);
+    waylandStopWaitFrame();
+  }
 }
 
 void waylandWindowUpdateScale(void)


### PR DESCRIPTION
There is no reason to call a bunch of stuff before the xdg_surface is configured, so let's not call them and cause early painting to happen should the compositor decide to send the `preferred_scale` message early.