### PR TITLE
[client] wayland: restore warping and support new protocol

### DIFF
--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -684,12 +684,16 @@ void waylandWarpPointer(int x, int y, bool exiting)
     return;
   }
 
-  LG_LOCK(wlWm.surfaceLock);
-  if (wlWm.lockedPointer)
+  if (!wlWm.pointerWarpper)
   {
-    LG_UNLOCK(wlWm.surfaceLock);
-    MTRACE("warp drop=lock-race target=%d,%d exit=%d", x, y, exiting);
-    return;
+    LG_LOCK(wlWm.surfaceLock);
+
+    if (wlWm.lockedPointer)
+    {
+      LG_UNLOCK(wlWm.surfaceLock);
+      MTRACE("warp drop=lock-race target=%d,%d exit=%d", x, y, exiting);
+      return;
+    }
   }
 
   int width, height;
@@ -700,21 +704,32 @@ void waylandWarpPointer(int x, int y, bool exiting)
   if (y < 0) y = 0;
   else if (y >= height) y = height - 1;
 
-  struct wl_region * region = wl_compositor_create_region(wlWm.compositor);
-  wl_region_add(region, x, y, 1, 1);
+  uint32_t tempId = 0;
+  uint64_t warpSeq;
 
-  struct zwp_confined_pointer_v1 * confine = zwp_pointer_constraints_v1_confine_pointer(
-    wlWm.pointerConstraints, wlWm.surface, wlWm.pointer, region,
-    ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
-  uint32_t tempId = proxyId(confine);
-  wl_surface_commit(wlWm.surface);
-  zwp_confined_pointer_v1_destroy(confine);
+  if (wlWm.pointerWarpper)
+  {
+    wp_pointer_warp_v1_warp_pointer(wlWm.pointerWarpper, wlWm.surface,
+      wlWm.pointer, wl_fixed_from_int(x), wl_fixed_from_int(y),
+      wlWm.pointerEnterSerial);
+    warpSeq = app_mouseSeq();
+  } else {
+    struct wl_region * region = wl_compositor_create_region(wlWm.compositor);
+    wl_region_add(region, x, y, 1, 1);
 
-  wl_surface_commit(wlWm.surface);
-  wl_region_destroy(region);
+    struct zwp_confined_pointer_v1 * confine = zwp_pointer_constraints_v1_confine_pointer(
+      wlWm.pointerConstraints, wlWm.surface, wlWm.pointer, region,
+      ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+    tempId = proxyId(confine);
+    wl_surface_commit(wlWm.surface);
+    zwp_confined_pointer_v1_destroy(confine);
 
-  uint64_t warpSeq = app_mouseSeq();
-  LG_UNLOCK(wlWm.surfaceLock);
+    wl_surface_commit(wlWm.surface);
+    wl_region_destroy(region);
+
+    warpSeq = app_mouseSeq();
+    LG_UNLOCK(wlWm.surfaceLock);
+  }
 
   MLOG(warpSeq, "warp req=%d,%d target=%d,%d exit=%d temp=%u",
       reqX, reqY, x, y, exiting, tempId);

--- a/client/displayservers/Wayland/input.c
+++ b/client/displayservers/Wayland/input.c
@@ -670,9 +670,54 @@ void waylandUngrabKeyboard(void)
 
 void waylandWarpPointer(int x, int y, bool exiting)
 {
-  (void)x;
-  (void)y;
-  (void)exiting;
+  const int reqX = x;
+  const int reqY = y;
+  if (!wlWm.pointerInSurface)
+  {
+    MTRACE("warp drop=surface target=%d,%d exit=%d", x, y, exiting);
+    return;
+  }
+
+  if (wlWm.lockedPointer)
+  {
+    MTRACE("warp drop=lock target=%d,%d exit=%d", x, y, exiting);
+    return;
+  }
+
+  LG_LOCK(wlWm.surfaceLock);
+  if (wlWm.lockedPointer)
+  {
+    LG_UNLOCK(wlWm.surfaceLock);
+    MTRACE("warp drop=lock-race target=%d,%d exit=%d", x, y, exiting);
+    return;
+  }
+
+  int width, height;
+  wlWm.desktop->getSize(&width, &height);
+
+  if (x < 0) x = 0;
+  else if (x >= width) x = width - 1;
+  if (y < 0) y = 0;
+  else if (y >= height) y = height - 1;
+
+  struct wl_region * region = wl_compositor_create_region(wlWm.compositor);
+  wl_region_add(region, x, y, 1, 1);
+
+  struct zwp_confined_pointer_v1 * confine = zwp_pointer_constraints_v1_confine_pointer(
+    wlWm.pointerConstraints, wlWm.surface, wlWm.pointer, region,
+    ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+  uint32_t tempId = proxyId(confine);
+  wl_surface_commit(wlWm.surface);
+  zwp_confined_pointer_v1_destroy(confine);
+
+  wl_surface_commit(wlWm.surface);
+  wl_region_destroy(region);
+
+  uint64_t warpSeq = app_mouseSeq();
+  LG_UNLOCK(wlWm.surfaceLock);
+
+  MLOG(warpSeq, "warp req=%d,%d target=%d,%d exit=%d temp=%u",
+      reqX, reqY, x, y, exiting, tempId);
 }
 
 void waylandRealignPointer(void)

--- a/client/displayservers/Wayland/protocol/CMakeLists.txt
+++ b/client/displayservers/Wayland/protocol/CMakeLists.txt
@@ -72,6 +72,9 @@ wayland_generate(
 wayland_generate(
   "${WAYLAND_PROTOCOLS_BASE}/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml"
   "${CMAKE_BINARY_DIR}/wayland/wayland-xdg-toplevel-icon-v1-client-protocol")
+wayland_generate(
+  "${WAYLAND_PROTOCOLS_BASE}/staging/pointer-warp/pointer-warp-v1.xml"
+  "${CMAKE_BINARY_DIR}/wayland/wayland-pointer-warp-v1-client-protocol")
 
 target_link_libraries(wayland_protocol
   PkgConfig::WAYLAND

--- a/client/displayservers/Wayland/registry.c
+++ b/client/displayservers/Wayland/registry.c
@@ -80,6 +80,9 @@ static void registryGlobalHandler(void * data, struct wl_registry * registry,
   else if (!strcmp(interface, xdg_toplevel_icon_manager_v1_interface.name))
     wlWm.iconManager = wl_registry_bind(wlWm.registry, name,
         &xdg_toplevel_icon_manager_v1_interface, 1);
+  else if (!strcmp(interface, wp_pointer_warp_v1_interface.name))
+    wlWm.pointerWarpper = wl_registry_bind(wlWm.registry, name,
+        &wp_pointer_warp_v1_interface, 1);
   else if (wlWm.desktop->registryGlobalHandler(
         data, registry, name, interface, version))
     return;

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -126,7 +126,7 @@ static bool waylandInit(const LG_DSInitParams params)
   char compositor[1024];
   if (getCompositor(compositor, sizeof(compositor)))
   {
-    DEBUG_INFO("Compositor: %s", compositor);
+    DEBUG_INFO("Compositor  : %s", compositor);
     for(int i = 0; i < WL_DESKTOP_COUNT; ++i)
       if (strcmp(WL_Desktops[i]->compositor, compositor) == 0)
       {
@@ -136,7 +136,9 @@ static bool waylandInit(const LG_DSInitParams params)
   }
   else
     DEBUG_WARN("Compositor: UNKNOWN");
-  DEBUG_INFO("Selected  : %s", wlWm.desktop->name);
+  DEBUG_INFO("Selected    : %s", wlWm.desktop->name);
+  DEBUG_INFO("Warp support: %s", wlWm.pointerWarpper ?
+    "pointer-warp-v1" : "pointer-constraints-v1");
 
   wl_list_init(&wlWm.surfaceOutputs);
 

--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -36,6 +36,13 @@ static struct Option waylandOptions[] =
 {
   {
     .module       = "wayland",
+    .name         = "warpSupport",
+    .description  = "Enable cursor warping",
+    .type         = OPTION_TYPE_BOOL,
+    .value.x_bool = true,
+  },
+  {
+    .module       = "wayland",
     .name         = "fractionScale",
     .description  = "Enable fractional scale",
     .type         = OPTION_TYPE_BOOL,
@@ -133,6 +140,7 @@ static bool waylandInit(const LG_DSInitParams params)
 
   wl_list_init(&wlWm.surfaceOutputs);
 
+  wlWm.warpSupport        = option_get_bool("wayland", "warpSupport");
   wlWm.useFractionalScale = option_get_bool("wayland", "fractionScale");
 
   if (!waylandPollInit())
@@ -215,7 +223,7 @@ static bool waylandGetProp(LG_DSProperty prop, void * ret)
 {
   if (prop == LG_DS_WARP_SUPPORT)
   {
-    *(enum LG_DSWarpSupport*)ret = LG_DS_WARP_NONE;
+    *(enum LG_DSWarpSupport*)ret = wlWm.warpSupport ? LG_DS_WARP_SURFACE : LG_DS_WARP_NONE;
     return true;
   }
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -142,6 +142,7 @@ struct WaylandDSState
   bool fractionalScale;
   bool needsResize;
   bool configured;
+  bool warpSupport;
   struct WlMotion motion;
   double scrollState;
 

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -53,6 +53,7 @@
 #include "wayland-content-type-v1-client-protocol.h"
 #include "wayland-color-management-v1-client-protocol.h"
 #include "wayland-xdg-toplevel-icon-v1-client-protocol.h"
+#include "wayland-pointer-warp-v1-client-protocol.h"
 
 #include "scale.h"
 #include "motion.h"
@@ -196,6 +197,7 @@ struct WaylandDSState
   struct zwp_pointer_constraints_v1 * pointerConstraints;
   struct zwp_relative_pointer_v1 * relativePointer;
   struct zwp_locked_pointer_v1 * lockedPointer;
+  struct wp_pointer_warp_v1 * pointerWarpper;
   bool captureRequested;
   bool showPointer;
   uint32_t pointerEnterSerial;

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -218,41 +218,8 @@ void core_setCursorInView(bool enable)
     return;
   }
 
-  enum LG_DSWarpSupport warpSupport = LG_DS_WARP_NONE;
-  app_getProp(LG_DS_WARP_SUPPORT, &warpSupport);
-
-  const bool immediate = g_cursor.grab || g_params.captureInputOnly ||
-    warpSupport == LG_DS_WARP_NONE;
-
-  if (g_cursor.viewReq == enable)
-  {
-    if (immediate)
-      applyView(enable, false);
-    else if (enable && !g_cursor.inView)
-    {
-      g_state.ds->grabPointer();
-      applyView(g_state.ds->isPointerGrabbed(), false);
-    }
-    else
-      MTRACE("view skip=same value=%d", enable);
-    return;
-  }
-
   g_cursor.viewReq = enable;
-
-  if (immediate)
-  {
-    applyView(enable, false);
-    return;
-  }
-
-  if (enable)
-  {
-    g_state.ds->grabPointer();
-    applyView(g_state.ds->isPointerGrabbed(), false);
-  }
-  else
-    g_state.ds->ungrabPointer();
+  applyView(enable, false);
 }
 
 void core_handleGrabEvent(bool active)

--- a/client/src/core.c
+++ b/client/src/core.c
@@ -325,10 +325,7 @@ void core_setGrabQuiet(bool enable)
       if (!g_params.captureInputOnly)
         applyView(g_state.ds->isPointerGrabbed(), false);
 
-      /* if exiting capture when input on capture only we need to align the
-       * local cursor to the guest's location before it is shown. */
-      if (g_params.captureInputOnly || !g_params.hideMouse)
-        core_alignToGuest();
+      core_alignToGuest();
     }
   }
 }


### PR DESCRIPTION
This PR restores the Wayland cursor warping code with the pointer confinement. It further adds support for the new `pointer-warp-v1` protocol.

`core_setCursorInView` has to be cleaned up since it expects all the nasty grab stuff to work in the Wayland backend when it advertises warp support, or the cursor will never be treated as in view.

Unfortunately, as Sway doesn't support the protocol, I could not test the new code. I would recommend someone with KWin test it out. With this protocol supported, it should print:

```
Warp support: pointer-warp-v1
```