### PR TITLE
[host] installer: make installer IDD aware

### DIFF
--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -18,6 +18,8 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+!define MUI_CUSTOMFUNCTION_GUIINIT customGUIInit
+
 ;Include
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
@@ -60,6 +62,7 @@ InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_LANGUAGE "English"
 
+Var IDD_UNINST
 
 Function ShowHelpMessage
   !define line1 "Command line options:$\r$\n$\r$\n"
@@ -196,6 +199,14 @@ Section "-Install" Section1
 
 SectionEnd
 
+Section /o "" Section7
+  DetailPrint "Uninstalling the Looking Glass IDD..."
+  nsExec::ExecToLog '$IDD_UNINST'
+
+  ; Wait for the IDD to relinquish the IVSHMEM, which takes time.
+  Sleep 5000
+SectionEnd
+
 Section "Looking Glass (host) Service" Section2
 
   ${If} $option_noservice == 0
@@ -252,12 +263,36 @@ Section "Uninstall" Section6
   RMDir $INSTDIR
 SectionEnd
 
+Function customGUIInit
+  ClearErrors
+
+  SetRegView 64
+  ReadRegStr $IDD_UNINST HKLM \
+    "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking Glass (IDD)" \
+    "QuietUninstallString"
+  SetRegView lastused
+
+  IfErrors +1 +4
+
+  SetRegView 32
+  ReadRegStr $IDD_UNINST HKLM \
+    "Software\Microsoft\Windows\CurrentVersion\Uninstall\Looking Glass (IDD)" \
+    "QuietUninstallString"
+  SetRegView lastused
+
+  ${Unless} ${Errors}
+    SectionSetText  ${Section7} "Uninstall LG IDD"
+    SectionSetFlags ${Section7} ${SF_SELECTED}
+  ${EndUnless}
+FunctionEnd
+
 ;Description text for selection of install items
 LangString DESC_Section0 ${LANG_ENGLISH} "Install the IVSHMEM driver. This driver is needed for Looking Glass to function. This will replace the driver if it is already installed."
 LangString DESC_Section1 ${LANG_ENGLISH} "Install Files into $INSTDIR"
 LangString DESC_Section2 ${LANG_ENGLISH} "Install service to automatically start Looking Glass (host)."
 LangString DESC_Section3 ${LANG_ENGLISH} "Create desktop shortcut icon."
 LangString DESC_Section4 ${LANG_ENGLISH} "Create start menu shortcut."
+LangString DESC_Section7 ${LANG_ENGLISH} "Uninstall the Looking Glass Indirect Display Driver (IDD), which is detected on this system."
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
 !ifdef IVSHMEM
@@ -267,4 +302,5 @@ LangString DESC_Section4 ${LANG_ENGLISH} "Create start menu shortcut."
   !insertmacro MUI_DESCRIPTION_TEXT ${Section2} $(DESC_Section2)
   !insertmacro MUI_DESCRIPTION_TEXT ${Section3} $(DESC_Section3)
   !insertmacro MUI_DESCRIPTION_TEXT ${Section4} $(DESC_Section4)
+  !insertmacro MUI_DESCRIPTION_TEXT ${Section7} $(DESC_Section7)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -19,6 +19,7 @@
  */
 
 !define MUI_CUSTOMFUNCTION_GUIINIT customGUIInit
+!define MUI_CUSTOMFUNCTION_ABORT   customGUIAbort
 
 ;Include
 !include "MUI2.nsh"
@@ -58,6 +59,9 @@ InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 
 ;Install and uninstall pages
 !insertmacro MUI_PAGE_WELCOME
+
+Page custom IddWarningLoad IddWarningUnload
+
 !insertmacro MUI_PAGE_LICENSE "LICENSE.txt"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_COMPONENTS
@@ -288,6 +292,87 @@ Function customGUIInit
     SectionSetText  ${Section7} "Uninstall LG IDD"
     SectionSetFlags ${Section7} ${SF_SELECTED}
   ${EndUnless}
+FunctionEnd
+
+LangString IDD_WARN_TITLE ${LANG_ENGLISH} "Looking Glass Indirect Display Driver"
+LangString IDD_WARN_SUBTITLE ${LANG_ENGLISH} "Are you aware that it exists?"
+
+LangString IDD_NOTICE_1 ${LANG_ENGLISH} "\
+  Starting in Looking Glass B8 release candidates, a new Indirect Display Driver (IDD) is now available. \
+  Henceforth, this will be the primary way of acquiring video from Windows guests."
+
+LangString IDD_NOTICE_2 ${LANG_ENGLISH} "\
+  The IDD supports the following new features absent from the host application:$\n\
+  • Acting as a true display in Windows and rendering directly into shared memory, bypassing    \
+    any need for video capture and the associated overhead;$\n\
+  • Running without a display output or a dummy plug attached;$\n\
+  • Running on muxless laptops without hacky third-party IDDs;$\n\
+  • Automatically resizing the Windows desktop to match the client viewport;$\n\
+  • Acting as a display output for virtual machines without a GPU; and$\n\
+  • High Dynamic Range (HDR) support."
+
+LangString IDD_NOTICE_3 ${LANG_ENGLISH} "The host application is no longer recommended for users who can use the IDD."
+
+LangString IDD_NOTICE_4 ${LANG_ENGLISH} "Download the Looking Glass IDD here:"
+
+LangString IDD_NOTICE_5 ${LANG_ENGLISH} "\
+  Only continue installation if the IDD doesn't work or \
+  directed to do so by a developer."
+
+Var IS_IDD_PAGE
+
+Function IddWarningLoad
+  !insertmacro MUI_HEADER_TEXT $(IDD_WARN_TITLE) $(IDD_WARN_SUBTITLE)
+
+  nsDialogs::Create 1018
+  Pop $0
+  ${If} $0 == error
+      Abort
+  ${EndIf}
+
+  ${NSD_CreateLabel} 0 0 100% 20u $(IDD_NOTICE_1)
+  Pop $0
+
+  ${NSD_CreateLabel} 0 20u 100% 68u $(IDD_NOTICE_2)
+  Pop $0
+
+  ${NSD_CreateLabel} 0 88u 100% 12u $(IDD_NOTICE_3)
+  Pop $0
+
+  ${NSD_CreateLabel} 0 100u 100% 8u $(IDD_NOTICE_4)
+  Pop $0
+
+  ${NSD_CreateLink} 0 108u 100% 12u "https://looking-glass.io/downloads"
+  Pop $0
+  ${NSD_OnClick} $0 OpenDownload
+
+  ${NSD_CreateLabel} 0 120u 100% 12u $(IDD_NOTICE_5)
+  Pop $0
+  SetCtlColors $0 0xFF0000 transparent
+
+  GetDlgItem $0 $HWNDPARENT 1
+  SendMessage $0 ${WM_SETTEXT} "0" "STR:Continue"
+
+  GetDlgItem $0 $HWNDPARENT 2
+  SendMessage $0 ${WM_SETTEXT} "0" "STR:Use IDD"
+
+  StrCpy $IS_IDD_PAGE 1
+
+  nsDialogs::Show
+FunctionEnd
+
+Function IddWarningUnload
+  StrCpy $IS_IDD_PAGE 0
+FunctionEnd
+
+Function OpenDownload
+  ExecShell "open" "https://looking-glass.io/downloads"
+FunctionEnd
+
+Function customGUIAbort
+  ${If} $IS_IDD_PAGE == 1
+    Call OpenDownload
+  ${EndIf}
 FunctionEnd
 
 ;Description text for selection of install items

--- a/host/platform/Windows/installer.nsi
+++ b/host/platform/Windows/installer.nsi
@@ -50,7 +50,11 @@ InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 !define MUI_WELCOMEFINISHPAGE_BITMAP "${NSISDIR}\Contrib\Graphics\Wizard\nsis3-grey.bmp"
 !define /file VERSION "../../VERSION"
 
-!define MUI_WELCOMEPAGE_TEXT "You are about to install $(^Name) version ${VERSION}.$\r$\n$\r$\nWhen upgrading, you don't need to close your Looking Glass client, but should install the ${VERSION} client after installation is complete.$\r$\n$\r$\nPress Next to continue."
+!define MUI_WELCOMEPAGE_TEXT "\
+  You are about to install $(^Name) version ${VERSION}.$\n$\n\
+  When upgrading, you don't need to close your Looking Glass client, but should \
+  install the ${VERSION} client after installation is complete.$\n$\n\
+  Press Next to continue."
 
 ;Install and uninstall pages
 !insertmacro MUI_PAGE_WELCOME
@@ -65,14 +69,14 @@ InstallDir "$PROGRAMFILES64\Looking Glass (host)"
 Var IDD_UNINST
 
 Function ShowHelpMessage
-  !define line1 "Command line options:$\r$\n$\r$\n"
-  !define line2 "/S - silent install (must be uppercase)$\r$\n"
-  !define line3 "/D=path\to\install\folder - Change install directory$\r$\n"
-  !define line4 "   (Must be uppercase, the last option given and no quotes)$\r$\n$\r$\n"
-  !define line5 "/startmenu - create start menu shortcut$\r$\n"
-  !define line6 "/desktop - create desktop shortcut$\r$\n"
-  !define line7 "/noservice - do not create a service to auto start and elevate the host"
-  MessageBox MB_OK "${line1}${line2}${line3}${line4}${line5}${line6}${line7}"
+  MessageBox MB_OK "\
+    Command line options:$\n\
+    /S - silent install (must be uppercase)$\n\
+    /D=path\to\install\folder - Change install directory$\n\
+       (Must be uppercase, the last option given and no quotes)$\r$\n$\n\
+    /startmenu - create start menu shortcut$\n\
+    /desktop - create desktop shortcut$\n\
+    /noservice - do not create a service to auto start and elevate the host"
   Abort
 FunctionEnd
 
@@ -287,12 +291,17 @@ Function customGUIInit
 FunctionEnd
 
 ;Description text for selection of install items
-LangString DESC_Section0 ${LANG_ENGLISH} "Install the IVSHMEM driver. This driver is needed for Looking Glass to function. This will replace the driver if it is already installed."
+LangString DESC_Section0 ${LANG_ENGLISH} "\
+  Install the IVSHMEM driver. \
+  This driver is needed for Looking Glass to function. \
+  This will replace the driver if it is already installed."
 LangString DESC_Section1 ${LANG_ENGLISH} "Install Files into $INSTDIR"
 LangString DESC_Section2 ${LANG_ENGLISH} "Install service to automatically start Looking Glass (host)."
 LangString DESC_Section3 ${LANG_ENGLISH} "Create desktop shortcut icon."
 LangString DESC_Section4 ${LANG_ENGLISH} "Create start menu shortcut."
-LangString DESC_Section7 ${LANG_ENGLISH} "Uninstall the Looking Glass Indirect Display Driver (IDD), which is detected on this system."
+LangString DESC_Section7 ${LANG_ENGLISH} "\
+  Uninstall the Looking Glass Indirect Display Driver (IDD), \
+  which is detected on this system."
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
 !ifdef IVSHMEM


### PR DESCRIPTION
This PR adds a page directing the users to use the IDD from now on:

<img width="581" height="477" alt="IDD suggestion page" src="https://github.com/user-attachments/assets/5ba6f85c-193b-4079-aa10-4561596ebe39" />

When "Use IDD" is pressed, https://looking-glass.io/downloads is opened and the installer exits.

If the user opts to continue, and an installation of the IDD is detected, we show this option:
<img width="581" height="477" alt="Uninstall IDD option" src="https://github.com/user-attachments/assets/3865325c-1e86-4dd0-819c-b1c5c069b6e6" />

When selected, this will run the IDD uninstaller in silent mode before installing the host service.