### PR TITLE
[client] Fix client crashes from cross-thread Wayland resizes and overlay teardown

### DIFF
--- a/client/displayservers/Wayland/wayland.c
+++ b/client/displayservers/Wayland/wayland.c
@@ -119,6 +119,8 @@ static bool waylandInit(const LG_DSInitParams params)
   atomic_init(&wlWm.cmCanDoHDR, false);
   atomic_init(&wlWm.hdrPQWhiteLevel, 203);
   atomic_init(&wlWm.hdrScRGBWhiteLevel, 80);
+  atomic_init(&wlWm.pendingResize, 0);
+  wlWm.resizeEventFd = -1;
 
   wlWm.display = wl_display_connect(NULL);
   if (!wlWm.display)
@@ -184,7 +186,10 @@ static bool waylandInit(const LG_DSInitParams params)
 
   if (!waylandEGLInit(waylandScaleMulInt(wlWm.scale, width),
         waylandScaleMulInt(wlWm.scale, height)))
+  {
+    waylandWindowFree();
     return false;
+  }
 
   app_handleResizeEvent(width, height, waylandScaleToDouble(wlWm.scale),
       (struct Border) {0, 0, 0, 0});
@@ -193,7 +198,10 @@ static bool waylandInit(const LG_DSInitParams params)
 
 #ifdef ENABLE_OPENGL
   if (params.opengl && !waylandOpenGLInit())
+  {
+    waylandWindowFree();
     return false;
+  }
 #endif
 
   return true;

--- a/client/displayservers/Wayland/wayland.h
+++ b/client/displayservers/Wayland/wayland.h
@@ -148,6 +148,9 @@ struct WaylandDSState
   bool warpSupport;
   struct WlMotion motion;
 
+  _Atomic(uint64_t) pendingResize; // 0 = none, else (width << 32) | height
+  int resizeEventFd;               // wakes the event loop to apply it
+
 #if defined(ENABLE_EGL) || defined(ENABLE_OPENGL)
   struct wl_egl_window * eglWindow;
   struct SwapWithDamageData swapWithDamage;

--- a/client/displayservers/Wayland/window.c
+++ b/client/displayservers/Wayland/window.c
@@ -23,6 +23,10 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <errno.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
 #include <wayland-client.h>
 
 #include "app.h"
@@ -132,6 +136,29 @@ static const struct wp_fractional_scale_v1_listener fractionalScaleListener = {
   .preferred_scale = fractionalScalePreferredScale,
 };
 
+static void resizePollCallback(uint32_t events, void * opaque)
+{
+  eventfd_t value;
+  eventfd_read(wlWm.resizeEventFd, &value);
+
+  const uint64_t pending = atomic_exchange_explicit(&wlWm.pendingResize, 0,
+      memory_order_acquire);
+  if (!pending || !app_isRunning())
+    return;
+
+  wlWm.desktop->shellResize((int)(pending >> 32), (int)(uint32_t)pending);
+}
+
+static void resizeEventFdFree(void)
+{
+  if (wlWm.resizeEventFd < 0)
+    return;
+
+  waylandPollUnregister(wlWm.resizeEventFd);
+  close(wlWm.resizeEventFd);
+  wlWm.resizeEventFd = -1;
+}
+
 bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, bool maximize, bool borderless, bool resizable)
 {
   wlWm.scale = waylandScaleFromInt(1);
@@ -142,11 +169,29 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
     DEBUG_ERROR("Failed to initialize event for waitFrame");
     return false;
   }
+
   waylandSignalFrame(LG_DS_WAIT_FRAME_INTERRUPTED);
+
+  wlWm.resizeEventFd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (wlWm.resizeEventFd < 0)
+  {
+    DEBUG_ERROR("Failed to create the resize eventfd: %s", strerror(errno));
+    return false;
+  }
+
+  if (!waylandPollRegister(wlWm.resizeEventFd, resizePollCallback, NULL,
+        EPOLLIN))
+  {
+    DEBUG_ERROR("Failed to register the resize eventfd");
+    close(wlWm.resizeEventFd);
+    wlWm.resizeEventFd = -1;
+    return false;
+  }
 
   if (!wlWm.compositor)
   {
     DEBUG_ERROR("Compositor missing wl_compositor (version 3+), will not proceed");
+    resizeEventFdFree();
     return false;
   }
 
@@ -154,6 +199,7 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
   if (!wlWm.surface)
   {
     DEBUG_ERROR("Failed to create wl_surface");
+    resizeEventFdFree();
     return false;
   }
 
@@ -176,7 +222,10 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
 
   if (!wlWm.desktop->shellInit(wlWm.display, wlWm.surface,
         title, appId, fullscreen, maximize, borderless, resizable))
+  {
+    resizeEventFdFree();
     return false;
+  }
 
   INTERLOCKED_SECTION(wlWm.surfaceLock,
   {
@@ -190,6 +239,7 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
     if (wl_display_roundtrip(wlWm.display) < 0)
     {
       DEBUG_ERROR("Failed waiting for the initial Wayland configure");
+      resizeEventFdFree();
       return false;
     }
   }
@@ -199,6 +249,8 @@ bool waylandWindowInit(const char * title, const char * appId, bool fullscreen, 
 
 void waylandWindowFree(void)
 {
+  resizeEventFdFree();
+
   struct SurfaceOutput * output;
   struct SurfaceOutput * temp;
   wl_list_for_each_safe(output, temp, &wlWm.surfaceOutputs, link)
@@ -217,7 +269,10 @@ void waylandWindowFree(void)
 
 void waylandSetWindowSize(int x, int y)
 {
-    wlWm.desktop->shellResize(x, y);
+  // The shell resize must run on the event-loop thread; see resizePollCallback
+  atomic_store_explicit(&wlWm.pendingResize,
+      (uint64_t)(uint32_t)x << 32 | (uint32_t)y, memory_order_release);
+  eventfd_write(wlWm.resizeEventFd, 1);
 }
 
 bool waylandIsValidPointerPos(int x, int y)

--- a/client/include/evdev.h
+++ b/client/include/evdev.h
@@ -31,9 +31,15 @@ void evdev_earlyInit(void);
 bool evdev_start(void);
 
 /**
- * stop the evdev layer
+ * join the evdev thread; device state stays valid for callbacks
  */
 void evdev_stop(void);
+
+/**
+ * restore the display server hooks and free the device state; only
+ * call once display server callbacks have stopped
+ */
+void evdev_free(void);
 
 /**
  * grab the keyboard for exclusive access

--- a/client/src/app.c
+++ b/client/src/app.c
@@ -858,6 +858,8 @@ void app_registerOverlay(const struct LG_OverlayOps * ops, const void * params)
     ops->earlyInit();
 }
 
+static bool l_overlaysInitialized = false;
+
 void app_initOverlays(void)
 {
   struct Overlay * overlay;
@@ -868,9 +870,12 @@ void app_initOverlays(void)
     if (!overlay->ops->init(&overlay->udata, overlay->params))
     {
       DEBUG_ERROR("Overlay `%s` failed to initialize", overlay->ops->name);
-      overlay->ops = NULL;
+      ll_removeNL(g_state.overlays, item);
+      free(item);
+      free(overlay);
     }
   }
+  l_overlaysInitialized = true;
   ll_unlock(g_state.overlays);
 
   /* Do not seed ImGui's clock with absolute host uptime. ImGui stores the
@@ -1066,9 +1071,11 @@ void app_freeOverlays(void)
   struct Overlay * overlay;
   while(ll_shift(g_state.overlays, (void **)&overlay))
   {
-    overlay->ops->free(overlay->udata);
+    if (l_overlaysInitialized)
+      overlay->ops->free(overlay->udata);
     free(overlay);
   }
+  l_overlaysInitialized = false;
 }
 
 void app_setOverlay(bool enable)

--- a/client/src/evdev.c
+++ b/client/src/evdev.c
@@ -68,7 +68,7 @@ struct EvdevState
   pending;
 };
 
-static struct EvdevState state = {};
+static struct EvdevState state = { .epoll = -1 };
 
 static struct Option options[] =
 {
@@ -351,31 +351,51 @@ bool evdev_start(void)
 
 void evdev_stop(void)
 {
+  if (state.thread)
+  {
+    lgJoinThread(state.thread, NULL);
+    state.thread = NULL;
+  }
+}
+
+void evdev_free(void)
+{
+  evdev_stop();
+
+  // restore the display server grab methods
+  if (state.dsGrabKeyboard)
+  {
+    g_state.ds->grabKeyboard   = state.dsGrabKeyboard;
+    g_state.ds->ungrabKeyboard = state.dsUngrabKeyboard;
+    state.dsGrabKeyboard       = NULL;
+    state.dsUngrabKeyboard     = NULL;
+  }
+  state.grabbed = false;
+
+  // the thread and grab callbacks reference the device state
   if (state.deviceList)
   {
     free(state.deviceList);
     state.deviceList = NULL;
   }
 
-  if (state.thread)
-  {
-    lgJoinThread(state.thread, NULL);
-    state.thread = NULL;
-  }
-
   if (state.epoll >= 0)
   {
     close(state.epoll);
-    state.epoll = 0;
+    state.epoll = -1;
   }
 
-  for(EvdevDevice * device = state.devices; device->path; ++device)
+  if (state.devices)
   {
-    if (device->fd <= 0)
-      continue;
-
-    close(device->fd);
-    device->fd = 0;
+    for(int i = 0; i < state.deviceCount; ++i)
+    {
+      EvdevDevice * device = &state.devices[i];
+      if (device->fd > 0)
+        close(device->fd);
+    }
+    free(state.devices);
+    state.devices     = NULL;
+    state.deviceCount = 0;
   }
 }
 
@@ -395,8 +415,9 @@ void evdev_grabKeyboard(void)
 
 //  state.dsGrabKeyboard();
 
-  for(EvdevDevice * device = state.devices; device->path; ++device)
+  for(int i = 0; i < state.deviceCount; ++i)
   {
+    EvdevDevice * device = &state.devices[i];
     if (device->fd > 0)
       evdev_grabDevice(device);
   }
@@ -418,8 +439,9 @@ void evdev_ungrabKeyboard(void)
       return;
     }
 
-  for(EvdevDevice * device = state.devices; device->path; ++device)
+  for(int i = 0; i < state.deviceCount; ++i)
   {
+    EvdevDevice * device = &state.devices[i];
     if (device->fd <= 0 || !device->grabbed)
       continue;
 

--- a/client/src/main.c
+++ b/client/src/main.c
@@ -1078,13 +1078,6 @@ static int renderThread(void * unused)
 
   app_setState(APP_STATE_SHUTDOWN);
 
-  if (g_state.overlays)
-  {
-    app_freeOverlays();
-    ll_free(g_state.overlays);
-    g_state.overlays = NULL;
-  }
-
   lgTimerDestroy(tickTimer);
   lgTimerDestroy(fpsTimer);
 
@@ -3505,6 +3498,9 @@ static void lg_shutdown(void)
   }
   LG_LOCK_FREE(l_cursorRepaint.lock);
 
+  // An evdev batch may call input handlers; join before input teardown
+  evdev_stop();
+
   if (g_state.transport.ops)
   {
     lgInput_dropTransport();
@@ -3540,6 +3536,7 @@ static void lg_shutdown(void)
 
   if (g_state.ds)
     g_state.ds->shutdown();
+
   lgClipboard_free();
 
   app_releaseAllKeybinds();
@@ -3547,6 +3544,16 @@ static void lg_shutdown(void)
 
   if (g_state.ds && g_state.dsInitialized)
     g_state.ds->free();
+
+  // Input callbacks have stopped; the evdev state and overlays can go
+  evdev_free();
+
+  if (g_state.overlays)
+  {
+    app_freeOverlays();
+    ll_free(g_state.overlays);
+    g_state.overlays = NULL;
+  }
 
   renderQueue_setSourceFns(NULL, NULL, NULL);
   renderQueue_free();

--- a/client/src/overlay_utils.c
+++ b/client/src/overlay_utils.c
@@ -182,5 +182,9 @@ void overlayFreeImage(OverlayImage * image)
   if (!image->tex)
     return;
 
-  RENDERER(freeTexture, image->tex);
+  // During shutdown the renderer is freed first, taking all textures with it
+  if (g_state.lgr)
+    RENDERER(freeTexture, image->tex);
+
+  image->tex = NULL;
 }


### PR DESCRIPTION
Two shutdown crashes, both from code running on the wrong thread:

- `waylandSetWindowSize` called `shellResize()` directly from the render,
  frame, and transport threads. Shell requests — and with libdecor-gtk,
  pango decoration rendering — are only safe on the event-loop thread;
  exiting threads crashed in pango's fontmap teardown. Resizes are now
  published atomically and applied by the event loop via an eventfd.

- The render thread freed the overlays on exit while the main thread could
  still be dispatching input callbacks that iterate them. They are now
  freed in `lg_shutdown()`, after the render thread is joined and the
  display server has shut down.