### PR TITLE
 [idd] helper: make exclusive monitor behaviour configurable

### DIFF
--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -52,6 +52,7 @@ CConfigWindow::CConfigWindow() : m_scale(1)
     m_modes = m_settings.getModes();
     m_defaultRefresh = m_settings.getDefaultRefresh();
     m_noGPU = m_settings.getNoGPU();
+    m_exclusive = m_settings.getExclusiveMonitor();
   }
 
   if (!CreateWindowEx(0, MAKEINTATOM(s_atom), L"Looking Glass IDD Configuration",
@@ -186,6 +187,9 @@ LRESULT CConfigWindow::onCreate()
 
   if (m_noGPU)
     m_prefNoGPU->setChecked(*m_noGPU);
+
+  if (m_exclusive)
+    m_prefExclusive->setChecked(*m_exclusive);
 
   LONG width, height;
   getMinimumSize(width, height);
@@ -329,6 +333,12 @@ LRESULT CConfigWindow::onCommand(WORD id, WORD code, HWND hwnd)
     *m_noGPU ^= true;
     m_settings.setNoGPU(*m_noGPU);
     m_prefNoGPU->setChecked(*m_noGPU);
+  }
+  else if (m_prefExclusive && hwnd == *m_prefExclusive && code == BN_CLICKED && m_exclusive)
+  {
+    *m_exclusive ^= true;
+    m_settings.setExclusiveMonitor(*m_exclusive);
+    m_prefExclusive->setChecked(*m_exclusive);
   }
   else if (m_modeSave && hwnd == *m_modeSave && code == BN_CLICKED)
   {

--- a/idd/LGIddHelper/CConfigWindow.cpp
+++ b/idd/LGIddHelper/CConfigWindow.cpp
@@ -91,7 +91,7 @@ void CConfigWindow::updateFont()
     *m_version, *m_modeGroup, *m_modeBox, *m_widthLabel, *m_heightLabel, *m_refreshLabel, *m_modePreferred,
     *m_modeWidth, *m_modeHeight, *m_modeRefresh, *m_modeUpdate, *m_modeDelete, *m_modeReset,
     *m_defRefreshLabel, *m_defRefresh, *m_defRefreshHz, *m_modeSave, *m_modeRevert,
-    *m_prefGroup, *m_prefNoGPU,
+    *m_prefGroup, *m_prefNoGPU, *m_prefExclusive,
   }))
     SendMessage(child, WM_SETFONT, (WPARAM)m_font.Get(), 1);
 }
@@ -182,6 +182,7 @@ LRESULT CConfigWindow::onCreate()
 
   m_prefGroup.reset(new CGroupBox(L"Preferences", 0, m_hwnd));
   m_prefNoGPU.reset(new CCheckbox(L"Disable no GPU warning", 0, m_hwnd));
+  m_prefExclusive.reset(new CCheckbox(L"Make LG the only monitor", 0, m_hwnd));
 
   if (m_noGPU)
     m_prefNoGPU->setChecked(*m_noGPU);
@@ -225,8 +226,9 @@ LRESULT CConfigWindow::onResize(DWORD width, DWORD height)
   pos.pinBottomLeft(*m_modeSave, 20, 20, 132, 24);
   pos.pinBottomLeft(*m_modeRevert, 154, 20, 50, 24);
 
-  pos.pinTopLeft(*m_prefGroup, 224, 40, 200, 52);
+  pos.pinTopLeft(*m_prefGroup, 224, 40, 200, 72);
   pos.pinTopLeft(*m_prefNoGPU, 236, 64, 176, 20);
+  pos.pinTopLeft(*m_prefExclusive, 236, 84, 176, 20);
   return 0;
 }
 

--- a/idd/LGIddHelper/CConfigWindow.h
+++ b/idd/LGIddHelper/CConfigWindow.h
@@ -74,6 +74,7 @@ class CConfigWindow : public CWindow
   std::optional<std::vector<DisplayMode>> m_modes;
   std::optional<DWORD> m_defaultRefresh;
   std::optional<bool> m_noGPU;
+  std::optional<bool> m_exclusive;
 
   void getMinimumSize(LONG &width, LONG &height);
   void updateFont();

--- a/idd/LGIddHelper/CConfigWindow.h
+++ b/idd/LGIddHelper/CConfigWindow.h
@@ -63,6 +63,7 @@ class CConfigWindow : public CWindow
 
   std::unique_ptr<CGroupBox> m_prefGroup;
   std::unique_ptr<CCheckbox> m_prefNoGPU;
+  std::unique_ptr<CCheckbox> m_prefExclusive;
 
   std::function<void()> m_onDestroy;
   std::function<void()> m_onSettingChange;

--- a/idd/LGIddHelper/CNotifyWindow.cpp
+++ b/idd/LGIddHelper/CNotifyWindow.cpp
@@ -35,7 +35,6 @@
 #define ID_DISPLAY_CHECK_TIMER 1
 #define DISPLAY_SETTLE_DELAY   250
 #define DISPLAY_RETRY_DELAY    1000
-#define DISPLAY_CHECK_INTERVAL 5000
 
 ATOM CNotifyWindow::s_atom = 0;
 UINT CNotifyWindow::s_taskbarCreated = 0;
@@ -96,14 +95,17 @@ LRESULT CNotifyWindow::handleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
     return 0;
 
   case WM_TIMER:
-    if (wParam == ID_DISPLAY_CHECK_TIMER)
+    switch (wParam)
     {
+    case ID_DISPLAY_CHECK_TIMER:
       KillTimer(m_hwnd, ID_DISPLAY_CHECK_TIMER);
-      const bool success = m_onDisplayChange && m_onDisplayChange();
-      scheduleDisplayCheck(success ? DISPLAY_CHECK_INTERVAL : DISPLAY_RETRY_DELAY);
-      return 0;
+      if (m_onEnsureOnlyDisplay && m_onEnsureOnlyDisplay())
+        DEBUG_INFO("Enforced Looking Glass as the only display");
+      else
+        DEBUG_WARN("Failed to ensure Looking Glass is the only display");
+      break;
     }
-    return CWindow::handleMessage(uMsg, wParam, lParam);
+    return 0;
 
   default:
     if (s_taskbarCreated && uMsg == s_taskbarCreated)
@@ -262,16 +264,24 @@ void CNotifyWindow::close()
 
 void CNotifyWindow::scheduleDisplayCheck(UINT delay)
 {
-  if (!m_onDisplayChange)
+  if (!m_onEnsureOnlyDisplay)
     return;
 
-  KillTimer(m_hwnd, ID_DISPLAY_CHECK_TIMER);
+  CRegistrySettings settings;
+  LSTATUS error = settings.open();
+  if (error != ERROR_SUCCESS)
+    DEBUG_ERROR_HR(error, "Failed to load settings");
+
+  auto exclusive = settings.getExclusiveMonitor();
+  if (!exclusive.has_value() || !exclusive.value())
+    return;
+
   if (!SetTimer(m_hwnd, ID_DISPLAY_CHECK_TIMER, delay, NULL))
     DEBUG_ERROR_HR(GetLastError(), "Failed to schedule primary display check");
 }
 
-void CNotifyWindow::onDisplayChange(std::function<bool()> func)
+void CNotifyWindow::onEnsureOnlyDisplay(std::function<bool()> func)
 {
-  m_onDisplayChange = std::move(func);
+  m_onEnsureOnlyDisplay = std::move(func);
   scheduleDisplayCheck(DISPLAY_SETTLE_DELAY);
 }

--- a/idd/LGIddHelper/CNotifyWindow.h
+++ b/idd/LGIddHelper/CNotifyWindow.h
@@ -39,7 +39,7 @@ class CNotifyWindow : public CWindow
   std::unique_ptr<CConfigWindow> m_config;
 
   std::function<void()> m_onSettingChange;
-  std::function<bool()> m_onDisplayChange;
+  std::function<bool()> m_onEnsureOnlyDisplay;
 
   LRESULT onNotifyIcon(UINT uEvent, WORD wIconId, int x, int y);
   void registerIcon();
@@ -76,5 +76,5 @@ public:
   void close();
 
   void onSettingChange(std::function<void()> func) { m_onSettingChange = std::move(func); }
-  void onDisplayChange(std::function<bool()> func);
+  void onEnsureOnlyDisplay(std::function<bool()> func);
 };

--- a/idd/LGIddHelper/CRegistrySettings.cpp
+++ b/idd/LGIddHelper/CRegistrySettings.cpp
@@ -209,3 +209,26 @@ LSTATUS CRegistrySettings::setNoGPU(bool noGPU)
   DWORD dwValue = noGPU;
   return RegSetValueEx(hKey, L"NoGPU", 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD));
 }
+
+std::optional<bool> CRegistrySettings::getExclusiveMonitor()
+{
+  DWORD result, cbData = sizeof result;
+
+  LSTATUS status = RegGetValue(hKey, nullptr, L"ExclusiveMonitor", RRF_RT_REG_DWORD, nullptr, &result, &cbData);
+  switch (status)
+  {
+  case ERROR_SUCCESS:
+    return !!result;
+  case ERROR_FILE_NOT_FOUND:
+    return true;
+  default:
+    DEBUG_ERROR_HR(status, "RegGetValue(ExclusiveMonitor)");
+    return {};
+  }
+}
+
+LSTATUS CRegistrySettings::setExclusiveMonitor(bool exclusive)
+{
+  DWORD dwValue = exclusive;
+  return RegSetValueEx(hKey, L"ExclusiveMonitor", 0, REG_DWORD, (LPBYTE)&dwValue, sizeof(DWORD));
+}

--- a/idd/LGIddHelper/CRegistrySettings.h
+++ b/idd/LGIddHelper/CRegistrySettings.h
@@ -53,4 +53,7 @@ public:
 
   std::optional<bool> getNoGPU();
   LSTATUS setNoGPU(bool noGPU);
+
+  std::optional<bool> getExclusiveMonitor();
+  LSTATUS setExclusiveMonitor(bool exclusive);
 };

--- a/idd/LGIddHelper/main.cpp
+++ b/idd/LGIddHelper/main.cpp
@@ -124,7 +124,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     g_pipe.ReloadSettings();
   });
 
-  window.onDisplayChange([]() {
+  window.onEnsureOnlyDisplay([]() {
     return g_pipe.EnsureOnlyDisplay();
   });
 


### PR DESCRIPTION
This PR adds a toggle to control whether the IDD makes itself the exclusive monitor, defaulting to on:

<img width="634" height="540" alt="Screenshot of config window" src="https://github.com/user-attachments/assets/527b80a9-daaf-422a-add4-5e7195a445f7" />

The timer code is cleaned up and the periodic thing is deleted until evidence of its necessity becomes clear.
