### PR TITLE
[idd] helper: deferred mode save and revert

### DIFF
--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -90,7 +90,7 @@ void CConfigWindow::updateFont()
   for (HWND child : std::initializer_list<HWND>({
     *m_version, *m_modeGroup, *m_modeBox, *m_widthLabel, *m_heightLabel, *m_refreshLabel, *m_modePreferred,
     *m_modeWidth, *m_modeHeight, *m_modeRefresh, *m_modeUpdate, *m_modeDelete, *m_modeReset,
-    *m_autosizeGroup, *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz,
+    *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz,
     *m_prefGroup, *m_prefNoGPU,
   }))
     SendMessage(child, WM_SETFONT, (WPARAM)m_font.Get(), 1);
@@ -147,7 +147,7 @@ LRESULT CConfigWindow::onCreate()
   m_scale = GetDpiForWindow(m_hwnd) / 96.0;
   m_version.reset(new CStaticWidget(L"Looking Glass IDD " LG_VERSION_STR, SS_CENTERIMAGE, m_hwnd));
 
-  m_modeGroup.reset(new CGroupBox(L"Custom modes", 0, m_hwnd));
+  m_modeGroup.reset(new CGroupBox(L"Driver mode settings", 0, m_hwnd));
 
   m_modeBox.reset(new CListBox(WS_VSCROLL | WS_TABSTOP | LBS_NOTIFY, m_hwnd));
   if (m_modes)
@@ -162,13 +162,12 @@ LRESULT CConfigWindow::onCreate()
   m_modeRefresh.reset(new CEditWidget(WS_TABSTOP | ES_LEFT | ES_NUMBER, m_hwnd));
   m_modePreferred.reset(new CCheckbox(L"prefer", 0, m_hwnd));
 
-  m_modeUpdate.reset(new CButton(L"Save", WS_TABSTOP, m_hwnd));
+  m_modeUpdate.reset(new CButton(L"Update", WS_TABSTOP, m_hwnd));
   m_modeDelete.reset(new CButton(L"Delete", WS_TABSTOP, m_hwnd));
-  m_modeReset.reset(new CButton(L"Reset", WS_TABSTOP, m_hwnd));
+  m_modeReset.reset(new CButton(L"Load default", WS_TABSTOP, m_hwnd));
   EnableWindow(*m_modeUpdate, FALSE);
   EnableWindow(*m_modeDelete, FALSE);
 
-  m_autosizeGroup.reset(new CGroupBox(L"Autosizing", 0, m_hwnd));
   m_defRefreshLabel.reset(new CStaticWidget(L"Default refresh:", SS_CENTERIMAGE, m_hwnd));
   m_defRefresh.reset(new CEditWidget(ES_LEFT | ES_NUMBER | WS_TABSTOP, m_hwnd));
   m_defRefreshHz.reset(new CStaticWidget(L"Hz", SS_CENTERIMAGE, m_hwnd));
@@ -206,7 +205,10 @@ LRESULT CConfigWindow::onResize(DWORD width, DWORD height)
   pos.pinTopLeftRight(*m_version, 12, 12, 12, 20);
 
   pos.pinLeftTopBottom(*m_modeGroup, 12, 40, 200, 12);
-  pos.pinLeftTopBottom(*m_modeBox, 24, 64, 176, 120);
+  pos.pinTopLeft(*m_defRefreshLabel, 24, 64, 95, 20);
+  pos.pinTopLeft(*m_defRefresh, 119, 64, 63, 20);
+  pos.pinTopLeft(*m_defRefreshHz, 186, 64, 16, 20);
+  pos.pinLeftTopBottom(*m_modeBox, 24, 90, 176, 120);
   pos.pinBottomLeft(*m_widthLabel, 24, 96, 50, 20);
   pos.pinBottomLeft(*m_heightLabel, 24, 72, 50, 20);
   pos.pinBottomLeft(*m_refreshLabel, 24, 48, 50, 20);
@@ -214,17 +216,12 @@ LRESULT CConfigWindow::onResize(DWORD width, DWORD height)
   pos.pinBottomLeft(*m_modeHeight, 75, 72, 50, 20);
   pos.pinBottomLeft(*m_modeRefresh, 75, 48, 50, 20);
   pos.pinBottomLeft(*m_modePreferred, 130, 96, 70, 20);
-  pos.pinBottomLeft(*m_modeUpdate, 24, 20, 50, 24);
-  pos.pinBottomLeft(*m_modeDelete, 75, 20, 50, 24);
-  pos.pinBottomLeft(*m_modeReset, 126, 20, 50, 24);
+  pos.pinBottomLeft(*m_modeUpdate, 20, 20, 50, 24);
+  pos.pinBottomLeft(*m_modeDelete, 72, 20, 50, 24);
+  pos.pinBottomLeft(*m_modeReset, 122, 20, 82, 24);
 
-  pos.pinTopLeft(*m_autosizeGroup, 224, 40, 200, 52);
-  pos.pinTopLeft(*m_defRefreshLabel, 236, 64, 95, 20);
-  pos.pinTopLeft(*m_defRefresh, 331, 64, 63, 20);
-  pos.pinTopLeft(*m_defRefreshHz, 398, 64, 16, 20);
-
-  pos.pinTopLeft(*m_prefGroup, 224, 100, 200, 52);
-  pos.pinTopLeft(*m_prefNoGPU, 236, 124, 176, 20);
+  pos.pinTopLeft(*m_prefGroup, 224, 40, 200, 52);
+  pos.pinTopLeft(*m_prefNoGPU, 236, 64, 176, 20);
   return 0;
 }
 

--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -290,12 +290,6 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
 
     m_modeBox->clear();
     m_modeBox->setSel(updateModeList(index));
-
-    LRESULT result = m_settings.setModes(*m_modes);
-    if (result == ERROR_SUCCESS)
-      sendSettingChange();
-    else
-      DEBUG_ERROR_HR((HRESULT) result, "Failed to save modes");
   }
   else if (m_modeDelete && hwnd == *m_modeDelete && code == BN_CLICKED && m_modes)
   {
@@ -309,12 +303,6 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
 
     updateModeList();
     onModeListSelectChange();
-
-    LRESULT result = m_settings.setModes(*m_modes);
-    if (result == ERROR_SUCCESS)
-      sendSettingChange();
-    else
-      DEBUG_ERROR_HR((HRESULT) result, "Failed to save modes");
   }
   else if (m_modeReset && hwnd == *m_modeReset && code == BN_CLICKED && m_modes)
   {
@@ -322,39 +310,64 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
     m_modeBox->clear();
     updateModeList();
     onModeListSelectChange();
-
-    LRESULT result = m_settings.setModes(*m_modes);
-    if (result == ERROR_SUCCESS)
-      sendSettingChange();
-    else
-      DEBUG_ERROR_HR((HRESULT)result, "Failed to save modes");
   }
   else if (m_defRefresh && hwnd == *m_defRefresh && code == EN_CHANGE && m_defaultRefresh)
   {
-    int value;
     try
     {
-      value = m_defRefresh->getNumericValue();
+      m_defaultRefresh = m_defRefresh->getNumericValue();
     }
     catch (std::logic_error &)
     {
       return 0;
     }
-
-    m_defaultRefresh = value;
-
-    LRESULT result = m_settings.setDefaultRefresh(value);
-    if (result == ERROR_SUCCESS)
-      sendSettingChange();
-    else
-      DEBUG_ERROR_HR((HRESULT)result, "Failed to default refresh");
   }
   else if (m_prefNoGPU && hwnd == *m_prefNoGPU && code == BN_CLICKED && m_noGPU)
   {
-    DEBUG_INFO("GPU button clicked");
     *m_noGPU ^= true;
     m_settings.setNoGPU(*m_noGPU);
     m_prefNoGPU->setChecked(*m_noGPU);
+  }
+  else if (m_modeSave && hwnd == *m_modeSave && code == BN_CLICKED)
+  {
+    bool updated = false;
+
+    if (m_modes)
+    {
+      LRESULT result = m_settings.setModes(*m_modes);
+      if (result == ERROR_SUCCESS)
+        updated = true;
+      else
+        DEBUG_ERROR_HR((HRESULT)result, "Failed to save modes");
+    }
+
+    if (m_defaultRefresh)
+    {
+      LRESULT result = m_settings.setDefaultRefresh(*m_defaultRefresh);
+      if (result == ERROR_SUCCESS)
+        updated = true;
+      else
+        DEBUG_ERROR_HR((HRESULT)result, "Failed to default refresh");
+    }
+
+    if (updated)
+      sendSettingChange();
+  }
+  else if (m_modeRevert && hwnd == *m_modeRevert && code == BN_CLICKED)
+  {
+    m_modes = m_settings.getModes();
+    m_defaultRefresh = m_settings.getDefaultRefresh();
+
+    if (m_modes)
+    {
+      m_modeBox->clear();
+      updateModeList();
+    }
+
+    if (m_defaultRefresh)
+      m_defRefresh->setNumericValue(*m_defaultRefresh);
+    else
+      m_defRefresh->disable();
   }
   return 0;
 }

--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -55,7 +55,7 @@ CConfigWindow::CConfigWindow() : m_scale(1)
   }
 
   if (!CreateWindowEx(0, MAKEINTATOM(s_atom), L"Looking Glass IDD Configuration",
-    WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 500, 400,
+    WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
     NULL, NULL, hInstance, this))
   {
     DEBUG_ERROR_HR(GetLastError(), "Failed to create window");
@@ -64,7 +64,7 @@ CConfigWindow::CConfigWindow() : m_scale(1)
 
 void CConfigWindow::getMinimumSize(LONG &width, LONG &height)
 {
-  RECT client = { 0, 0, (LONG)(436 * m_scale), (LONG)(300 * m_scale) };
+  RECT client = { 0, 0, (LONG)(436 * m_scale), (LONG)(340 * m_scale) };
   AdjustWindowRect(&client, WS_OVERLAPPEDWINDOW, FALSE);
   width = client.right - client.left;
   height = client.bottom - client.top;
@@ -90,7 +90,7 @@ void CConfigWindow::updateFont()
   for (HWND child : std::initializer_list<HWND>({
     *m_version, *m_modeGroup, *m_modeBox, *m_widthLabel, *m_heightLabel, *m_refreshLabel, *m_modePreferred,
     *m_modeWidth, *m_modeHeight, *m_modeRefresh, *m_modeUpdate, *m_modeDelete, *m_modeReset,
-    *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz,
+    *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz, *m_modeSave, *m_modeRevert,
     *m_prefGroup, *m_prefNoGPU,
   }))
     SendMessage(child, WM_SETFONT, (WPARAM)m_font.Get(), 1);
@@ -168,6 +168,9 @@ LRESULT CConfigWindow::onCreate()
   EnableWindow(*m_modeUpdate, FALSE);
   EnableWindow(*m_modeDelete, FALSE);
 
+  m_modeSave.reset(new CButton(L"Save && reload driver", WS_TABSTOP, m_hwnd));
+  m_modeRevert.reset(new CButton(L"Revert", WS_TABSTOP, m_hwnd));
+
   m_defRefreshLabel.reset(new CStaticWidget(L"Default refresh:", SS_CENTERIMAGE, m_hwnd));
   m_defRefresh.reset(new CEditWidget(ES_LEFT | ES_NUMBER | WS_TABSTOP, m_hwnd));
   m_defRefreshHz.reset(new CStaticWidget(L"Hz", SS_CENTERIMAGE, m_hwnd));
@@ -208,17 +211,19 @@ LRESULT CConfigWindow::onResize(DWORD width, DWORD height)
   pos.pinTopLeft(*m_defRefreshLabel, 24, 64, 95, 20);
   pos.pinTopLeft(*m_defRefresh, 119, 64, 63, 20);
   pos.pinTopLeft(*m_defRefreshHz, 186, 64, 16, 20);
-  pos.pinLeftTopBottom(*m_modeBox, 24, 90, 176, 120);
-  pos.pinBottomLeft(*m_widthLabel, 24, 96, 50, 20);
-  pos.pinBottomLeft(*m_heightLabel, 24, 72, 50, 20);
-  pos.pinBottomLeft(*m_refreshLabel, 24, 48, 50, 20);
-  pos.pinBottomLeft(*m_modeWidth, 75, 96, 50, 20);
-  pos.pinBottomLeft(*m_modeHeight, 75, 72, 50, 20);
-  pos.pinBottomLeft(*m_modeRefresh, 75, 48, 50, 20);
-  pos.pinBottomLeft(*m_modePreferred, 130, 96, 70, 20);
-  pos.pinBottomLeft(*m_modeUpdate, 20, 20, 50, 24);
-  pos.pinBottomLeft(*m_modeDelete, 72, 20, 50, 24);
-  pos.pinBottomLeft(*m_modeReset, 122, 20, 82, 24);
+  pos.pinLeftTopBottom(*m_modeBox, 24, 90, 176, 148);
+  pos.pinBottomLeft(*m_widthLabel, 24, 124, 50, 20);
+  pos.pinBottomLeft(*m_heightLabel, 24, 100, 50, 20);
+  pos.pinBottomLeft(*m_refreshLabel, 24, 76, 50, 20);
+  pos.pinBottomLeft(*m_modeWidth, 75, 124, 50, 20);
+  pos.pinBottomLeft(*m_modeHeight, 75, 100, 50, 20);
+  pos.pinBottomLeft(*m_modeRefresh, 75, 76, 50, 20);
+  pos.pinBottomLeft(*m_modePreferred, 130, 124, 70, 20);
+  pos.pinBottomLeft(*m_modeUpdate, 20, 48, 50, 24);
+  pos.pinBottomLeft(*m_modeDelete, 72, 48, 50, 24);
+  pos.pinBottomLeft(*m_modeReset, 122, 48, 82, 24);
+  pos.pinBottomLeft(*m_modeSave, 20, 20, 132, 24);
+  pos.pinBottomLeft(*m_modeRevert, 154, 20, 50, 24);
 
   pos.pinTopLeft(*m_prefGroup, 224, 40, 200, 52);
   pos.pinTopLeft(*m_prefNoGPU, 236, 64, 176, 20);

--- a/idd/LGIddHelper/CConfigWindow.h
+++ b/idd/LGIddHelper/CConfigWindow.h
@@ -54,6 +54,8 @@ class CConfigWindow : public CWindow
   std::unique_ptr<CButton> m_modeUpdate;
   std::unique_ptr<CButton> m_modeDelete;
   std::unique_ptr<CButton> m_modeReset;
+  std::unique_ptr<CButton> m_modeSave;
+  std::unique_ptr<CButton> m_modeRevert;
 
   std::unique_ptr<CStaticWidget> m_defRefreshLabel;
   std::unique_ptr<CEditWidget> m_defRefresh;

--- a/idd/LGIddHelper/CConfigWindow.h
+++ b/idd/LGIddHelper/CConfigWindow.h
@@ -55,7 +55,6 @@ class CConfigWindow : public CWindow
   std::unique_ptr<CButton> m_modeDelete;
   std::unique_ptr<CButton> m_modeReset;
 
-  std::unique_ptr<CGroupBox> m_autosizeGroup;
   std::unique_ptr<CStaticWidget> m_defRefreshLabel;
   std::unique_ptr<CEditWidget> m_defRefresh;
   std::unique_ptr<CStaticWidget> m_defRefreshHz;


### PR DESCRIPTION
This PR rearranges the IDD settings to look like this:

<img width="607" height="516" alt="new IDD config screenshot" src="https://github.com/user-attachments/assets/f3126a3a-bec1-4c8f-9c58-48772b701f61" />

Changes in the new "Driver mode settings" panel are no longer automatically saved to the registry or trigger a driver reload. Instead, that is deferred to when the "Save & reload driver" button is pressed.

A revert button is added revert all changes to the ones currently in the registry.

Several buttons also had the labels changed to be more obvious.