### PR TITLE
[host] delete redundant / sizeof(char)

### DIFF
--- a/host/platform/Windows/src/service.c
+++ b/host/platform/Windows/src/service.c
@@ -102,7 +102,7 @@ void winerr(void)
   char buf[256];
   FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
     NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-    buf, (sizeof(buf) / sizeof(char)), NULL);
+    buf, sizeof(buf), NULL);
   doLog("0x%08lx - %s", GetLastError(), buf);
 }
 


### PR DESCRIPTION
`sizeof(char) == 1` always per standard, so this is redundant.