### PR TITLE
[common] linux/proctitle: fix off-by-one bug

### DIFF
--- a/common/src/platform/linux/proctitle.c
+++ b/common/src/platform/linux/proctitle.c
@@ -124,7 +124,7 @@ void lgSetProcessTitle(const char * title)
     return;
 
   size_t effective = strlen(title);
-  if (effective > totalSize)
+  if (effective >= totalSize)
     effective = totalSize - 1;
 
   memcpy(buffer, title, effective);


### PR DESCRIPTION
0884d14bde8ee142a5688cec690e1a5320a00af8 introduces an off-by-one bug: if `strlen(title) == totalSize`, then no space will be left for a null terminator.