### PR TITLE
[common] linux/proctitle: zero out entire usable memory block

### DIFF
--- a/common/src/platform/linux/proctitle.c
+++ b/common/src/platform/linux/proctitle.c
@@ -123,10 +123,10 @@ void lgSetProcessTitle(const char * title)
   if (!totalSize)
     return;
 
-  size_t effective = strlen(title) + 1;
+  size_t effective = strlen(title);
   if (effective > totalSize)
-    effective = totalSize;
+    effective = totalSize - 1;
 
-  memcpy(buffer, title, effective - 1);
-  buffer[effective - 1] = '\0';
+  memcpy(buffer, title, effective);
+  memset(buffer + effective, 0, totalSize - effective);
 }


### PR DESCRIPTION
This avoids additional arguments showing up when their memory hasn't been touched at all.